### PR TITLE
Consume API

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,5 +1,7 @@
 import DS from 'ember-data';
+import ENV from 'labs-applicant-maps/config/environment';
 const { JSONAPIAdapter } = DS;
+
 
 export default class ApplicationAdapter extends JSONAPIAdapter {
   _ajaxRequest() {
@@ -10,5 +12,5 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
     super._ajaxRequest(...arguments);
   }
 
-  host = 'http://localhost:3000'
+  host = ENV.host;
 }

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -9,4 +9,6 @@ export default class ApplicationAdapter extends JSONAPIAdapter {
 
     super._ajaxRequest(...arguments);
   }
+
+  host = 'http://localhost:3000'
 }

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -40,11 +40,12 @@ export default class ProjectModel extends Model {
   @attr() dcp_communitydistrict;
   @attr('string') dcp_communitydistricts;
   @attr('string') dcp_validatedcommunitydistricts;
-  @attr() bbl_feature_collection;
+  @attr() bbls;
+  @attr() bbl_featurecollection;
 
-  @computed('bbl_feature_collection')
+  @computed('bbl_featurecollection')
   get bblFeatureCollectionSource() {
-    const data = this.get('bbl_feature_collection');
+    const data = this.get('bbl_featurecollection');
     return {
       type: 'geojson',
       data,

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -42,6 +42,10 @@ export default class ProjectModel extends Model {
   @attr('string') dcp_validatedcommunitydistricts;
   @attr() bbls;
   @attr() bbl_featurecollection;
+  @attr() milestones;
+  @attr() actions;
+  @attr() addresses;
+  @attr() keywords;
 
   @computed('bbl_featurecollection')
   get bblFeatureCollectionSource() {

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,0 +1,6 @@
+import DS from 'ember-data';
+const { JSONAPISerializer } = DS;
+
+export default class ApplicationSerializer extends JSONAPISerializer {
+  keyForAttribute(key) { return key; }
+}

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,6 +1,11 @@
 import DS from 'ember-data';
+import ENV from 'labs-applicant-maps/config/environment';
+import { dasherize } from '@ember/string';
+
 const { JSONAPISerializer } = DS;
 
 export default class ApplicationSerializer extends JSONAPISerializer {
-  keyForAttribute(key) { return key; }
+  keyForAttribute(key) {
+    return ENV.environment === 'production' ? key : dasherize(key);
+  }
 }

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -16,66 +16,39 @@
 
         <div class="grid-x grid-padding-x">
           <div class="cell medium-6">
+            {{log model}}
             <h2>Actions</h2>
             <ul class="no-bullet">
-              <li class="grid-x grid-padding-small">
-                <div class="cell shrink dark-gray">{{fa-icon 'bullhorn' size=2}}</div>
-                <div class="cell auto">
-                  <p class="no-margin"><strong><a href="#">Action Name</a></strong></p>
-                  <p class="text-small dark-gray">XX <span class="medium-gray">|</span> <a>Resolution 1234a</a> <span class="medium-gray">|</span> Status</p>
-                </div>
-              </li>
-              <li class="grid-x grid-padding-small">
-                <div class="cell shrink dark-gray">{{fa-icon 'bullhorn' size=2}}</div>
-                <div class="cell auto">
-                  <p class="no-margin"><strong><a href="#">Action Name</a></strong></p>
-                  <p class="text-small dark-gray">XX <span class="medium-gray">|</span> <a>Resolution 1234a</a> <span class="medium-gray">|</span> Status</p>
-                </div>
-              </li>
-              <li class="grid-x grid-padding-small">
-                <div class="cell shrink dark-gray">{{fa-icon 'bullhorn' size=2}}</div>
-                <div class="cell auto">
-                  <p class="no-margin"><strong><a href="#">Action Name</a></strong></p>
-                  <p class="text-small dark-gray">XX <span class="medium-gray">|</span> <a>Resolution 1234a</a> <span class="medium-gray">|</span> Status</p>
-                </div>
-              </li>
+              {{#each model.actions as | action |}}
+                <li class="grid-x grid-padding-small">
+                  <div class="cell shrink dark-gray">{{fa-icon 'bullhorn' size=2}}</div>
+                  <div class="cell auto">
+                    <p class="no-margin"><strong><a href="#">{{action.dcp_name}}</a></strong></p>
+                    <p class="text-small dark-gray">
+                      {{action.dcp_prefix}}
+                      <span class="medium-gray">|</span>
+                      {{action.dcp_ulurpnumber}}
+                      <span class="medium-gray">|</span>
+                      {{action.statuscode}}
+                    </p>
+                  </div>
+                </li>
+              {{/each}}
             </ul>
           </div>
           <div class="cell medium-6">
             <h2>Milestones</h2>
             <ul class="no-bullet">
-              <li class="grid-x grid-padding-small">
-                <div class="cell shrink dark-gray">{{fa-icon 'calendar' size=2}}</div>
-                <div class="cell auto">
-                  <p class="no-margin"><strong>Milestone Title</strong></p>
-                  <p class="no-margin text-small dark-gray">01/23/45 Start</p>
-                  <p class="text-small dark-gray">01/23/45 Completion</p>
-                </div>
-              </li>
-              <li class="grid-x grid-padding-small">
-                <div class="cell shrink dark-gray">{{fa-icon 'calendar' size=2}}</div>
-                <div class="cell auto">
-                  <p class="no-margin"><strong>Milestone Title</strong></p>
-                  <p class="no-margin text-small dark-gray">01/23/45 Start</p>
-                  <p class="text-small dark-gray">01/23/45 Completion</p>
-                </div>
-              </li>
-              <li class="grid-x grid-padding-small">
-                <div class="cell shrink dark-gray">{{fa-icon 'calendar' size=2}}</div>
-                <div class="cell auto">
-                  <p class="no-margin"><strong>Milestone Title</strong></p>
-                  <p class="no-margin text-small dark-gray">01/23/45 Start</p>
-                  <p class="text-small dark-gray">01/23/45 Completion</p>
-                </div>
-              </li>
-              <li class="grid-x grid-padding-small">
-                <div class="cell shrink dark-gray">{{fa-icon 'calendar' size=2}}</div>
-                <div class="cell auto">
-                  <p class="no-margin"><strong>Milestone Title</strong></p>
-                  <p class="no-margin text-small dark-gray">01/23/45 Start</p>
-                  <p class="text-small dark-gray">01/23/45 Completion</p>
-                </div>
-              </li>
+              {{#each model.milestones as | milestone |}}
+                <li class="grid-x grid-padding-small">
+                  <div class="cell shrink dark-gray">{{fa-icon 'calendar' size=2}}</div>
+                  <div class="cell auto">
+                    <p class="no-margin"><strong>{{milestone.dcp_name}}</strong></p>
+                    <p class="no-margin text-small dark-gray">{{moment-format milestone.dcp_plannedstartdate "MMMM D, YYYY" }} <small>Planned Start</small></p>
+                    <p class="text-small dark-gray">{{moment-format milestone.dcp_plannedcompletoiondate "MMMM D, YYYY" }} <small>Planned Completion</small></p>
+                  </div>
+                </li>
+              {{/each}}
             </ul>
           </div>
         </div>
@@ -102,10 +75,20 @@
         {{/mapbox-gl}}
 
         <p class="text-small"><strong>BBLs:</strong> {{#each model.bbls as |bbl index|}}{{if index ", "}}{{bbl}}{{/each}}</p>
-        <p class="text-small"><strong>Addresses:</strong> 1234 Main Street, 1236 Main Street</p>
+        <p class="text-small">
+          <strong>Addresses:</strong>
+          {{#each model.addresses as |address index|}}
+            {{if index ", "}}{{address.dcp_validatedaddressnumber}} {{address.dcp_validatedstreet}}
+          {{/each}}
+        </p>
         <p class="text-small"><strong>Borough:</strong> {{model.dcp_borough}}</p>
         <p class="text-small"><strong>Lead Division:</strong> {{model.dcp_leaddivision}}</p>
-        <p class="text-small"><strong>Keywords:</strong> <a>Foo</a>, <a>Bar</a>, <a>Baz</a>, <a>Qux</a></p>
+        <p class="text-small">
+          <strong>Keywords:</strong>
+          {{#each model.keywords as |keyword index|}}
+            {{if index ", "}}<a>{{keyword}}</a>
+          {{/each}}
+        </p>
         <p class="text-small"><strong>CEQR:</strong> {{model.dcp_ceqrtype}} <span class="medium-gray">|</span> {{model.dcp_ceqrnumber}}</p>
         <p class="text-small"><strong>FEMA:</strong> {{model.dcp_femafloodzonea}} <span class="medium-gray">|</span> {{model.dcp_femafloodzonecoastala}} <span class="medium-gray">|</span> {{model.dcp_femafloodzoneshadedx}} <span class="medium-gray">|</span> {{model.dcp_femafloodzonev}}</p>
         <p class="text-small"><strong>Additional Files:</strong> </p>

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -4,9 +4,9 @@
     <div class="grid-x grid-padding-x grid-padding-y">
       <div class="cell large-7">
 
-        <h1 class="no-margin">{{model.dcp_name}}</h1>
+        <h1 class="no-margin">{{model.dcp_projectname}}</h1>
 
-        <p><a href="#">{{fa-icon 'share-alt'}} <strong>Share</strong> <small>Project {{model.dcp_projectid}}</small></a></p>
+        <p><a href="#">{{fa-icon 'share-alt'}} <strong>Share</strong> <small>Project {{model.dcp_name}}</small></a></p>
 
         <p class="lead"><strong>Applicant:</strong> {{model.dcp_applicant_customer}}</p>
         <p><strong>Project Brief:</strong> {{model.dcp_projectbrief}}</p>
@@ -82,7 +82,6 @@
 
       </div>
       <div class="cell large-5">
-        {{log model.bbl_feature_collection}}
         {{#mapbox-gl
             id='project-map'
             initOptions=(hash
@@ -91,7 +90,7 @@
               interactive=false
               transformRequest=transformRequest
             )
-            mapLoaded=(action handleMapLoad model.bbl_feature_collection)
+            mapLoaded=(action handleMapLoad model.bbl_featurecollection)
             as |map|
         }}
           {{#map.source options=model.bblFeatureCollectionSource as |source|}}
@@ -102,7 +101,7 @@
           {{/map.source}}
         {{/mapbox-gl}}
 
-        <p class="text-small"><strong>BBLs:</strong> 1234567890, 0987654321, 6789012345</p>
+        <p class="text-small"><strong>BBLs:</strong> {{#each model.bbls as |bbl index|}}{{if index ", "}}{{bbl}}{{/each}}</p>
         <p class="text-small"><strong>Addresses:</strong> 1234 Main Street, 1236 Main Street</p>
         <p class="text-small"><strong>Borough:</strong> {{model.dcp_borough}}</p>
         <p class="text-small"><strong>Lead Division:</strong> {{model.dcp_leaddivision}}</p>

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -3,7 +3,6 @@
   <div class="grid-container">
     <div class="grid-x grid-padding-x grid-padding-y">
       <div class="cell large-7">
-
         <h1 class="no-margin">{{model.dcp_projectname}}</h1>
 
         <p><a href="#">{{fa-icon 'share-alt'}} <strong>Share</strong> <small>Project {{model.dcp_name}}</small></a></p>
@@ -16,7 +15,6 @@
 
         <div class="grid-x grid-padding-x">
           <div class="cell medium-6">
-            {{log model}}
             <h2>Actions</h2>
             <ul class="no-bullet">
               {{#each model.actions as | action |}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -44,6 +44,9 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
+    ENV['ember-cli-mirage'] = {
+      enabled: false
+    };
   }
 
   if (environment === 'test') {

--- a/config/environment.js
+++ b/config/environment.js
@@ -45,7 +45,7 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
     ENV['ember-cli-mirage'] = {
-      enabled: false
+      enabled: true
     };
   }
 
@@ -63,8 +63,10 @@ module.exports = function(environment) {
 
   if (environment === 'production') {
     ENV['ember-cli-mirage'] = {
-      enabled: true
+      enabled: false
     };
+
+    ENV.host = 'https://zap-api.planninglabs.nyc';
   }
 
   return ENV;

--- a/mirage/factories/project.js
+++ b/mirage/factories/project.js
@@ -141,7 +141,7 @@ export default Factory.extend({
     return faker.random.word();
   },
 
-  bblFeatureCollection() {
+  bbl_featurecollection() {
     return bblFeatureCollection;
   }
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mirage": "0.4.7",
+    "ember-cli-moment-shim": "^3.7.1",
     "ember-cli-qunit": "^4.1.1",
     "ember-cli-sass": "^6.0.0",
     "ember-cli-shims": "^1.2.0",
@@ -45,6 +46,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-mapbox-gl": "^0.10.0",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-moment": "^7.7.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.0.0",
     "ember-truth-helpers": "2.0.0",
@@ -59,9 +61,9 @@
   },
   "dependencies": {
     "@ember-decorators/argument": "0.8.15",
+    "@turf/bbox": "^6.0.1",
     "@turf/boolean-point-in-polygon": "6.0.1",
     "@turf/intersect": "6.1.2",
-    "@turf/bbox": "^6.0.1",
     "foundation-sites": "^6.4.3"
   }
 }

--- a/tests/unit/serializers/application-test.js
+++ b/tests/unit/serializers/application-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
+module('Unit | Serializer | application', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let serializer = store.serializerFor('application');
+
+    assert.ok(serializer);
+  });
+
+  test('it serializes records', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let record = run(() => store.createRecord('application', {}));
+
+    let serializedRecord = record.serialize();
+
+    assert.ok(serializedRecord);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1952,7 +1952,7 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@^3.2.6:
+browserslist@^3.1.1, browserslist@^3.2.6:
   version "3.2.8"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
   dependencies:
@@ -2151,7 +2151,6 @@ cartobox-promises-utility@nycplanning/cartobox-promises-utility#v1.0.2:
   resolved "https://codeload.github.com/nycplanning/cartobox-promises-utility/tar.gz/57f1c96a0bf03c47e048c30d202643cc49db3c69"
   dependencies:
     ember-cli-babel "^6.6.0"
-    ember-fetch "5.0.0"
 
 caseless@~0.11.0:
   version "0.11.0"
@@ -2945,7 +2944,7 @@ ember-cli-app-version@^3.0.0:
     ember-cli-babel "^6.12.0"
     git-repo-version "^1.0.2"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.7.2, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2, ember-cli-babel@^6.9.0:
   version "6.14.1"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.14.1.tgz#796339229035910b625593caffbc2683792ada68"
   dependencies:
@@ -3059,6 +3058,10 @@ ember-cli-htmlbars@^2.0.1, ember-cli-htmlbars@^2.0.2, ember-cli-htmlbars@^2.0.3:
     json-stable-stringify "^1.0.0"
     strip-bom "^3.0.0"
 
+ember-cli-import-polyfill@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-import-polyfill/-/ember-cli-import-polyfill-0.2.0.tgz#c1a08a8affb45c97b675926272fe78cf4ca166f2"
+
 ember-cli-inject-live-reload@^1.4.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-1.7.0.tgz#af94336e015336127dfb98080ad442bb233e37ed"
@@ -3094,6 +3097,21 @@ ember-cli-mirage@0.4.7:
     faker "^3.0.0"
     pretender "^1.6.1"
     route-recognizer "^0.2.3"
+
+ember-cli-moment-shim@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-moment-shim/-/ember-cli-moment-shim-3.7.1.tgz#3ad691c5027c1f38a4890fe47d74b5224cc98e32"
+  dependencies:
+    broccoli-funnel "^2.0.0"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-source "^1.1.0"
+    broccoli-stew "^1.5.0"
+    chalk "^1.1.3"
+    ember-cli-babel "^6.6.0"
+    ember-cli-import-polyfill "^0.2.0"
+    lodash.defaults "^4.2.0"
+    moment "^2.19.3"
+    moment-timezone "^0.5.13"
 
 ember-cli-node-assets@^0.1.4:
   version "0.1.6"
@@ -3366,6 +3384,12 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
+ember-factory-for-polyfill@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz#b446ed64916d293c847a4955240eb2c993b86eae"
+  dependencies:
+    ember-cli-version-checker "^2.1.0"
+
 ember-fetch@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-5.0.0.tgz#fc58980010d625e9d86d238cbaabe7803fdddcfa"
@@ -3403,6 +3427,13 @@ ember-get-config@^0.2.2, ember-get-config@^0.2.3:
     broccoli-file-creator "^1.1.1"
     ember-cli-babel "^6.3.0"
 
+ember-getowner-polyfill@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz#38e7dccbcac69d5ec694000329ec0b2be651d2b2"
+  dependencies:
+    ember-cli-version-checker "^2.1.0"
+    ember-factory-for-polyfill "^1.3.1"
+
 ember-inflector@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/ember-inflector/-/ember-inflector-2.3.0.tgz#94797eba0eea98d902aa1e5da0f0aeef6053317f"
@@ -3425,6 +3456,15 @@ ember-lodash@^4.17.3:
     broccoli-string-replace "^0.1.1"
     ember-cli-babel "^6.10.0"
     lodash-es "^4.17.4"
+
+ember-macro-helpers@^0.17.0:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/ember-macro-helpers/-/ember-macro-helpers-0.17.1.tgz#34836e9158cc260ee1c540935371d11f52ec98d9"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+    ember-cli-string-utils "^1.1.0"
+    ember-cli-test-info "^1.0.0"
+    ember-weakmap "^3.0.0"
 
 ember-mapbox-gl@^0.10.0:
   version "0.10.0"
@@ -3450,6 +3490,14 @@ ember-maybe-in-element@^0.1.3:
   resolved "https://registry.yarnpkg.com/ember-maybe-in-element/-/ember-maybe-in-element-0.1.3.tgz#1c89be49246e580c1090336ad8be31e373f71b60"
   dependencies:
     ember-cli-babel "^6.11.0"
+
+ember-moment@^7.7.0:
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/ember-moment/-/ember-moment-7.7.0.tgz#febf7cc5bfc665c8f1d45fa24e5c7a5f5f91afa5"
+  dependencies:
+    ember-cli-babel "^6.7.2"
+    ember-getowner-polyfill "^2.0.1"
+    ember-macro-helpers "^0.17.0"
 
 ember-power-select@2.0.2:
   version "2.0.2"
@@ -3574,6 +3622,14 @@ ember-try@^0.2.23:
     rimraf "^2.3.2"
     rsvp "^3.0.17"
     semver "^5.1.0"
+
+ember-weakmap@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ember-weakmap/-/ember-weakmap-3.2.0.tgz#663871d7a8bb085c5b1cedcb3fb183857990343f"
+  dependencies:
+    browserslist "^3.1.1"
+    debug "^3.1.0"
+    ember-cli-babel "^6.6.0"
 
 ember-welcome-page@^3.0.0:
   version "3.2.0"
@@ -5775,6 +5831,10 @@ lodash.debounce@^3.1.1:
   dependencies:
     lodash._getnative "^3.0.0"
 
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+
 lodash.defaults@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-2.3.0.tgz#a832b001f138f3bb9721c2819a2a7cc5ae21ed25"
@@ -6341,6 +6401,16 @@ mkdirp@^0.3.5:
 mktemp@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
+
+moment-timezone@^0.5.13:
+  version "0.5.17"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.17.tgz#3c8fef32051d84c3af174d91dc52977dcb0ad7e5"
+  dependencies:
+    moment ">= 2.9.0"
+
+"moment@>= 2.9.0", moment@^2.19.3:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
 morgan@^1.8.1:
   version "1.9.0"


### PR DESCRIPTION
This PR disables mirage and has the app consume data from `{api-domain}/projects/:projectid`.

`labs-zap-api` is now serving jsonapi compliant responses on `/projects` that are ready for this branch to consume.