### PR TITLE
Fix map tooltip positioning

### DIFF
--- a/app/components/projects-map-data.js
+++ b/app/components/projects-map-data.js
@@ -44,7 +44,7 @@ export default class ProjectsMapComponent extends Component {
   }
 
   @action
-  handleMapMove(e) {
+  handleMouseMove(e) {
     const map = this.get('mapInstance');
     const [feature] = map.queryRenderedFeatures(
       e.point,

--- a/app/templates/components/projects-map-data.hbs
+++ b/app/templates/components/projects-map-data.hbs
@@ -7,20 +7,20 @@
     mapLoaded=(action 'handleMapLoad')
     as |map|
 }}
-  {{yield (hash 
-    dynamic-tiles=(component 'mapbox-gl-dynamic-tiles' 
-      map=map 
+  {{yield (hash
+    dynamic-tiles=(component 'mapbox-gl-dynamic-tiles'
+      map=map
       mapInstance=mapInstance
     )
     map=map
   )}}
 
   {{map.on 'click' (action 'handleMapClick')}}
-  {{map.on 'mousemove' (action 'handleMapMove')}}
-{{/mapbox-gl}}
+  {{map.on 'mousemove' (action 'handleMouseMove')}}
 
-{{#if highlightedFeature}}
-  <div class='map-tooltip' style="top = {{tooltipPoint.y}}px;left: {{tooltipPoint.x}}px;">
-    {{highlightedFeature.properties.dcp_projectname}}
-  </div>
-{{/if}}
+  {{#if highlightedFeature}}
+    <div class='map-tooltip' style="top:{{tooltipPoint.y}}px;left:{{tooltipPoint.x}}px;">
+      {{highlightedFeature.properties.dcp_projectname}}
+    </div>
+  {{/if}}
+{{/mapbox-gl}}


### PR DESCRIPTION
This PR fixes the positioning of the map tooltip. 

- The action was poorly named — changed `handleMapMove()` to `handleMouseMove()`
- Moved the tooltip markup inside `{{mapbox-gl}}` so it's positioned relative to the right container
- Fixed the bad inline CSS — it was using `=` instead of `:` 

Closes #202 