### PR TITLE
add zoning resolution url helper

### DIFF
--- a/app/helpers/build-zr-url.js
+++ b/app/helpers/build-zr-url.js
@@ -1,0 +1,22 @@
+import { helper } from '@ember/component/helper';
+
+function pad(string, size) {
+  while (string.length < (size || 2)) {string = "0" + string;}
+  return string;
+}
+
+export function buildZrUrl([zr]) {
+  // get everything before the hyphen
+  const articleChapter = zr.split('-')[0];
+
+  // to get article, drop the last character
+  const article = pad(articleChapter.slice(0, - 1), 2);
+  // to get chapter, get the last character
+  const chapter = pad(articleChapter.substr(-1), 2);
+
+  // TODO handle values that don't match this hyphenated format (AppendixD, AppendixF, E37-04f1, E37-04g6)
+
+  return `https://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-text/art${article}c${chapter}.pdf`;
+}
+
+export default helper(buildZrUrl);

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -39,6 +39,9 @@
                       <span class="medium-gray">|</span>
                       {{action.statuscode}}
                     </p>
+                    {{#if action.dcp_zoningresolution}}
+                      <p class="text-small dark-gray">Zoning Resolution: <a href="{{build-zr-url action.dcp_zoningresolution}}" target="_blank">{{action.dcp_zoningresolution}}</a></p>
+                    {{/if}}
                   </div>
                 </li>
               {{/each}}

--- a/tests/integration/helpers/build-zr-url-test.js
+++ b/tests/integration/helpers/build-zr-url-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | build-zr-url', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', '1234');
+
+    await render(hbs`{{build-zr-url inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '1234');
+  });
+});


### PR DESCRIPTION
Adds a helper for building zoning resolution links from the numbers we have in the database.

`62-811a` should link to the Article 6 Chapter 2 pdf of the zoning resolution: https://www1.nyc.gov/assets/planning/download/pdf/zoning/zoning-text/art06c02.pdf