### PR TITLE
remove unused default filters, make default for status only Filed and…

### DIFF
--- a/app/controllers/query-parameters/show-geography.js
+++ b/app/controllers/query-parameters/show-geography.js
@@ -5,7 +5,7 @@ import moment from 'moment';
 export const projectParams = new QueryParams({
   // meta
   'applied-filters': {
-    defaultValue: ['community-districts', 'dcp_publicstatus', 'action-types'].sort(),
+    defaultValue: ['dcp_publicstatus'].sort(),
     refresh: true,
     serialize(value) {
       return value.toString();
@@ -68,7 +68,7 @@ export const projectParams = new QueryParams({
     },
   },
   dcp_publicstatus: {
-    defaultValue: ['Filed', 'In Public Review', 'Completed'].sort(),
+    defaultValue: ['Filed', 'In Public Review'].sort(),
     refresh: true,
     serialize(value) {
       value = value.filter(d => d !== '')

--- a/tests/acceptance/filter-checkbox-test.js
+++ b/tests/acceptance/filter-checkbox-test.js
@@ -18,7 +18,7 @@ module('Acceptance | filter checkbox', function(hooks) {
     await visit('/');
     await click('.stage-checkbox li:first-child a');
 
-    assert.equal(currentURL().includes('Completed%2CIn%20Public%20Review'), true);
+    assert.equal(currentURL().includes('In%20Public%20Review'), true);
   });
 
   test('User clicks first CEQR Status and it filters', async function(assert) {
@@ -52,7 +52,7 @@ module('Acceptance | filter checkbox', function(hooks) {
     await fillIn('.filter-section-community-district .ember-power-select-multiple-options input', 'Brooklyn 1');
     await click ('.ember-power-select-options li:first-child');
 
-    assert.equal(currentURL(), '/projects?community-districts=BK01');
+    assert.equal(currentURL(), '/projects?applied-filters=community-districts%2Cdcp_publicstatus&community-districts=BK01');
   });
 
   skip('Page reloads (pagination reset) when click new filter', async function(assert) {
@@ -93,7 +93,7 @@ module('Acceptance | filter checkbox', function(hooks) {
     await visit('/projects');
     await click('.filter-section-fema-flood-zone .switch-paddle');
 
-    assert.equal(currentURL(), '/projects?applied-filters=action-types%2Ccommunity-districts%2Cdcp_femafloodzonea%2Cdcp_femafloodzonecoastala%2Cdcp_femafloodzoneshadedx%2Cdcp_femafloodzonev%2Cdcp_publicstatus');
+    assert.equal(currentURL(), '/projects?applied-filters=dcp_femafloodzonea%2Cdcp_femafloodzonecoastala%2Cdcp_femafloodzoneshadedx%2Cdcp_femafloodzonev%2Cdcp_publicstatus');
     await click('.filter-section-fema-flood-zone .switch-paddle');
 
     assert.equal(currentURL(), '/projects');


### PR DESCRIPTION
- Removes Borough and Community District from default enabled filter-sections
- Sets default for projectstatus to only include 'Filed' and 'In Public Review'

Closes #295