### PR TITLE
Better responsive subtitle

### DIFF
--- a/app/templates/components/labs-site-header.hbs
+++ b/app/templates/components/labs-site-header.hbs
@@ -3,7 +3,7 @@
   <div class="grid-x grid-padding-x">
     <div class="branding cell shrink large-auto">
       <a class="dcp-link" href="http://www1.nyc.gov/site/planning/index.page"><img class="dcp-logo" src="https://raw.githubusercontent.com/NYCPlanning/logo/master/dcp_logo_772.png" alt="NYC Planning"></a>
-      {{#link-to 'show-geography' classNames='site-name' click=(action (mut closed) true)}}ZAP Search <small class="site-subtitle show-for-medium">Find N<span class="show-for-large">ew </span>Y<span class="show-for-large">ork </span>C<span class="show-for-large">ity</span> Zoning and Land Use Applications</small>{{/link-to}}
+      {{#link-to 'show-geography' classNames='site-name' click=(action (mut closed) true)}}ZAP Search <small class="site-subtitle show-for-medium">Find N<span class="show-for-xlarge">ew </span>Y<span class="show-for-xlarge">ork </span>C<span class="show-for-xlarge">ity</span> <span class="hide-for-large-only">Zoning &amp;</span> Land Use Applications</small>{{/link-to}}
     </div>
     <div class="cell auto hide-for-large text-right">
       <button {{action (mut closed) (not closed)}} class="responsive-nav-toggler hide-for-print" data-toggle="responsive-menu">Menu</button>


### PR DESCRIPTION
This PR prevents the site subtitle from breaking to multiple lines and breaking layout

As seen here, you can't see the results header because the site header is too tall: 
![image](https://user-images.githubusercontent.com/409279/43176320-05f22f32-8f91-11e8-9c4b-0fc301e42188.png)
