### PR TITLE
190 map loading spinner

### DIFF
--- a/app/components/projects-map-data.js
+++ b/app/components/projects-map-data.js
@@ -4,6 +4,7 @@ import { action } from '@ember-decorators/object';
 import { inject as service } from '@ember-decorators/service';
 import { restartableTask } from 'ember-concurrency-decorators';
 import { timeout } from 'ember-concurrency';
+import Ember from 'ember';
 
 /**
   ProjectsMapComponent manages mapbox-gl-js specific configuration objects, tooltip hovering
@@ -56,6 +57,10 @@ export default class ProjectsMapComponent extends Component {
       yield timeout(500);
 
       this.set('tilesLoading', !map.areTilesLoaded());
+
+      // Required for Ember testing to know when it's done rendering
+      // See: http://ember-concurrency.com/docs/testing-debugging/
+      if (Ember.testing) return;
     }
   }
 
@@ -177,5 +182,7 @@ export default class ProjectsMapComponent extends Component {
   willDestroyElement() {
     this.resultMapEvents.off('hover', this, 'hoverPoint');
     this.resultMapEvents.off('unhover', this, 'unHoverPoint');
+
+    this.updateTileState.cancelAll();
   }
 }

--- a/app/styles/modules/_m-maps.scss
+++ b/app/styles/modules/_m-maps.scss
@@ -178,9 +178,9 @@
 
 .map-loading-spinner {
   position: absolute;
-  right: 10px;
-  bottom: 30px;
-  opacity: 0.5;
+  top: calc(50% - 0.5em);
+  left: calc(50% - 0.5em);
+  opacity: 0.3;
   z-index: 1;
   pointer-events: none;
 }

--- a/app/templates/components/projects-map-data.hbs
+++ b/app/templates/components/projects-map-data.hbs
@@ -16,6 +16,10 @@
     </div>
   {{/if}}
 
+  {{#if tilesLoading}}
+    {{fa-icon 'spinner' spin="true" size="5x" class="map-loading-spinner"}}
+  {{/if}}
+
   {{yield (merge
     map
     (hash

--- a/app/templates/show-geography.hbs
+++ b/app/templates/show-geography.hbs
@@ -71,8 +71,6 @@
 
         {{map-info-box}}
 
-        {{fa-icon 'spinner' spin="true" size="5x" class="map-loading-spinner"}}
-
         {{map.call 'fitBounds' bounds (hash padding=20)}}
       {{/structural/project-list-map}}
     {{/filters.section}}

--- a/app/templates/show-geography.hbs
+++ b/app/templates/show-geography.hbs
@@ -71,6 +71,8 @@
 
         {{map-info-box}}
 
+        {{fa-icon 'spinner' spin="true" size="5x" class="map-loading-spinner"}}
+
         {{map.call 'fitBounds' bounds (hash padding=20)}}
       {{/structural/project-list-map}}
     {{/filters.section}}

--- a/tests/helpers/mapbox-gl-stub.js
+++ b/tests/helpers/mapbox-gl-stub.js
@@ -18,6 +18,7 @@ const defaultMapboxEventStub = {
       sources: {},
       layers: {},
     }),
+    areTilesLoaded: () => true,
   },
 };
 


### PR DESCRIPTION
Closes #190 by having projects-map-data component contain state about whether tiles have loaded, and adding a spinnner.

Need feedback from @julialucyhogan on clarity, documentation, and @andycochran on functionality found in the deploy branch.
