### PR TITLE
515: re-add ulurp/nonulurp filter

### DIFF
--- a/app/controllers/query-parameters/show-geography.js
+++ b/app/controllers/query-parameters/show-geography.js
@@ -129,13 +129,19 @@ export const projectParams = new QueryParams({
     defaultValue: '',
     refresh: true,
   },
-  ulurp_ceqr_text: {
-    defaultValue: '',
-    refresh: true,
-  },
   block: {
     defaultValue: '',
     refresh: true,
+  },
+  dcp_ulurp_nonulurp: {
+    defaultValue: [],
+    refresh: true,
+    serialize(value) {
+      return value.toString();
+    },
+    deserialize(value = '') {
+      return value.split(',');
+    },
   },
 });
 

--- a/app/templates/show-geography.hbs
+++ b/app/templates/show-geography.hbs
@@ -331,6 +331,36 @@
         </ul>
         {{/section.filter-wrapper}}
       {{/filters.section}}
+
+      {{!-- FILTER: ULURP TYPE --}}
+      {{#filters.section
+        filterNames='dcp_ulurp_nonulurp'
+        as |section|}}
+        {{#section.filter-wrapper
+          filterTitle='ULURP Type'
+          tooltip='Applications can either follow the Uniform Land Use Review Procedure (ULURP) or are designated as Non-ULURP, and are therefore not restricted to ULURP rules and timing.'}}
+          <ul class="menu vertical medium-horizontal ULURP-checkbox">
+            <li {{action section.delegate-mutation (action 'mutateArray' 'dcp_ulurp_nonulurp' 'ULURP')}}
+              data-test-ulurp-checkbox
+            >
+              <a>
+                {{filter-checkbox
+                  value='ULURP'
+                  currentValues=dcp_ulurp_nonulurp}}
+              </a>
+            </li>
+            <li {{action section.delegate-mutation (action 'mutateArray' 'dcp_ulurp_nonulurp' 'Non-ULURP')}}
+              data-test-nonulurp-checkbox
+            >
+              <a>
+                {{filter-checkbox
+                  value='Non-ULURP'
+                  currentValues=dcp_ulurp_nonulurp}}
+              </a>
+            </li>
+          </ul>
+        {{/section.filter-wrapper}}
+      {{/filters.section}}
     </div>
 
   {{/filter-mutators}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -86,6 +86,7 @@ module.exports = function(environment) {
         dcp_femafloodzoneshadedx: 'FEMA Flood Zone',
         dcp_femafloodzonev: 'FEMA Flood Zone',
         dcp_publicstatus: 'Project Stage',
+        dcp_ulurp_nonulurp: 'ULURP Type',
         distance_from_point: 'Radius Filter',
         project_applicant_text: 'Text Match',
         radius_from_point: 'Radius Filter',

--- a/tests/acceptance/filter-checkbox-test.js
+++ b/tests/acceptance/filter-checkbox-test.js
@@ -14,7 +14,7 @@ module('Acceptance | filter checkbox', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('User clicks first project status and it filters', async function(assert) {
+  test('User clicks Filed project status and it filters', async function(assert) {
     server.createList('project', 20);
     await visit('/');
     await click('[data-test-status-checkbox="Filed"]');
@@ -38,6 +38,14 @@ module('Acceptance | filter checkbox', function(hooks) {
     await selectChoose('.community-district-dropdown-selection', 'Brooklyn 2');
 
     assert.equal(currentURL(), '/projects?applied-filters=community-districts%2Cdcp_certifiedreferred&community-districts=BK02');
+  });
+
+  test('User clicks ULURP checkbox and it filters', async function(assert) {
+    server.createList('project', 20);
+    await visit('/');
+    await click('[data-test-nonulurp-checkbox]');
+
+    assert.equal(currentURL().includes('dcp_ulurp_nonulurp=Non-ULURP'), true);
   });
 
   skip('Page reloads (pagination reset) when click new filter', async function(assert) {


### PR DESCRIPTION
ULURP/Non-ULURP filter was removed during filter refactor. After users mentioned that they wanted it back, we are reinstating this filter. 

This is waiting on PR [#123](https://github.com/NYCPlanning/labs-zap-api/pull/123) in zap-api

Closes #515 