### PR TITLE
nix lead division

### DIFF
--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -180,11 +180,6 @@
           </p>
 
           <p class="text-small">
-            <strong>Lead Division:</strong>
-            {{lookup-dcp-division model.dcp_leaddivision}}
-          </p>
-
-          <p class="text-small">
             <strong>Keywords:</strong>
             {{#if model.keywords}}
               {{#each model.keywords as |keyword|}}


### PR DESCRIPTION
This PR removes "Lead Division" from the project meta (because contacting the project's boro office is better than contacting the lead division).  Closes #151.