### PR TITLE
520: Update CPC Report build-url to include condition with version letters

### DIFF
--- a/app/helpers/build-url.js
+++ b/app/helpers/build-url.js
@@ -39,8 +39,15 @@ function bisweb(bbl) {
 }
 
 function cpcReport(ulurp) {
-  const ulurpNumber = ulurp.match(/\d+/g)[0]; // pull 100149 from C100149ZSM to make a cpc report URL
-  return `http://www1.nyc.gov/assets/planning/download/pdf/about/cpc/${ulurpNumber}.pdf`;
+  // for ulurp numbers that have a letter at the end of the 6 numbers to represent the version (ex. the "A" in C18005AZMX)
+  // pull 6 numbers AND next character after the last number
+  const ulurpNumberWithLetter = (ulurp.match(/(\d+)./g)[0]).toLowerCase();
+  const ulurpNumberWithoutLetter = ulurp.match(/\d+/g)[0]; // pull 100149 from C100149ZSM
+
+  // the ulurp numbers with that extra letter have overall 11 characters compared to the usual 10
+  if (ulurp.length > 10) {
+    return `http://www1.nyc.gov/assets/planning/download/pdf/about/cpc/${ulurpNumberWithLetter}.pdf`;
+  } return `http://www1.nyc.gov/assets/planning/download/pdf/about/cpc/${ulurpNumberWithoutLetter}.pdf`;
 }
 
 function acris(bbl) {


### PR DESCRIPTION
Some ulurp numbers include a letter after the 6 numerical characters:

Ex. `C170305MMX` (10 characters) vs. `C180051AZMX` (11 characters)

Before, the regex that built the CPC report link did not take into account the condition of this letter appearing at the end of these 6 digits, which meant that certain links were not pointing to the correct URL. 

This PR updates the `build-url.js` CPC report URL to reflect two different conditions based on the length of the ULURP number. If the ulurp number has 10 characters, the regex pulls the 6 numerical characters. If the ulurp number has more than 10 characters, the regex pulls the 6 numerical characters AND the character right after the last digit. 

Closes #520 