### PR TITLE
add margin to sup tooltips to prevent overlapping text

### DIFF
--- a/app/styles/modules/_m-tooltipster.scss
+++ b/app/styles/modules/_m-tooltipster.scss
@@ -34,6 +34,10 @@ $tooltipster-border-color: #3a3c47;
       }
     }
   }
+
+  sup & {
+    margin-left: 1px;
+  }
 }
 
 .tooltipster-box {


### PR DESCRIPTION
This tiny PR adds a 1px of margin to tooltips inside `<sup>` elements so that they don't smash up against the text. 

Before: 
![image](https://user-images.githubusercontent.com/409279/41925463-aa4b1732-793a-11e8-8278-d87204a014a8.png)

After: 
![image](https://user-images.githubusercontent.com/409279/41925489-b896adc4-793a-11e8-8f0d-9785a8d9a64b.png)
