### PR TITLE
Inactive filter styles

### DIFF
--- a/app/controllers/show-geography.js
+++ b/app/controllers/show-geography.js
@@ -69,7 +69,7 @@ export const projectParams = new QueryParams({
   },
 
   // params for whether filters are applied or not
-  status: {
+  stage: {
     defaultValue: true,
     refresh: true,
   },

--- a/app/styles/modules/_m-project-filters.scss
+++ b/app/styles/modules/_m-project-filters.scss
@@ -21,6 +21,8 @@ $project-filters-font-size: rem-calc(12);
     float: left;
     width: 15em;
     padding-right: 0.4rem;
+    position: relative;
+    z-index: 2;
 
     .filter-name {
       color: $dark-gray;
@@ -48,6 +50,14 @@ $project-filters-font-size: rem-calc(12);
         input:checked ~ .switch-paddle::after { left: 0.625rem; }
       }
     }
+  }
+
+  .filter.inactive .filter-header ~ * {
+    opacity: 0.4;
+  }
+
+  .filter.active .filter-name {
+    color: $black;
   }
 
   .menu a {

--- a/app/templates/show-geography.hbs
+++ b/app/templates/show-geography.hbs
@@ -3,17 +3,17 @@
   {{projects-map-data meta=meta}}
 
   {{#project-filters as |filters-data|}}
-    <div class="filter active">
+    <div class="filter {{if stage 'active' 'inactive'}}">
       <div class="filter-header">
         <div class="switch tiny float-left">
-          <input class="switch-input" type="checkbox" checked={{if status 'checked'}}>
-          <label {{action (toggle 'status' this)}} class="switch-paddle">
-            <span class="show-for-sr">Toggle Project Status</span>
+          <input class="switch-input" type="checkbox" checked={{if stage 'checked'}}>
+          <label {{action (toggle 'stage' this)}} class="switch-paddle">
+            <span class="show-for-sr">Toggle Project Stage Filter</span>
           </label>
         </div>
-        <h6 class="filter-name" {{action (toggle 'status' this)}}>Project Status</h6>
+        <h6 class="filter-name" {{action (toggle 'stage' this)}}>Project Stage</h6>
       </div>
-      <ul class="menu vertical medium-horizontal status-checkbox">
+      <ul class="menu vertical medium-horizontal stage-checkbox">
         {{#each (array 'Filed' 'Certified' 'Complete' 'Unknown') as |type|}}
           <li onclick={{action 'mutateArray' 'dcp_publicstatus' type}}>
             <a>
@@ -28,12 +28,12 @@
 
     {{!-- <div class="filter">Borough</div> --}}
 
-    <div class="filter">
+    <div class="filter {{if cds 'active' 'inactive'}}">
       <div class="filter-header">
         <div class="switch tiny float-left">
           <input class="switch-input" type="checkbox" checked={{if cds 'checked'}}>
           <label {{action (toggle 'cds' this)}} class="switch-paddle">
-            <span class="show-for-sr">Toggle Community Districts</span>
+            <span class="show-for-sr">Toggle Community Districts Filter</span>
           </label>
         </div>
         <h6 class="filter-name" {{action (toggle 'cds' this)}}>Community Districts</h6>
@@ -55,12 +55,12 @@
       </div>
     </div>
 
-    <div class="filter">
+    <div class="filter {{if ceqr 'active' 'inactive'}}">
       <div class="filter-header">
         <div class="switch tiny float-left">
           <input class="switch-input" type="checkbox" checked={{if ceqr 'checked'}}>
           <label {{action (toggle 'ceqr' this)}} class="switch-paddle">
-            <span class="show-for-sr">Toggle Layer Group</span>
+            <span class="show-for-sr">Toggle CEQR Type Filter</span>
           </label>
         </div>
         <h6 class="filter-name" {{action (toggle 'ceqr' this)}}>CEQR Type <sup>{{icon-tooltip tip='The City Environmental Quality Review (CEQR)  identifies any potential adverse environmental effects of proposed actions, assesses their significance, and proposes measures to eliminate or mitigate significant impacts. Only certain minor actions, known as Type II actions, are exempt from environmental review.'}}</sup></h6>
@@ -78,12 +78,12 @@
       </ul>
     </div>
 
-    <div class="filter">
+    <div class="filter {{if fema 'active' 'inactive'}}">
       <div class="filter-header">
         <div class="switch tiny float-left">
           <input class="switch-input" type="checkbox" checked={{if fema 'checked'}}>
           <label {{action (toggle 'fema' this)}} class="switch-paddle">
-            <span class="show-for-sr">Toggle Layer Group</span>
+            <span class="show-for-sr">Toggle FEMA Flood Zone Filter</span>
           </label>
         </div>
         <h6 class="filter-name" {{action (toggle 'fema' this)}}>FEMA Flood Zone <sup>{{icon-tooltip tip='FEMA flood zone filters are applied collectively, checking more than one will yield only projects affected by all checked zones' class="dark-gray" }}</sup></h6>
@@ -128,12 +128,12 @@
       </ul>
     </div>
 
-    <div class="filter">
+    <div class="filter {{if ulurp 'active' 'inactive'}}">
       <div class="filter-header">
         <div class="switch tiny float-left">
           <input class="switch-input" type="checkbox" checked={{if ulurp 'checked'}}>
           <label {{action (toggle 'ulurp' this)}} class="switch-paddle">
-            <span class="show-for-sr">Toggle ULURP</span>
+            <span class="show-for-sr">Toggle ULURP Filter</span>
           </label>
         </div>
         <h6 class="filter-name" {{action (toggle 'ulurp' this)}}>ULURP <sup>{{icon-tooltip tip='Uniform Land Use Review Procedure (ULURP) is a standardized procedure whereby applications affecting the land use of the city are publicly reviewed within mandated time frames.'}}</sup></h6>
@@ -156,12 +156,12 @@
       </ul>
     </div>
 
-    <div class="filter">
+    <div class="filter {{if action_status 'active' 'inactive'}}">
       <div class="filter-header">
         <div class="switch tiny float-left">
           <input class="switch-input" type="checkbox" checked={{if action_status 'checked'}}>
           <label {{action (toggle 'action_status' this)}} class="switch-paddle">
-            <span class="show-for-sr">Toggle Layer Group</span>
+            <span class="show-for-sr">Toggle Action Status Reason Filter</span>
           </label>
         </div>
         <h6 class="filter-name" {{action (toggle 'action_status' this)}}>Action Status Reason</h6>

--- a/tests/acceptance/filter-checkbox-test.js
+++ b/tests/acceptance/filter-checkbox-test.js
@@ -10,7 +10,7 @@ module('Acceptance | filter checkbox', function(hooks) {
   test('User clicks first project status and it filters', async function(assert) {
     server.createList('project', 20);
     await visit('/');
-    await click('.status-checkbox li:first-child a');
+    await click('.stage-checkbox li:first-child a');
 
     assert.equal(currentURL(), '/projects?dcp_publicstatus=Certified%2CComplete');
   });
@@ -52,7 +52,7 @@ module('Acceptance | filter checkbox', function(hooks) {
   test('Page reloads (pagination reset) when click new filter', async function(assert) {
     server.createList('project', 20);
     await visit('/projects?page=2');
-    await click('.status-checkbox li:first-child a');
+    await click('.stage-checkbox li:first-child a');
 
     assert.equal(currentURL(), '/projects?dcp_publicstatus=Certified%2CComplete');
   });
@@ -60,7 +60,7 @@ module('Acceptance | filter checkbox', function(hooks) {
   test('Page reloads (pagination reset) when click new filter', async function(assert) {
     server.createList('project', 20);
     await visit('/projects?page=2');
-    await click('.status-checkbox li:first-child a');
+    await click('.stage-checkbox li:first-child a');
 
     assert.equal(currentURL(), '/projects?dcp_publicstatus=Certified%2CComplete');
   });


### PR DESCRIPTION
This PR…
- Adds an `.active`/`.inactive` class to filters
- Adds styles for inactive filters (inactive = transparent; active = opaque)  
- Fixes a `z-index` bug where you couldn't click the inactive "Community Districts" toggle (because of powerselect)
- Fixes a regression ("Project Status" was changed to "Project Stage") 