### PR TITLE
add ceqraccess links

### DIFF
--- a/app/helpers/build-url.js
+++ b/app/helpers/build-url.js
@@ -1,4 +1,5 @@
 import { helper } from '@ember/component/helper';
+import ENV from 'labs-zap-search/config/environment';
 
 function pad(string, size) {
   while (string.length < (size || 2)) {string = "0" + string;}
@@ -47,12 +48,18 @@ function acris(bbl) {
   return `http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`;
 }
 
+function ceqraccess(ceqrnumber) {
+  return `${ENV.host}/ceqr/${ceqrnumber}`;
+}
+
 export function buildUrl([type, value]) {
   if (type === "zoningResolution") return zoningResolution(value);
   if (type === "zola") return zola(value);
   if (type === "bisweb") return bisweb(value);
   if (type === "cpcReport") return cpcReport(value);
   if (type === "acris") return acris(value);
+  if (type === "ceqraccess") return ceqraccess(value);
+
 
   throw 'invalid type passed to build-url helper';
 }

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -37,7 +37,7 @@
         <p>
           <strong>Project Brief:</strong>
           {{#if model.dcp_projectbrief}}
-            {{markdown-to-html 
+            {{markdown-to-html
               markdown=model.dcp_projectbrief}}
           {{else}}
             No Project Brief
@@ -85,7 +85,7 @@
                             tip=(lookup-action-type action.actioncode)}}
                         </sup>
                       {{/if}}
-                    </h5> 
+                    </h5>
                     <p class="text-small no-margin">
                       {{#if action.dcp_ulurpnumber}}
                         ULURP Number:
@@ -169,7 +169,7 @@
             <p class="text-small label-group">
               <strong>CEQR<sup class="dark-gray">{{icon-tooltip tip='City Environmental Quality Review. Only certain minor actions, known as Type II actions, are exempt from environmental review.'}}</sup>:</strong>
               {{#if model.dcp_ceqrtype}}<span class="label light-gray">{{model.dcp_ceqrtype}}</span>{{/if~}}
-              {{#if model.dcp_ceqrnumber}}<span class="label light-gray">{{model.dcp_ceqrnumber}}</span>{{/if~}}
+              {{#if model.dcp_ceqrnumber}}<span class="label light-gray"><a href="{{build-url "ceqraccess" model.dcp_ceqrnumber}}" target="_blank">{{model.dcp_ceqrnumber}} {{fa-icon 'external-link-alt'}}</a></span>{{/if~}}
             </p>
           {{/if}}
 


### PR DESCRIPTION
Adds a new type to the `build-url` utility, for ceqr access links.
Turns all ceqr numbers on the project pages into hyperlinks with an external link icon.

Depends on [this PR](https://github.com/NYCPlanning/labs-zap-api/pull/45) for the API.

Closes #260