### PR TITLE
List applied filters when there are no results

### DIFF
--- a/app/components/applied-filters-list.js
+++ b/app/components/applied-filters-list.js
@@ -1,0 +1,26 @@
+import Component from '@ember/component';
+import { computed } from '@ember-decorators/object';
+import { getLabelFor } from 'labs-zap-search/helpers/get-label-for';
+
+/**
+ * Component that takes an array, runs it through a service method
+ * for translations, and prints them on the page with a friendly msg.
+ */
+export default class AppliedFiltersListComponent extends Component {
+  /**
+   * Array of column names, will be passed through a translator
+   *
+   * @argument(Array)
+   */
+  appliedFilters;
+
+  /**
+   * Unique "humanized" filter names from the translations/en-us.yaml file.
+   */
+  @computed('appliedFilters')
+  get currentFiltersNames() {
+    return this.appliedFilters
+      .map(filterName => getLabelFor(`filters.${filterName}`))
+      .uniq();
+  }
+}

--- a/app/helpers/get-label-for.js
+++ b/app/helpers/get-label-for.js
@@ -1,0 +1,9 @@
+import { helper } from '@ember/component/helper';
+import { get } from '@ember/object';
+import config from 'labs-zap-search/config/environment';
+
+export function getLabelFor([path]) {
+  return get(config.labels, path);
+}
+
+export default helper(getLabelFor);

--- a/app/templates/components/applied-filters-list.hbs
+++ b/app/templates/components/applied-filters-list.hbs
@@ -1,0 +1,7 @@
+<div class="no-results-message text-center dark-gray">
+  <p class="medium-gray">{{fa-icon 'search' size='4x'}}</p>
+  <h4>No results. The following filters are applied, which may be too specific or contradictory:</h4>
+  {{#each currentFiltersNames as |name|}}
+    <p>{{name}}</p>
+  {{/each}}
+</div>

--- a/app/templates/show-geography.hbs
+++ b/app/templates/show-geography.hbs
@@ -99,7 +99,7 @@
         filterNames='project_applicant_text'
         as |section|}}
         {{#section.filter-wrapper
-          filterTitle='Text Match'
+          filterTitle=(get-label-for 'filters.project_applicant_text')
           tooltip="Enter an exact word or phrase that matches a project's name, description, applicant name, ULURP/CEQR number, or BBL."}}
            <input
             class="filter-text-input"
@@ -115,7 +115,7 @@
         filterNames=(array 'distance_from_point' 'radius_from_point')
         as |section|}}
         {{#section.filter-wrapper
-          filterTitle='DISTANCE FROM POINT'
+          filterTitle=(get-label-for 'filters.distance_from_point')
           tooltip='Click on the map to set filter first then drag to adjust radius'}}
           {{#if queryParamsState.distance_from_point.changed}}
             <div class="grid-x">
@@ -153,7 +153,7 @@
         filterNames='dcp_certifiedreferred'
         as |section|}}
         {{#section.filter-wrapper
-          filterTitle='Date Certified / Referred'
+          filterTitle=(get-label-for 'filters.dcp_certifiedreferred')
           tooltip='Move the handles along the date range slider to filter projects by the date they were certified / referred.'}}
           {{date-range-filter
             start=dcp_certifiedreferred
@@ -168,7 +168,7 @@
         filterNames=(array 'boroughs' 'block')
         as |section|}}
         {{#section.filter-wrapper
-          filterTitle='Borough / Block'
+          filterTitle=(get-label-for 'filters.boroughs')
           tooltip='Unless projects fall under the category of "Citywide", they will only exist within one borough. Selecting multiple boroughs will return projects that exist in any one of the selected options. Different boroughs may have the same block number, so filter by borough first before typing in a 4-digit block number in order to better locate your desired results.'}}
           <ul class="menu vertical medium-horizontal">
             {{#each (array 'Citywide' 'Manhattan' 'Bronx' 'Brooklyn' 'Queens' 'Staten Island') as |type|}}
@@ -197,7 +197,7 @@
         filterNames='community-districts'
         as |section|}}
         {{#section.filter-wrapper
-          filterTitle='Community District'
+          filterTitle=(get-label-for 'filters.community-districts')
           tooltip='Filter by Community District in each borough by either typing the Community District name (e.g. “Brooklyn 1”) or by selecting from the dropdown list. Multiple Community Districts can be selected.'}}
           {{#power-select-multiple
             options=(lookup-community-district)
@@ -220,7 +220,7 @@
         filterNames='dcp_publicstatus'
         as |section|}}
         {{#section.filter-wrapper
-          filterTitle='Project Stage'
+          filterTitle=(get-label-for 'filters.dcp_publicstatus')
           tooltip='These checkboxes filter projects by their stage in the application process. “Filed” refers to applications that have been submitted but have not yet started the public review process. “In Public Review” refers to applications that have graduated to the public review process. “Completed” refers to applications that have been Approved, Disapproved, Withdrawn or Terminated.'}}
           <ul class="menu vertical medium-horizontal stage-checkboxes">
             {{#each (array 'Filed' 'In Public Review' 'Completed' 'Unknown') as |type|}}
@@ -243,7 +243,7 @@
         filterNames='action-types'
         as |section|}}
         {{#section.filter-wrapper
-          filterTitle='Action Type'
+          filterTitle=(get-label-for 'filters.action-types')
           tooltip='Filter by action type by either typing the code/name of the action or by selecting from the dropdown list. Action type refers to city planning land use actions that accompany a project. There may be multiple land use actions attached to an application. Many action types have been retired and are listed for historical projects only. Searching by one action type should return all projects that include that action. Multiple action types can be selected.'}}
           {{#power-select-multiple
             options=(lookup-action-type)
@@ -270,7 +270,7 @@
         filterNames=(array 'dcp_femafloodzonea' 'dcp_femafloodzoneshadedx' 'dcp_femafloodzonecoastala' 'dcp_femafloodzonev')
         as |section|}}
         {{#section.filter-wrapper
-          filterTitle='FEMA Flood Zone'
+          filterTitle=(get-label-for 'filters.dcp_femafloodzonea')
           tooltip='Projects may be located within multiple flood zones. Selecting multiple checkboxes will return projects that are at least partially located withinin all of the selected zones.'}}
         <ul class="menu vertical medium-horizontal FEMA-checkbox">
           <li {{action section.delegate-mutation (action 'toggleBoolean' 'dcp_femafloodzonev')}}>
@@ -361,11 +361,9 @@
     </ul>
 
     {{#if (eq fetchData.lastSuccessful.value.meta.total 0)}}
-      <div class="no-results-message text-center dark-gray">
-        <p class="medium-gray">{{fa-icon 'search' size='4x'}}</p>
-        <h4>No matching projects</h4>
-        <p class="text-small">The enabled filters may be too specific or contradictory. Please change your search parameters.</p>
-      </div>
+      {{applied-filters-list
+        appliedFilters=applied-filters
+      }}
     {{else}}
       {{load-more-button
         page=page

--- a/config/environment.js
+++ b/config/environment.js
@@ -71,6 +71,26 @@ module.exports = function(environment) {
         },
       },
     ],
+
+    // people-friendly labels for query parameters and database
+    // column names
+    labels: {
+      filters: {
+        'action-types': 'Action Type',
+        block: 'Borough / Block',
+        boroughs: 'Borough / Block',
+        'community-districts': 'Community District',
+        dcp_certifiedreferred: 'Date Certified / Referred',
+        dcp_femafloodzonea: 'FEMA Flood Zone',
+        dcp_femafloodzonecoastala: 'FEMA Flood Zone',
+        dcp_femafloodzoneshadedx: 'FEMA Flood Zone',
+        dcp_femafloodzonev: 'FEMA Flood Zone',
+        dcp_publicstatus: 'Project Stage',
+        distance_from_point: 'Radius Filter',
+        project_applicant_text: 'Text Match',
+        radius_from_point: 'Radius Filter',
+      },
+    },
   };
 
   if (environment === 'development') {

--- a/tests/integration/components/applied-filters-list-test.js
+++ b/tests/integration/components/applied-filters-list-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | applied-filters-list', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{applied-filters-list appliedFilters=(array)}}`);
+
+    assert.ok(this.element);
+  });
+});

--- a/tests/integration/helpers/get-label-for-test.js
+++ b/tests/integration/helpers/get-label-for-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | get-label-for', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('inputValue', 'formats.block');
+
+    await render(hbs`{{get-label-for inputValue}}`);
+
+    assert.ok(this.element);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4883,7 +4883,6 @@ ember-string-ishtmlsafe-polyfill@2.0.2:
 ember-test-selectors@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-2.1.0.tgz#faebdf06702aaa0bc510d55eb721ce54d2e85793"
-  integrity sha512-c5HmvefmeABH8hg380TSNZiE9VAK1CBeXWrgyXy+IXHtsew4lZHHw7GnqCAqsakxwvmaMARbAKY9KfSAE91s1g==
   dependencies:
     ember-cli-babel "^6.8.2"
     ember-cli-version-checker "^3.1.2"
@@ -6681,7 +6680,6 @@ jquery-deferred@^0.3.0:
 jquery@^3.3.1:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.0.tgz#8de513fa0fa4b2c7d2e48a530e26f0596936efdf"
-  integrity sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ==
 
 js-base64@^2.1.8:
   version "2.5.1"


### PR DESCRIPTION
Use ember-intl to “translate” between column names and person-friendly titles, keeping such mappings in one place without overhauling the overall architecture of the show-geography controller.