### PR TITLE
Upgrade nouislider; remove date “round” to nearest year

### DIFF
--- a/app/components/date-range-filter.js
+++ b/app/components/date-range-filter.js
@@ -53,15 +53,25 @@ export default class SliderFilterComponent extends Component {
   replaceProperty = () => {}
 
   /**
-   * Passed to {{range-slider}}; triggered when {{range-slider}} mutates some data
+   * Callback that gets passed to {{range-slider}}; triggered when {{range-slider}}
+   * mutates some data. It receives numerics from range-slider, they are sometimes
+   * not rounded. This callback performs some cleaning by rounding the values into
+   * integers and "rounding" the epoch timestamps to be inclusive of the full year
+   * they intersect with.
+   *
+   * For example, if the toggle lands on march of 2016, this will round to the very
+   * beginning of 2016.
    * @private
    */
   @action
   sliderChanged([min, max]) {
-    // because the slider returns unix epochs based on its own step increment,
-    // get the startOf() the min timestamp's year, and the endOf() of the max timestamp's year
-    const minStart = parseInt(moment(min, 'X').utc().startOf('year').format('X'), 10);
-    const maxEnd = parseInt(moment(max, 'X').utc().endOf('year').format('X'), 10);
+    // must round integers because range slider sometimes provides
+    // decimal values in the callback
+    const roundedMin = Math.round(min);
+    const roundedMax = Math.round(max);
+
+    const minStart = parseInt(moment(roundedMin, 'X').utc().startOf('year').format('X'), 10) + 1;
+    const maxEnd = parseInt(moment(roundedMax, 'X').utc().endOf('year').format('X'), 10);
 
     this.replaceProperty([minStart, maxEnd]);
   }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ember-cli-mirage": "0.4.15",
     "ember-cli-moment-shim": "^3.7.1",
     "ember-cli-netlify": "^0.1.0",
-    "ember-cli-nouislider": "1.0.0",
+    "ember-cli-nouislider": "1.1.0",
     "ember-cli-sass": "^7.1.7",
     "ember-cli-showdown": "4.4.4",
     "ember-cli-sri": "^2.1.1",
@@ -95,6 +95,7 @@
     "ember-concurrency-decorators": "0.6.0",
     "foundation-sites": "^6.3.1",
     "labs-ember-search": "3.1.0",
+    "nouislider": "13.1.5",
     "numeral": "^2.0.6",
     "qs": "^6.1.0",
     "underscore": "^1.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4315,9 +4315,9 @@ ember-cli-normalize-entity-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-nouislider@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-nouislider/-/ember-cli-nouislider-1.0.0.tgz#193d4293ad0603fbd83854e87d6b8a3bd65e16f1"
+ember-cli-nouislider@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-nouislider/-/ember-cli-nouislider-1.1.0.tgz#835d814433d9e2a1aa674b463ee296cd7723d42f"
   dependencies:
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^2.0.0"
@@ -4883,7 +4883,6 @@ ember-string-ishtmlsafe-polyfill@2.0.2:
 ember-test-selectors@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-test-selectors/-/ember-test-selectors-2.1.0.tgz#faebdf06702aaa0bc510d55eb721ce54d2e85793"
-  integrity sha512-c5HmvefmeABH8hg380TSNZiE9VAK1CBeXWrgyXy+IXHtsew4lZHHw7GnqCAqsakxwvmaMARbAKY9KfSAE91s1g==
   dependencies:
     ember-cli-babel "^6.8.2"
     ember-cli-version-checker "^3.1.2"
@@ -6681,7 +6680,6 @@ jquery-deferred@^0.3.0:
 jquery@^3.3.1:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.0.tgz#8de513fa0fa4b2c7d2e48a530e26f0596936efdf"
-  integrity sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ==
 
 js-base64@^2.1.8:
   version "2.5.1"
@@ -7963,6 +7961,10 @@ normalize-url@2.0.1:
     prepend-http "^2.0.0"
     query-string "^5.0.1"
     sort-keys "^2.0.0"
+
+nouislider@13.1.5:
+  version "13.1.5"
+  resolved "https://registry.yarnpkg.com/nouislider/-/nouislider-13.1.5.tgz#3a0f3004159b9a77ebc07c3bedc26c97327d3522"
 
 nouislider@^11.0.3:
   version "11.1.0"


### PR DESCRIPTION
Previously, the date-ranger-filter was rounding epoch time back to the _end_ of the previous year instead of the very beginning of the input yet. It's unclear why but it was off by one.

The fix was to add this offset into the commit.

Closes #360