### PR TITLE
Simplify fetch data

### DIFF
--- a/app/templates/show-geography.hbs
+++ b/app/templates/show-geography.hbs
@@ -259,7 +259,7 @@
   <div class="results">
     <h3 class="results-header header-large">{{numeral-format fetchData.lastSuccessful.value.meta.total '0,0'}} project{{unless (eq fetchData.lastSuccessful.value.meta.total 1) 's'}} match{{if (eq fetchData.lastSuccessful.value.meta.total 1) 'es'}} your filters</h3>
     <ul class="results-list no-bullet">
-      {{#each fetchData.lastSuccessful.value.projects as |project|}}
+      {{#each cachedProjects as |project|}}
         <li class="grid-x grid-padding-small projects-list-result">
           <div class="cell shrink">
             <a class="button gray text-orange">


### PR DESCRIPTION
This pull request further addresses a bug concerning synchronization between states of the ephemeral result list and the store's own system of "collecting" records for caching. Solution based on discussion here: https://discuss.emberjs.com/t/ember-concurrency-and-store-unloadall-fall-out-of-sync/15068.

This pull request switches out "restartableTask" with "lastSuccessful". Additionally, the query object that's created is split out into a computed property and called from the task. The task itself no longer unloads the entire store every new request. Instead, it mutates a cached array property on the controller as a side effect. 

(Thanks, @sukima!)
