### PR TITLE
no markers on unmapped results

### DIFF
--- a/app/templates/components/project-list-item.hbs
+++ b/app/templates/components/project-list-item.hbs
@@ -1,6 +1,15 @@
 <li class="grid-x grid-padding-small projects-list-result">
   <div class="cell results-meta publicstatus-{{dasherize project.dcp_publicstatus_simp}}" style="width:5rem;">
-    {{project-list-map-pin project=project}}
+    {{#if project.has_centroid}}
+      {{project-list-map-pin project=project}}
+    {{else}}
+      <a class="button hollow expanded map-marker-button" style="opacity:1;" disabled>
+        <span class="fa-layers fa-fw" style="font-size: 1.5rem;">
+          {{fa-icon 'map-marker-alt' fixedWidth=true class="light-gray"}}
+          <span class="fa-layers-text" style="font-size:0.625rem;color:#000;">Not Mapped</span>
+        </span>
+      </a>
+    {{/if}}
     <span class="label publicstatus-label">{{unless (eq project.dcp_publicstatus_simp 'Unknown') project.dcp_publicstatus_simp "Unknown Status"}}</span>
   </div>
   <div class="cell auto">

--- a/app/templates/components/project-list-map-pin.hbs
+++ b/app/templates/components/project-list-map-pin.hbs
@@ -1,8 +1,3 @@
 <span class="fa-layers fa-fw" style="font-size: 1.5rem;">
-  {{#if project.has_centroid}}
-    {{fa-icon 'map-marker-alt' fixedWidth=true}}
-  {{else}}
-    {{fa-icon 'map-marker-alt' fixedWidth=true class='medium-gray'}}
-    {{fa-icon 'ban' fixedWidth=true class='lu-red' transform='grow-8'}}
-  {{/if}}
+  {{fa-icon 'map-marker-alt' fixedWidth=true}}
 </span>


### PR DESCRIPTION
This PR prevents unmapped projects from showing a map marker in the results list. Instead is shows "Not Mapped" and has no hover/click actions.

Closes #311. 
Closes #312. 