### PR TITLE
513: add CEQR number tag to project list

### DIFF
--- a/app/templates/components/project-list-item.hbs
+++ b/app/templates/components/project-list-item.hbs
@@ -35,6 +35,10 @@
       {{#each project.ulurpnumbers as |ulurpnumber|}}
         <span class="label light-gray"><strong class="dark-gray">{{ulurpnumber}}</strong></span>
       {{/each}}
+
+      {{#unless (and (or (eq project.dcp_ceqrtype 'Unlisted') (eq project.dcp_ceqrtype null)) (eq project.dcp_ceqrnumber null))}}
+        <span class="label light-gray"><strong class="dark-gray">CEQR {{project.dcp_ceqrnumber}} {{unless (eq project.dcp_ceqrtype 'Unlisted') project.dcp_ceqrtype}}</strong></span>
+      {{/unless}}
     </p>
   </div>
 </li>


### PR DESCRIPTION
- Add `dcp_ceqrnumber` and `dcp_ceqrtype` as a single tag to projects list. 
- If both `dcp_ceqrtype` and `dcp_ceqrnumber` are NULL, the tag does not show up. 
- If `dcp_ceqrtype` is "Unlisted" and `dcp_ceqrnumber` is NULL, the tag does not show up. 
- Some projects have an associated CEQR type but no associated number, and vice versa. In this case, the tag still shows up, but only the available info is shown. 

Closes #513