### PR TITLE
better milestone mirage data

### DIFF
--- a/app/components/project-milestone.js
+++ b/app/components/project-milestone.js
@@ -144,6 +144,13 @@ export default class ProjectMilestoneComponent extends Component {
     return milestoneLookup[milestonename].displayName;
   }
 
+  // useful so handlebars knows whether to append "start" and "end" labels to dates
+  @computed('milestonename')
+  get isRange() {
+    const milestonename = this.get('milestone.milestonename');
+    return milestoneLookup[milestonename].dateFormat === 'range';
+  }
+
   // Returns an array
   // first item in array is the offset string
   // subsquent items are time objects
@@ -160,13 +167,6 @@ export default class ProjectMilestoneComponent extends Component {
   //     date: date,
   //   },
   // ]
-
-  // useful so handlebars knows whether to append "start" and "end" labels to dates
-  @computed('milestonename')
-  get isRange() {
-    const milestonename = this.get('milestone.milestonename');
-    return milestoneLookup[milestonename].dateFormat === 'range';
-  }
 
   @computed('milestonename')
   get milestoneDisplayDates() {

--- a/mirage/factories/project.js
+++ b/mirage/factories/project.js
@@ -178,10 +178,10 @@ export default Factory.extend({
         milestonename: "Land Use Fee Payment",
         dcp_plannedstartdate: "2018-10-31T01:21:46",
         dcp_plannedcompletiondate: "2018-11-02T01:21:46",
-        dcp_actualstartdate: null,
-        dcp_actualenddate: null,
-        statuscode: "Overridden",
-        dcp_milestonesequence: 28
+        dcp_actualstartdate: "2018-05-11T04:00:00",
+        dcp_actualenddate: "2018-05-12T04:00:00",
+        statuscode: "Completed",
+        dcp_milestonesequence: 28,
       },
       {
         dcp_name: "ZC - Land Use Application Filed Review ",
@@ -192,6 +192,16 @@ export default Factory.extend({
         dcp_actualenddate: null,
         statuscode: "Overridden",
         dcp_milestonesequence: 29
+      },
+      {
+        dcp_name: "ZC - City Council Review ",
+        milestonename: "City Council Review",
+        dcp_plannedstartdate: null,
+        dcp_plannedcompletiondate: null,
+        dcp_actualstartdate: "2016-04-22T01:40:24",
+        dcp_actualenddate: "2022-05-02T01:40:24",
+        statuscode: "Not Started",
+        dcp_milestonesequence: 60
       },
       {
         dcp_name: "ZC - Final Letter Sent ",


### PR DESCRIPTION
Adds better mirage data for milestones. The order is nonsense, but now we can see all the various formats: past/present/future, day/range, etc. 

![image](https://user-images.githubusercontent.com/409279/42100486-568b8982-7b8e-11e8-83c9-44748f672ed6.png)
