### PR TITLE
Prominent results dates

### DIFF
--- a/app/styles/layouts/_l-default.scss
+++ b/app/styles/layouts/_l-default.scss
@@ -150,6 +150,26 @@ body {
   }
 }
 
+.projects-list-result {}
+
+.projects-list-result--header {
+  display: inline;
+  margin: 0;
+}
+
+.projects-list-result--date {
+  display: block;
+  white-space: nowrap;
+  font-size: rem-calc(12);
+  line-height: 2;
+  float: right;
+  margin-left: rem-calc(10);
+}
+
+.projects-list-result--description {}
+
+.projects-list-result--meta {}
+
 .no-results-message {
   @include breakpoint(large) {
     margin-top: 15vh;
@@ -169,159 +189,6 @@ body {
 .ember-content-placeholders-img {
   min-height: 350px;
 }
-
-// .search-container {
-//   position: relative;
-//   z-index: 3;
-//   width: 100%;
-//   height: 5.25rem;
-//   overflow: visible;
-//   box-shadow: 0 2px 0 rgba(0,0,0,0.1);
-//
-//   @include breakpoint(medium) {
-//     position: absolute;
-//     top: 0;
-//     right: 0;
-//     width: 15rem;
-//     box-shadow: 0 2px 0 rgba(0,0,0,0.1), -4px 0 0 rgba(0,0,0,0.1);
-//   }
-//
-//   @include breakpoint(large) {
-//     position: fixed;
-//     top: 6rem;
-//     right: auto;
-//     left: 0;
-//     box-shadow: 0 2px 0 rgba(0,0,0,0.1), 2px 0 0 rgba(0,0,0,0.1);
-//   }
-//
-//   @include breakpoint(xlarge) {
-//     width: 18rem;
-//   }
-// }
-
-// .map-container {
-//   @include xy-cell-static(full,false,0);
-//
-//   position: relative;
-//   z-index: 1;
-//   height: 50vh;
-//   background-color: $medium-gray;
-//
-//   @include breakpoint(large) {
-//     height: 100%;
-//   }
-// }
-
-// .layer-menu {
-//   background-color: $light-gray;
-//   z-index: 2;
-//   // min-height: calc(50vh - 8rem);
-//
-//   @include breakpoint(medium) {
-//     min-height: none;
-//     max-height: 50vh;
-//     height: calc(50vh - 5.25rem);
-//     width: 15rem;
-//     box-shadow: -4px 0 0 rgba(0,0,0,0.1);
-//     overflow: scroll;
-//     margin-top: 5.25rem;
-//   }
-//
-//   @include breakpoint(large) {
-//     height: calc(100% - 5.25rem);
-//     box-shadow: 2px 0 0 rgba(0,0,0,0.1);
-//     // padding-bottom: 6.25rem;
-//   }
-//
-//   @include breakpoint(xlarge) {
-//     width: 18rem;
-//   }
-// }
-
-// .route-index {
-//
-//   @include breakpoint(small only) {
-//     .map-container {
-//       height: calc(100vh - 14.25rem);
-//     }
-//
-//     .layer-menu {
-//       min-height: 6rem;
-//     }
-//   }
-//
-//   @include breakpoint(medium only) {
-//     .map-container {
-//       height: 100%;
-//       max-height: none;
-//     }
-//
-//     .layer-menu {
-//       height: calc(100% - 5.25rem);
-//       max-height: none;
-//     }
-//   }
-// }
-
-// .content-close-button-container {
-//   position: relative;
-//   z-index: 4;
-//   box-shadow: 0 -2px 0 rgba(0,0,0,0.1);
-//   background-color: $body-background;
-//   text-align: right;
-//   padding: $global-margin $global-margin 0;
-//
-//   @include breakpoint(small only) {
-//     margin-bottom: -$global-margin;
-//   }
-//
-//   @include breakpoint(medium down) {
-//     @include xy-cell-static(full,false,0);
-//   }
-//
-//   @include breakpoint(large) {
-//     padding: 0;
-//   }
-// }
-// .content-close-button {
-//   color: $dark-gray;
-//   font-size: rem-calc(32);
-//   line-height: 1;
-//   position: relative;
-//   margin: 0;
-//   width: 1em;
-//
-//   &:hover {
-//     color: $lu-red;
-//   }
-//
-//   @include breakpoint(large) {
-//     display: block;
-//     position: fixed;
-//     z-index: 3;
-//     top: 6.5rem;
-//     right: 41.66667%;
-//     background-color: $body-background;
-//     margin-right: -4px;
-//     padding: 0 rem-calc(6) rem-calc(3);
-//     box-shadow: -4px 4px 0 rgba(0,0,0,0.1);
-//   }
-//   @include breakpoint(xxlarge) {
-//     right: 33.33333%;
-//   }
-// }
-
-// .content-area {
-//   z-index: 3;
-//   background-color: $body-background;
-//   min-height: calc(50vh - 6rem);
-//   padding: $global-margin;
-//
-//   @include breakpoint(large) {
-//     height: 100%;
-//     box-shadow: -4px 0 0 rgba(0,0,0,0.1);
-//   }
-// }
 
 .grid-padding-small {
   margin-right: -0.5rem;

--- a/app/templates/components/project-list-item.hbs
+++ b/app/templates/components/project-list-item.hbs
@@ -12,15 +12,21 @@
     <span class="label publicstatus-label">{{unless (eq project.dcp_publicstatus_simp 'Unknown') project.dcp_publicstatus_simp "Unknown Status"}}</span>
   </div>
   <div class="cell auto">
-    <h3 class="header-medium no-margin">
+    {{#if project.lastmilestonedate}}
+      <span class="date dark-gray projects-list-result--date">
+        {{icon-tooltip icon='calendar' tip='Latest Milestone'}}
+        {{moment-format project.lastmilestonedate "MMMM D, YYYY"}}
+      </span>
+    {{/if}}
+    <h3 class="projects-list-result--header header-medium">
       {{#link-to 'show-project' project.id}}
         {{if project.dcp_projectname project.dcp_projectname "No Project Name"}}
       {{/link-to}}
     </h3>
-    <p class="no-margin text-small dark-grey">
+    <p class="projects-list-result--description no-margin text-small dark-grey">
       <strong>{{firstApplicant}}</strong> &mdash; {{if project.dcp_projectbrief (substring-projectbrief project.dcp_projectbrief) "No Project Brief"}}
     </p>
-    <p class="no-margin text-tiny dark-gray label-group">
+    <p class="projects-list-result--meta no-margin text-tiny dark-gray label-group">
       {{#if (eq project.dcp_borough 'Citywide')}}<span class="label light-gray"><strong class="dark-gray">{{project.dcp_borough}}</strong></span>{{/if}}
 
       {{consolidated-cds cds=project.dcp_communitydistricts}}
@@ -29,9 +35,6 @@
       {{#each project.ulurpnumbers as |ulurpnumber|}}
         <span class="label light-gray"><strong class="dark-gray">{{ulurpnumber}}</strong></span>
       {{/each}}
-      {{#if project.lastmilestonedate}}
-      <span class="label light-gray"> <strong class="dark-gray">{{icon-tooltip icon='calendar' tip='Latest Milestone'}} {{ moment-format project.lastmilestonedate "MMMM D, YYYY" }} </strong></span>
-      {{/if}}
     </p>
   </div>
 </li>


### PR DESCRIPTION
This PR makes the dates in the results list more prominent so that the users knows how the results are sorted. Closes #444. 

![image](https://user-images.githubusercontent.com/409279/55241702-051a2800-5212-11e9-8f9c-4d3d8a5a408f.png)

One thing that is odd: Since we're sorting by reverse chronology of `lastmilestonedate`, and some dates are WAAAY in the future, the most time-sensitive stuff isn't first. We might check with the customer to see if there's a better way we might order the results — e.g. from now forward, followed by from now backward? 

_* Also removes a bunch of crufty CSS._ 