### PR TITLE
Add filter toggles; simplify some code

### DIFF
--- a/app/controllers/show-geography.js
+++ b/app/controllers/show-geography.js
@@ -3,10 +3,13 @@ import { action, computed } from '@ember-decorators/object';
 import QueryParams from 'ember-parachute';
 
 export const projectParams = new QueryParams({
+  // pagination
   page: {
     defaultValue: 1,
     refresh: true,
   },
+
+  // filter values
   'community-districts': {
     defaultValue: [],
     refresh: true,
@@ -60,6 +63,32 @@ export const projectParams = new QueryParams({
     refresh: true,
   },
   dcp_femafloodzonev: {
+    defaultValue: false,
+    refresh: true,
+  },
+
+  // params for whether filters are applied or not
+  status: {
+    defaultValue: true,
+    refresh: true,
+  },
+  cds: {
+    defaultValue: true,
+    refresh: true,
+  },
+  ceqr: {
+    defaultValue: false,
+    refresh: true,
+  },
+  fema: {
+    defaultValue: false,
+    refresh: true,
+  },
+  ulurp: {
+    defaultValue: false,
+    refresh: true,
+  },
+  action_status: {
     defaultValue: false,
     refresh: true,
   },

--- a/app/routes/show-geography.js
+++ b/app/routes/show-geography.js
@@ -29,10 +29,17 @@ export default class ShowGeographyRoute extends Route {
     dcp_femafloodzonev: {
       refreshModel: true,
     },
+    status: {
+      refreshModel: true,
+    }
   };
 
   async model(params) {
     const {
+      // pagination
+      page = 1,
+
+      // filter values
       'community-districts': communityDistricts = [],
       dcp_publicstatus,
       dcp_ceqrtype,
@@ -41,24 +48,35 @@ export default class ShowGeographyRoute extends Route {
       dcp_femafloodzonecoastala,
       dcp_femafloodzoneshadedx,
       dcp_femafloodzonev,
-      page = 1,
 
+      // toggle filters
+      status = true,
+      cds = false,
+      ceqr = false,
+      fema = false,
+      ulurp = false,
+      // action_status = false,
     } = params;
 
     const queryOptions = {
       'community-districts': communityDistricts,
-      dcp_publicstatus,
       dcp_ceqrtype,
       dcp_ulurp_nonulurp,
       page,
     }
 
-    // special handling for FEMA flood zones
     // only add to the api call if set to true
-    if (dcp_femafloodzonea) queryOptions.dcp_femafloodzonea = true;
-    if (dcp_femafloodzonecoastala) queryOptions.dcp_femafloodzonecoastala = true;
-    if (dcp_femafloodzoneshadedx) queryOptions.dcp_femafloodzoneshadedx = true;
-    if (dcp_femafloodzonev) queryOptions.dcp_femafloodzonev = true;
+    if (fema) {
+      if (dcp_femafloodzonea) queryOptions.dcp_femafloodzonea = true;
+      if (dcp_femafloodzonecoastala) queryOptions.dcp_femafloodzonecoastala = true;
+      if (dcp_femafloodzoneshadedx) queryOptions.dcp_femafloodzoneshadedx = true;
+      if (dcp_femafloodzonev) queryOptions.dcp_femafloodzonev = true;
+    }
+    if (status) queryOptions.dcp_publicstatus = dcp_publicstatus;
+    if (cds) queryOptions.communityDistricts = communityDistricts;
+    if (ceqr) queryOptions.dcp_ceqrtype = dcp_ceqrtype;
+    if (ulurp) queryOptions.dcp_ulurp_nonulurp = dcp_ulurp_nonulurp;
+    // if (action_status) queryOptions
 
     const projects = await this.store.query('project', queryOptions);
 

--- a/app/routes/show-geography.js
+++ b/app/routes/show-geography.js
@@ -31,7 +31,22 @@ export default class ShowGeographyRoute extends Route {
     },
     status: {
       refreshModel: true,
-    }
+    },
+    cds: {
+      refreshModel: true,
+    },
+    ceqr: {
+      refreshModel: true,
+    },
+    fema: {
+      refreshModel: true,
+    },
+    ulurp: {
+      refreshModel: true,
+    },
+    action_status: {
+      refreshModel: true,
+    },
   };
 
   async model(params) {
@@ -59,9 +74,6 @@ export default class ShowGeographyRoute extends Route {
     } = params;
 
     const queryOptions = {
-      'community-districts': communityDistricts,
-      dcp_ceqrtype,
-      dcp_ulurp_nonulurp,
       page,
     }
 
@@ -72,8 +84,9 @@ export default class ShowGeographyRoute extends Route {
       if (dcp_femafloodzoneshadedx) queryOptions.dcp_femafloodzoneshadedx = true;
       if (dcp_femafloodzonev) queryOptions.dcp_femafloodzonev = true;
     }
+
     if (status) queryOptions.dcp_publicstatus = dcp_publicstatus;
-    if (cds) queryOptions.communityDistricts = communityDistricts;
+    if (cds) queryOptions['community-districts'] = communityDistricts;
     if (ceqr) queryOptions.dcp_ceqrtype = dcp_ceqrtype;
     if (ulurp) queryOptions.dcp_ulurp_nonulurp = dcp_ulurp_nonulurp;
     // if (action_status) queryOptions

--- a/app/templates/show-geography.hbs
+++ b/app/templates/show-geography.hbs
@@ -31,12 +31,12 @@
     <div class="filter">
       <div class="filter-header">
         <div class="switch tiny float-left">
-          <input class="switch-input" type="checkbox" checked={{if active 'checked'}}>
-          <label {{action 'toggle'}} class="switch-paddle">
-            <span class="show-for-sr">Toggle Layer Group</span>
+          <input class="switch-input" type="checkbox" checked={{if cds 'checked'}}>
+          <label {{action (toggle 'cds' this)}} class="switch-paddle">
+            <span class="show-for-sr">Toggle Community Districts</span>
           </label>
         </div>
-        <h6 class="filter-name" {{action 'toggle'}}>Community Districts</h6>
+        <h6 class="filter-name" {{action (toggle 'cds' this)}}>Community Districts</h6>
       </div>
       <div class="medium-horizontal">
         {{#power-select-multiple
@@ -58,12 +58,12 @@
     <div class="filter">
       <div class="filter-header">
         <div class="switch tiny float-left">
-          <input class="switch-input" type="checkbox" checked={{if active 'checked'}}>
-          <label {{action 'toggle'}} class="switch-paddle">
+          <input class="switch-input" type="checkbox" checked={{if ceqr 'checked'}}>
+          <label {{action (toggle 'ceqr' this)}} class="switch-paddle">
             <span class="show-for-sr">Toggle Layer Group</span>
           </label>
         </div>
-        <h6 class="filter-name" {{action 'toggle'}}>CEQR Type <sup>{{icon-tooltip tip='The City Environmental Quality Review (CEQR)  identifies any potential adverse environmental effects of proposed actions, assesses their significance, and proposes measures to eliminate or mitigate significant impacts. Only certain minor actions, known as Type II actions, are exempt from environmental review.'}}</sup></h6>
+        <h6 class="filter-name" {{action (toggle 'ceqr' this)}}>CEQR Type <sup>{{icon-tooltip tip='The City Environmental Quality Review (CEQR)  identifies any potential adverse environmental effects of proposed actions, assesses their significance, and proposes measures to eliminate or mitigate significant impacts. Only certain minor actions, known as Type II actions, are exempt from environmental review.'}}</sup></h6>
       </div>
       <ul class="menu vertical medium-horizontal CEQR-checkbox">
         {{#each (array 'Unlisted' 'Type I' 'Type II') as |type|}}
@@ -81,12 +81,12 @@
     <div class="filter">
       <div class="filter-header">
         <div class="switch tiny float-left">
-          <input class="switch-input" type="checkbox" checked={{if active 'checked'}}>
-          <label {{action 'toggle'}} class="switch-paddle">
+          <input class="switch-input" type="checkbox" checked={{if fema 'checked'}}>
+          <label {{action (toggle 'fema' this)}} class="switch-paddle">
             <span class="show-for-sr">Toggle Layer Group</span>
           </label>
         </div>
-        <h6 class="filter-name" {{action 'toggle'}}>FEMA Flood Zone <sup>{{icon-tooltip tip='FEMA flood zone filters are applied collectively, checking more than one will yield only projects affected by all checked zones' class="dark-gray" }}</sup></h6>
+        <h6 class="filter-name" {{action (toggle 'fema' this)}}>FEMA Flood Zone <sup>{{icon-tooltip tip='FEMA flood zone filters are applied collectively, checking more than one will yield only projects affected by all checked zones' class="dark-gray" }}</sup></h6>
       </div>
       <ul class="menu vertical medium-horizontal FEMA-checkbox">
         <li onclick={{action 'toggleBoolean' 'dcp_femafloodzonea'}}>
@@ -131,12 +131,12 @@
     <div class="filter">
       <div class="filter-header">
         <div class="switch tiny float-left">
-          <input class="switch-input" type="checkbox" checked={{if active 'checked'}}>
-          <label {{action 'toggle'}} class="switch-paddle">
-            <span class="show-for-sr">Toggle Layer Group</span>
+          <input class="switch-input" type="checkbox" checked={{if ulurp 'checked'}}>
+          <label {{action (toggle 'ulurp' this)}} class="switch-paddle">
+            <span class="show-for-sr">Toggle ULURP</span>
           </label>
         </div>
-        <h6 class="filter-name" {{action 'toggle'}}>ULURP <sup>{{icon-tooltip tip='Uniform Land Use Review Procedure (ULURP) is a standardized procedure whereby applications affecting the land use of the city are publicly reviewed within mandated time frames.'}}</sup></h6>
+        <h6 class="filter-name" {{action (toggle 'ulurp' this)}}>ULURP <sup>{{icon-tooltip tip='Uniform Land Use Review Procedure (ULURP) is a standardized procedure whereby applications affecting the land use of the city are publicly reviewed within mandated time frames.'}}</sup></h6>
       </div>
       <ul class="menu vertical medium-horizontal ULURP-checkbox">
         <li  onclick={{action 'mutateArray' 'dcp_ulurp_nonulurp' 'ULURP'}}>
@@ -159,12 +159,12 @@
     <div class="filter">
       <div class="filter-header">
         <div class="switch tiny float-left">
-          <input class="switch-input" type="checkbox" checked={{if active 'checked'}}>
-          <label {{action 'toggle'}} class="switch-paddle">
+          <input class="switch-input" type="checkbox" checked={{if action_status 'checked'}}>
+          <label {{action (toggle 'action_status' this)}} class="switch-paddle">
             <span class="show-for-sr">Toggle Layer Group</span>
           </label>
         </div>
-        <h6 class="filter-name" {{action 'toggle'}}>Action Status Reason</h6>
+        <h6 class="filter-name" {{action (toggle 'action_status' this)}}>Action Status Reason</h6>
       </div>
       <ul class="menu vertical medium-horizontal">
         <li><a>{{fa-icon 'square' prefix='far' class="medium-gray"}} Active</a></li>

--- a/app/templates/show-geography.hbs
+++ b/app/templates/show-geography.hbs
@@ -14,7 +14,7 @@
         <h6 class="filter-name" {{action (toggle 'status' this)}}>Project Status</h6>
       </div>
       <ul class="menu vertical medium-horizontal status-checkbox">
-        {{#each (array 'Filed' 'Approved' 'Certified' 'Withdrawn' 'Unknown') as |type|}}
+        {{#each (array 'Filed' 'Certified' 'Complete' 'Unknown') as |type|}}
           <li onclick={{action 'mutateArray' 'dcp_publicstatus' type}}>
             <a>
               {{filter-checkbox

--- a/app/templates/show-geography.hbs
+++ b/app/templates/show-geography.hbs
@@ -6,49 +6,23 @@
     <div class="filter active">
       <div class="filter-header">
         <div class="switch tiny float-left">
-          <input class="switch-input" type="checkbox" checked={{if active 'checked'}}>
-          <label {{action 'toggle'}} class="switch-paddle">
-            <span class="show-for-sr">Toggle Layer Group</span>
+          <input class="switch-input" type="checkbox" checked={{if status 'checked'}}>
+          <label {{action (toggle 'status' this)}} class="switch-paddle">
+            <span class="show-for-sr">Toggle Project Status</span>
           </label>
         </div>
-        <h6 class="filter-name" {{action 'toggle'}}>Project Status</h6>
+        <h6 class="filter-name" {{action (toggle 'status' this)}}>Project Status</h6>
       </div>
       <ul class="menu vertical medium-horizontal status-checkbox">
-        <li onclick={{action 'mutateArray' 'dcp_publicstatus' 'Filed'}}>
-          <a>
-            {{filter-checkbox
-              value='Filed'
-              currentValues=dcp_publicstatus}}
-          </a>
-        </li>
-        <li onclick={{action 'mutateArray' 'dcp_publicstatus' 'Approved'}}>
-          <a>
-            {{filter-checkbox
-              value='Approved'
-              currentValues=dcp_publicstatus}}
-          </a>
-        </li>
-        <li onclick={{action 'mutateArray' 'dcp_publicstatus' 'Certified'}}>
-          <a>
-            {{filter-checkbox
-              value='Certified'
-              currentValues=dcp_publicstatus}}
-          </a>
-        </li>
-        <li onclick={{action 'mutateArray' 'dcp_publicstatus' 'Withdrawn'}}>
-          <a>
-            {{filter-checkbox
-              value='Withdrawn'
-              currentValues=dcp_publicstatus}}
-          </a>
-        </li>
-        <li onclick={{action 'mutateArray' 'dcp_publicstatus' 'Unknown'}}>
-          <a>
-            {{filter-checkbox
-              value='Unknown'
-              currentValues=dcp_publicstatus}}
-          </a>
-        </li>
+        {{#each (array 'Filed' 'Approved' 'Certified' 'Withdrawn' 'Unknown') as |type|}}
+          <li onclick={{action 'mutateArray' 'dcp_publicstatus' type}}>
+            <a>
+              {{filter-checkbox
+                value=type
+                currentValues=dcp_publicstatus}}
+            </a>
+          </li>
+        {{/each}}
       </ul>
     </div>
 
@@ -92,21 +66,15 @@
         <h6 class="filter-name" {{action 'toggle'}}>CEQR Type <sup>{{icon-tooltip tip='The City Environmental Quality Review (CEQR)  identifies any potential adverse environmental effects of proposed actions, assesses their significance, and proposes measures to eliminate or mitigate significant impacts. Only certain minor actions, known as Type II actions, are exempt from environmental review.'}}</sup></h6>
       </div>
       <ul class="menu vertical medium-horizontal CEQR-checkbox">
-        <li onclick={{action 'mutateArray' 'dcp_ceqrtype' 'Unlisted'}}><a>
-          {{filter-checkbox
-            value='Unlisted'
-            currentValues=dcp_ceqrtype}}
-        </a></li>
-        <li onclick={{action 'mutateArray' 'dcp_ceqrtype' 'Type I'}}><a>
-          {{filter-checkbox
-            value='Type I'
-            currentValues=dcp_ceqrtype}}
-        </a></li>
-        <li onclick={{action 'mutateArray' 'dcp_ceqrtype' 'Type II'}}><a>
-          {{filter-checkbox
-            value='Type II'
-            currentValues=dcp_ceqrtype}}
-        </a></li>
+        {{#each (array 'Unlisted' 'Type I' 'Type II') as |type|}}
+          <li onclick={{action 'mutateArray' 'dcp_ceqrtype' type}}>
+            <a>
+              {{filter-checkbox
+                value=type
+                currentValues=dcp_ceqrtype}}
+            </a>
+          </li>
+        {{/each}}
       </ul>
     </div>
 

--- a/tests/acceptance/filter-checkbox-test.js
+++ b/tests/acceptance/filter-checkbox-test.js
@@ -23,7 +23,7 @@ module('Acceptance | filter checkbox', function(hooks) {
     assert.equal(currentURL(), '/projects?dcp_ceqrtype=Type%20I%2CType%20II%2CUnknown');
   });
 
-    test('User clicks first FEMA Flood Zone status and it filters', async function(assert) {
+  test('User clicks first FEMA Flood Zone status and it filters', async function(assert) {
     server.createList('project', 20);
     await visit('/');
     await click('.FEMA-checkbox li:first-child a');
@@ -31,7 +31,7 @@ module('Acceptance | filter checkbox', function(hooks) {
     assert.equal(currentURL(), '/projects?dcp_femafloodzonea=true');
   });
 
-    test('User clicks first ULURP status and it filters', async function(assert) {
+  test('User clicks first ULURP status and it filters', async function(assert) {
     server.createList('project', 20);
     await visit('/');
     await click('.ULURP-checkbox li:first-child a');
@@ -49,7 +49,7 @@ module('Acceptance | filter checkbox', function(hooks) {
     assert.equal(currentURL(), '/projects?community-districts=BK01');
   });
 
-    test('Page reloads (pagination reset) when click new filter', async function(assert) {
+  test('Page reloads (pagination reset) when click new filter', async function(assert) {
     server.createList('project', 20);
     await visit('/projects?page=2');
     await click('.status-checkbox li:first-child a');
@@ -57,6 +57,11 @@ module('Acceptance | filter checkbox', function(hooks) {
     assert.equal(currentURL(), '/projects?dcp_publicstatus=Approved%2CCertified%2CWithdrawn');
   });
 
+  test('Page reloads (pagination reset) when click new filter', async function(assert) {
+    server.createList('project', 20);
+    await visit('/projects?page=2');
+    await click('.status-checkbox li:first-child a');
 
-
+    assert.equal(currentURL(), '/projects?dcp_publicstatus=Approved%2CCertified%2CWithdrawn');
+  });
 });

--- a/tests/acceptance/filter-checkbox-test.js
+++ b/tests/acceptance/filter-checkbox-test.js
@@ -62,6 +62,6 @@ module('Acceptance | filter checkbox', function(hooks) {
     await visit('/projects?page=2');
     await click('.status-checkbox li:first-child a');
 
-    assert.equal(currentURL(), '/projects?dcp_publicstatus=Approved%2CCertified%2CWithdrawn');
+    assert.equal(currentURL(), '/projects?dcp_publicstatus=Certified%2CComplete');
   });
 });

--- a/tests/acceptance/user-searches-address-test.js
+++ b/tests/acceptance/user-searches-address-test.js
@@ -40,26 +40,4 @@ module('Acceptance | user searches address', function(hooks) {
 
     assert.equal(currentURL(), '/');
   });
-
 });
-
-// function () {
-//   return 'something';
-// }
-
-// // returns a promise
-
-// function() {
-//   return fetch('http://example.com/movies.json')
-//   .then(function(response) {
-//     return response.json();
-//   })
-//   .then(function(myJson) {
-//     console.log(myJson);
-//   });
-// }
-
-// async function () {
-//   const response = await fetch('http://example.com/movies.json');
-//   return response.json();
-// }


### PR DESCRIPTION
This is a first pass at toggleable filters - user can decide whether a filter is applied to a search query at all. Right now, it's fairly sloppy - the FEMA filter wraps the other filters because it's not a "where in" query. We could create some kind of query object factory utility that generates this for us, but it's unclear what that would look like that at this point. 

Other thoughts:
Lots of duplication across route and controller because of some differences in how ember parachute handles refreshing a query. This should be refactored. 

Closes #117 