### PR TITLE
prevent results header breaking lines

### DIFF
--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -88,6 +88,8 @@ body {
   padding-bottom: $global-margin;
 
   .results-header {
+    font-size: rem-calc(16);
+
     @include breakpoint(large) {
       position: fixed;
       z-index: 2;
@@ -100,14 +102,17 @@ body {
       padding: $global-margin*0.75 rem-calc(5);
       box-shadow: 0 2px 0 rgba(0,0,0,0.1);
     }
+
     @include breakpoint(xlarge) {
       width: calc(41.66667% - #{rem-calc(30)});
     }
+
     @include breakpoint(xxlarge) {
       width: calc(50% - #{rem-calc(30)});
+      font-size: rem-calc(20);
     }
 
-    .results-header-count {
+    .results-header-meta {
       font-weight: normal;
       font-size: $small-font-size;
       padding: rem-calc(6) 0 0 rem-calc(10);

--- a/app/templates/show-geography.hbs
+++ b/app/templates/show-geography.hbs
@@ -249,11 +249,13 @@
 </div>
 <div class="cell large-6 xlarge-5 xxlarge-6">
   <div class="results">
-    <h3 class="results-header header-medium">
-      {{numeral-format fetchData.lastSuccessful.value.meta.total '0,0'}}
-      application{{unless (eq fetchData.lastSuccessful.value.meta.total 1) 's'}}
-      {{if (eq fetchData.lastSuccessful.value.meta.total 1) 'matches' 'match'}} your filters
-      <span class="float-right results-header-count">
+    <h3 class="results-header clearfix">
+      <span class="float-left results-header-title">
+        {{numeral-format fetchData.lastSuccessful.value.meta.total '0,0'}}
+        application{{unless (eq fetchData.lastSuccessful.value.meta.total 1) 's'}}
+        {{if (eq fetchData.lastSuccessful.value.meta.total 1) 'matches' 'match'}} your filters
+      </span>
+      <span class="float-right results-header-meta">
         {{#if fetchData.isRunning}}
           {{fa-icon 'spinner' class="fa-spin medium-gray"}}
         {{else}}


### PR DESCRIPTION
This PR adjusts the style of the results header so that it cannot break to multiple lines, which was causing it to overlap the results list. 

Closes #283. 