### PR TITLE
284 multiple filings

### DIFF
--- a/app/components/project-milestone.js
+++ b/app/components/project-milestone.js
@@ -108,7 +108,16 @@ const milestoneLookup = {
     dateFormat: 'start',
     hideIfFiled: false,
     ulurptooltip: '',
-    nonulurptooltip: '', 
+    nonulurptooltip: '',
+  },
+
+  // special handling for subsequent instances of Filing
+  'Revised Land Use Application Filed Review': {
+    displayName: 'Revised Land Use Application Filed',
+    dateFormat: 'start',
+    hideIfFiled: false,
+    ulurptooltip: '',
+    nonulurptooltip: '',
   },
   'Land Use Fee Payment': {
     displayName: 'Land Use Fee Paid',
@@ -204,10 +213,10 @@ export default class ProjectMilestoneComponent extends Component {
 
   if (isUlurp) {
     const  tooltip   = `${ulurptip}`;
-    return  tooltip; 
+    return  tooltip;
   } else {
     const  tooltip  = `${nonulurptip}`;
-    return tooltip; 
+    return tooltip;
   }
  }
 

--- a/app/controllers/show-project.js
+++ b/app/controllers/show-project.js
@@ -37,6 +37,22 @@ export default class ShowProjectController extends Controller {
     return this.get('model.dcp_publicstatus') === 'Filed';
   }
 
+  // workaround for displaying "Revised Land Use Application..." for subsequent copies of the same milestone
+  @computed('model.milestones')
+  get revisedmilestones() {
+    const { milestones } = this.model;
+    let filedCounter = 0;
+    return milestones.map((milestone) => {
+      if (milestone.milestonename === 'Land Use Application Filed Review') {
+        filedCounter += 1;
+        if (filedCounter > 1) milestone.milestonename = 'Revised Land Use Application Filed Review';
+        return milestone;
+      }
+
+      return milestone
+    })
+  }
+
   @action
   handleMapLoad(bblFeatureCollection, map) {
     window.map = map;

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -111,7 +111,7 @@
             <h2>Milestones</h2>
             <ul class="no-bullet milestones-list">
               {{#if model.milestones}}
-                {{#each model.milestones as | milestone |}}
+                {{#each revisedmilestones as | milestone |}}
                   {{project-milestone milestone=milestone isFiled=isFiled  isUlurp=(eq model.dcp_ulurp_nonulurp "ULURP")}}
                 {{/each}}
               {{else}}


### PR DESCRIPTION
Adds logic to change the display values for subsequent application filings.  The first one will show "Land use application filed", subsequent ones will show "Revised Land Use Application Filed"

This is accomplished by adding a computed property in show-project controller that changes the milestonename if there are multiple filings.

![](https://files.slack.com/files-pri/T15PHEFJ9-FBQPWS3SS/image.png)

Closes #284