### PR TITLE
483: remove default coordinate for radius filter

### DIFF
--- a/app/controllers/query-parameters/show-geography.js
+++ b/app/controllers/query-parameters/show-geography.js
@@ -112,7 +112,7 @@ export const projectParams = new QueryParams({
     },
   },
   distance_from_point: {
-    defaultValue: [-73.9868, 40.724],
+    defaultValue: [],
     refresh: true,
     serialize(value) {
       return value.toString();

--- a/app/controllers/show-geography.js
+++ b/app/controllers/show-geography.js
@@ -168,9 +168,13 @@ export default class ShowGeographyController extends GeographyParachuteControlle
 
     // If metadata includes tiling and bounds information, continue
     if (meta.tiles && meta.bounds) {
-      // If radius filter is on, be sure to prefer the bounding box for that
-      // instead of what the server comes back with.
-      if (queryOptions.distance_from_point && queryOptions.radius_from_point) {
+      /*
+      * Filtering does not occur until a user has created a point/selected a centroid, even if the filter is turned on.
+      * If radius filter is on, and a point exists, indicating the user has actually clicked a point (default is []),
+      * use bounding box calculated from radius and point instead of bounding box from response.
+      * Check for point existence is also done in filter-distance-from-point.hbs
+      */
+      if (queryOptions.distance_from_point && queryOptions.distance_from_point.length && queryOptions.radius_from_point) {
         const {
           distance_from_point,
           radius_from_point,

--- a/app/templates/components/filter-distance-from-point.hbs
+++ b/app/templates/components/filter-distance-from-point.hbs
@@ -14,16 +14,18 @@
       paint=(hash circle-color='rgba(238,102,170,0.8)' circle-radius=7))
     }}
   {{/map.source}}
-
-  {{#map.source options=(hash
-    type='geojson'
-    data=circleFromRadius) as |source|
-  }}
-    {{source.layer layer=(hash
-      type='line'
-      paint=(hash line-dasharray=(array 1 1) line-width=3 line-color='rgba(238,102,170,0.8)')
-    )}}
-  {{/map.source}}
+  {{! only display radius circle and zoom to point if point exists}}
+  {{#if pointGeometry}}
+    {{#map.source options=(hash
+      type='geojson'
+      data=circleFromRadius) as |source|
+    }}
+      {{source.layer layer=(hash
+        type='line'
+        paint=(hash line-dasharray=(array 1 1) line-width=3 line-color='rgba(238,102,170,0.8)')
+      )}}
+    {{/map.source}}
+  {{/if}}
 {{/if}}
 
 {{map.on 'click' (action 'handleClick')}}

--- a/app/templates/show-geography.hbs
+++ b/app/templates/show-geography.hbs
@@ -1,6 +1,6 @@
 <div class="cell large-6 xlarge-7 xxlarge-5 xxlarge-offset-1">
 
-{{!--
+{{!
   FAQ:
     `section.delegate-mutation` is a wrapper action to notify the "applied-filters"
     that an explicit change has happened
@@ -13,27 +13,27 @@
     mutateArray=(action 'mutateArray')
     appliedFilters=applied-filters
     as |filters|}}
-  {{/filter-mutators}}
+  {{!/filter-mutators}}
 
-  Filter-mutators yields a `filters.section` component which helps group together
+  {{! Filter-mutators yields a `filters.section` component which helps group together
   the actual filterable fieldnames. For example, some "filters" may actually be affecting
   multiple fields in the database. `filters.section` makes sure those get turned on when
   mutated.
 
   {{#filters.section
     filterNames=(array 'names' 'of' 'grouped' 'fields') as |section|}}
-  {{/filters.section}}
+  {{!/filters.section}}
 
-  this component is abstract because it has no markup - it only sets up some actions needed for
+  {{! this component is abstract because it has no markup - it only sets up some actions needed for
   mutating groups. It gets a `filter-wrapper` component and the `delegate-mutation` action.
 
   {{#section.filter-wrapper}}
-    This component invokes all the necessary markup for this to work
+    {{! This component invokes all the necessary markup for this to work
   {{/section.filter-wrapper}}
 
-  `delegate-mutation` is a wrapper action that should wrap all filter mutators. It is responsible for
+  {{!`delegate-mutation` is a wrapper action that should wrap all filter mutators. It is responsible for
   notifying the applied-filters query param that something should be added or removed.
- --}}
+ }}
 
   {{#filter-mutators
     mutateArray=(action 'mutateArray')

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "ember-resolver": "^5.0.1",
     "ember-router-scroll": "0.7.1",
     "ember-source": "~3.8.0",
+    "ember-test-selectors": "^2.1.0",
     "ember-truth-helpers": "2.0.0",
     "ember-welcome-page": "^3.2.0",
     "eslint": "^4.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4434,7 +4434,7 @@ ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0, ember-cli-ve
     resolve "^1.3.3"
     semver "^5.3.0"
 
-ember-cli-version-checker@^3.0.0, ember-cli-version-checker@^3.0.1:
+ember-cli-version-checker@^3.0.0, ember-cli-version-checker@^3.0.1, ember-cli-version-checker@^3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz#7c9b4f5ff30fdebcd480b1c06c4de43bb51c522c"
   dependencies:
@@ -4879,6 +4879,14 @@ ember-string-ishtmlsafe-polyfill@2.0.2:
   resolved "https://registry.yarnpkg.com/ember-string-ishtmlsafe-polyfill/-/ember-string-ishtmlsafe-polyfill-2.0.2.tgz#f7c1beb2fcb95599f499af41772477284b16ed74"
   dependencies:
     ember-cli-version-checker "^2.1.0"
+
+ember-test-selectors@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-2.1.0.tgz#faebdf06702aaa0bc510d55eb721ce54d2e85793"
+  integrity sha512-c5HmvefmeABH8hg380TSNZiE9VAK1CBeXWrgyXy+IXHtsew4lZHHw7GnqCAqsakxwvmaMARbAKY9KfSAE91s1g==
+  dependencies:
+    ember-cli-babel "^6.8.2"
+    ember-cli-version-checker "^3.1.2"
 
 ember-text-measurer@^0.4.0:
   version "0.4.1"


### PR DESCRIPTION
- make default for `distance_from_point` equal to an empty array `[]`
- make it so that filtering will not occur until user has created a point/selected a centroid, even if the filter is turned on. This is done by checking if `queryOptions.distance_from_point.length` is true (that the array is populated)
- in `filter-distance-from-point.hbs`, check if `pointGeometry` exists before displaying radius circle and zooming to point
- this PR also installs `ember-test-selectors` for better testing and updates some comments on `show-geography.hbs`

Closes #488 