### PR TITLE
478: Add test selectors to optimize filter tests

### DIFF
--- a/app/templates/components/filter-wrapper.hbs
+++ b/app/templates/components/filter-wrapper.hbs
@@ -1,4 +1,7 @@
-<div class="filter-header">
+<div
+  class="filter-header"
+  data-test-filter-section={{dasherizedFilterTitle}}
+>
   <div class="switch tiny float-left">
     <input class="switch-input" type="checkbox" checked={{if (contains filterNames appliedFilters) 'checked'}}>
     <label {{action mutateWithAction}} class="switch-paddle">
@@ -12,6 +15,7 @@
   </h6>
 </div>
 
-<div class="filter-controls">
+<div class="filter-controls"
+ data-test-filter-control={{dasherizedFilterTitle}}>
   {{yield}}
 </div>

--- a/app/templates/show-geography.hbs
+++ b/app/templates/show-geography.hbs
@@ -172,7 +172,9 @@
           tooltip='Unless projects fall under the category of "Citywide", they will only exist within one borough. Selecting multiple boroughs will return projects that exist in any one of the selected options. Different boroughs may have the same block number, so filter by borough first before typing in a 4-digit block number in order to better locate your desired results.'}}
           <ul class="menu vertical medium-horizontal">
             {{#each (array 'Citywide' 'Manhattan' 'Bronx' 'Brooklyn' 'Queens' 'Staten Island') as |type|}}
-              <li {{action section.delegate-mutation (action 'mutateArray' 'boroughs' type)}}>
+              <li {{action section.delegate-mutation (action 'mutateArray' 'boroughs' type)}}
+              data-test-borough-checkbox={{type}}
+              >
                 <a>
                   {{filter-checkbox
                     value=type
@@ -200,6 +202,7 @@
           filterTitle='Community District'
           tooltip='Filter by Community District in each borough by either typing the Community District name (e.g. “Brooklyn 1”) or by selecting from the dropdown list. Multiple Community Districts can be selected.'}}
           {{#power-select-multiple
+            triggerClass="community-district-dropdown-selection"
             options=(lookup-community-district)
             selected=(contains-keys
               (lookup-community-district)
@@ -224,7 +227,9 @@
           tooltip='These checkboxes filter projects by their stage in the application process. “Filed” refers to applications that have been submitted but have not yet started the public review process. “In Public Review” refers to applications that have graduated to the public review process. “Completed” refers to applications that have been Approved, Disapproved, Withdrawn or Terminated.'}}
           <ul class="menu vertical medium-horizontal stage-checkboxes">
             {{#each (array 'Filed' 'In Public Review' 'Completed' 'Unknown') as |type|}}
-              <li {{action section.delegate-mutation (action 'mutateArray' 'dcp_publicstatus' type)}}>
+              <li {{action section.delegate-mutation (action 'mutateArray' 'dcp_publicstatus' type)}}
+                data-test-status-checkbox={{type}}
+              >
                 <a>
                   {{filter-checkbox
                     value=type
@@ -273,7 +278,8 @@
           filterTitle='FEMA Flood Zone'
           tooltip='Projects may be located within multiple flood zones. Selecting multiple checkboxes will return projects that are at least partially located withinin all of the selected zones.'}}
         <ul class="menu vertical medium-horizontal FEMA-checkbox">
-          <li {{action section.delegate-mutation (action 'toggleBoolean' 'dcp_femafloodzonev')}}>
+          <li {{action section.delegate-mutation (action 'toggleBoolean' 'dcp_femafloodzonev')}}
+          data-test-flood-v-checkbox>
             {{#filters/named-checkbox
               mainProperty=dcp_femafloodzonev
               label='V'}}

--- a/tests/acceptance/filter-checkbox-test.js
+++ b/tests/acceptance/filter-checkbox-test.js
@@ -8,6 +8,7 @@ import {
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { selectChoose } from 'ember-power-select/test-support';
 
 module('Acceptance | filter checkbox', function(hooks) {
   setupApplicationTest(hooks);
@@ -16,7 +17,7 @@ module('Acceptance | filter checkbox', function(hooks) {
   test('User clicks first project status and it filters', async function(assert) {
     server.createList('project', 20);
     await visit('/');
-    await click('.stage-checkboxes li:first-child a');
+    await click('[data-test-status-checkbox="Filed"]');
 
     assert.equal(currentURL().includes('Filed'), true);
   });
@@ -24,7 +25,7 @@ module('Acceptance | filter checkbox', function(hooks) {
   test('User clicks first FEMA Flood Zone status and it filters', async function(assert) {
     server.createList('project', 20);
     await visit('/');
-    await click('.FEMA-checkbox li:first-child a');
+    await click('[data-test-flood-v-checkbox]');
 
     assert.equal(currentURL().includes('dcp_femafloodzonev=true'), true);
   });
@@ -32,17 +33,17 @@ module('Acceptance | filter checkbox', function(hooks) {
   test('User clicks community district box, fills in community district name, selects CD', async function(assert) {
     server.createList('project', 20);
     await visit('/');
-    await click('.filter-section-community-district .ember-power-select-multiple-options');
-    await fillIn('.filter-section-community-district .ember-power-select-multiple-options input', 'Brooklyn 1');
-    await click('.ember-power-select-options li:first-child');
+    await click('[data-test-filter-control="filter-section-community-district"] .ember-power-select-multiple-options');
+    await fillIn('[data-test-filter-control="filter-section-community-district"] .ember-power-select-multiple-options input', 'Brooklyn');
+    await selectChoose('.community-district-dropdown-selection', 'Brooklyn 2');
 
-    assert.equal(currentURL(), '/projects?applied-filters=community-districts%2Cdcp_certifiedreferred&community-districts=BK01');
+    assert.equal(currentURL(), '/projects?applied-filters=community-districts%2Cdcp_certifiedreferred&community-districts=BK02');
   });
 
   skip('Page reloads (pagination reset) when click new filter', async function(assert) {
     server.createList('project', 20);
     await visit('/projects');
-    await click('.stage-checkboxes li:first-child a');
+    await click('[data-test-status-checkbox="Filed"]');
 
     assert.equal(currentURL(), '/projects');
   });
@@ -50,35 +51,34 @@ module('Acceptance | filter checkbox', function(hooks) {
   test('Reset filters button works', async function(assert) {
     server.createList('project', 20);
     await visit('/projects');
-    await click('.filter-section-community-district .ember-power-select-multiple-options');
-    await fillIn('.filter-section-community-district .ember-power-select-multiple-options input', 'Brooklyn 1');
-    await click('.ember-power-select-options li:first-child');
+    await click('[data-test-filter-control="filter-section-community-district"] .ember-power-select-multiple-options');
+    await fillIn('[data-test-filter-control="filter-section-community-district"] .ember-power-select-multiple-options input', 'Brooklyn 3');
+    await selectChoose('.community-district-dropdown-selection', 'Brooklyn 3');
     await click('.projects-reset-filters-button');
 
     assert.equal(currentURL(), '/projects');
   });
 
-  // Commenting these out until we implement a better named IDs for testing for each of the filters
-  // test('Landing on QP default leads to cleaned URL', async function(assert) {
-  //   server.createList('project', 20);
-  //   await visit('/projects');
-  //   await click('.stage-checkboxes li:nth-child(1)');
-  //   await click('.stage-checkboxes li:nth-child(2)');
-  //   await click('.stage-checkboxes li:nth-child(3)');
-  //   await click('.stage-checkboxes li:nth-child(3)');
-  //   await click('.stage-checkboxes li:nth-child(2)');
-  //   await click('.stage-checkboxes li:nth-child(1)');
+  test('Landing on QP default leads to cleaned URL', async function(assert) {
+    server.createList('project', 20);
+    await visit('/projects');
+    await click('[data-test-status-checkbox="Filed"]');
+    await click('[data-test-status-checkbox="In Public Review"]');
+    await click('[data-test-status-checkbox="Completed"]');
+    await click('[data-test-status-checkbox="Completed"]');
+    await click('[data-test-status-checkbox="In Public Review"]');
+    await click('[data-test-status-checkbox="Filed"]');
 
-  //   assert.equal(currentURL(), '/projects');
-  // });
+    assert.equal(currentURL(), '/projects?applied-filters=dcp_certifiedreferred%2Cdcp_publicstatus');
+  });
 
   test('User can click on filter switches with updated state', async function(assert) {
     server.createList('project', 20);
     await visit('/projects');
-    await click('.filter-section-fema-flood-zone .switch-paddle');
+    await click('[data-test-filter-section="filter-section-fema-flood-zone"] .switch-paddle');
 
     assert.equal(currentURL(), '/projects?applied-filters=dcp_certifiedreferred%2Cdcp_femafloodzonea%2Cdcp_femafloodzonecoastala%2Cdcp_femafloodzoneshadedx%2Cdcp_femafloodzonev');
-    await click('.filter-section-fema-flood-zone .switch-paddle');
+    await click('[data-test-filter-section="filter-section-fema-flood-zone"] .switch-paddle');
 
     assert.equal(currentURL(), '/projects');
   });
@@ -87,23 +87,24 @@ module('Acceptance | filter checkbox', function(hooks) {
     server.createList('project', 20);
 
     await visit('/projects');
-    await find('.filter-section-text-match.inactive');
-    await fillIn('.filter-section-text-match .filter-text-input', 'peanut butter');
-    await find('.filter-section-text-match.active');
+    await find('[data-test-filter-control="filter-section-text-match"].inactive');
+    await fillIn('[data-test-filter-control="filter-section-text-match"] .filter-text-input', 'peanut butter');
+    await find('[data-test-filter-control="filter-section-text-match"].active');
 
     assert.equal(currentURL().includes('project_applicant_text'), true);
     assert.equal(currentURL().includes('applied-filters'), true);
 
-    await find('.filter-section-borough-\\/-block.inactive');
-    await click('.filter-section-borough-\\/-block li:nth-child(1)');
-    await click('.filter-section-borough-\\/-block li:nth-child(2)');
-    await click('.filter-section-borough-\\/-block li:nth-child(3)');
-    await find('.filter-section-borough-\\/-block.active');
+    await find('[data-test-filter-control="filter-section-borough-/-block"].inactive');
+    await click('[data-test-borough-checkbox="Citywide"]');
+    await click('[data-test-borough-checkbox="Manhattan"]');
+    await click('[data-test-borough-checkbox="Bronx"]');
+    await find('[data-test-filter-control="filter-section-borough-/-block"].active');
 
     assert.equal(currentURL().includes('boroughs=Bronx%2CCitywide%2CManhattan'), true);
 
-    await click('.filter-section-fema-flood-zone .FEMA-checkbox li:first-child a');
-    await find('.filter-section-fema-flood-zone.active');
+    await find('[data-test-filter-control="filter-section-fema-flood-zone"].inactive');
+    await click('[data-test-flood-v-checkbox]');
+    await find('[data-test-filter-control="filter-section-fema-flood-zone"].active');
     assert.equal(currentURL().includes('dcp_femafloodzonev=true'), true);
   });
 });


### PR DESCRIPTION
Add in `ember-test-selectors` so that we can optimize `filter-checkbox-test` and remove the need to select by `li: first-child`

**I also noticed that we had a lot of empty integration tests, I can jump on those if we think it's necessary**

Closes #478 