### PR TITLE
fix bug: unknown status shows for each list item

### DIFF
--- a/app/models/project.js
+++ b/app/models/project.js
@@ -31,7 +31,7 @@ export default class ProjectModel extends Model {
   @attr('boolean') dcp_previousactiononsite;
   @attr('string') dcp_projectbrief;
   @attr('string') dcp_projectname;
-  @attr() dcp_publicstatus;
+  @attr() dcp_publicstatus_simp;
   @attr() dcp_hiddenprojectmetrictarget;
   @attr('boolean') dcp_sischoolseat;
   @attr('boolean') dcp_sisubdivision;

--- a/app/templates/show-geography.hbs
+++ b/app/templates/show-geography.hbs
@@ -220,7 +220,7 @@
               {{substring-projectbrief project.dcp_projectbrief}}
             </p>
             <p class="no-margin text-tiny dark-gray">
-              <span class="label light-gray">{{if project.dcp_publicstatus project.dcp_publicstatus "Unknown Status"}}</span>
+              <span class="label light-gray">{{if project.dcp_publicstatus_simp project.dcp_publicstatus_simp 'Unknown Status'}}</span>
               {{#if project.dcp_borough}}<span class="label light-gray">{{project.dcp_borough}}</span>{{/if}}
               {{#if project.dcp_communitydistricts}}<span class="label light-gray">{{project.dcp_communitydistricts}}</span>{{/if}}
               {{#if project.dcp_ulurp_nonulurp}}<span class="label light-gray">{{project.dcp_ulurp_nonulurp}}</span>{{/if}}


### PR DESCRIPTION
Update Model "projects" to include dcp_publicstatus_simp instead of dcp_public status (the API was changed)

Update show.geography template to to display dcp_publicstatus_simp instead of dcp_publicstatus