### PR TITLE
521: update logic for displaying BBLs on map on project view

### DIFF
--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -154,7 +154,7 @@
 
       </div>
       <div class="cell large-5">
-        {{#if model.bbl_featurecollection}}
+        {{#if model.bbls}}
           {{#mapbox-gl
               id='project-map'
               initOptions=(hash


### PR DESCRIPTION
I think there might have been a data format change which caused a problem for the original logic that we were using to display BBLs on a project map vs. display "No Map Available". Our original logic was `#if model.bbl_featurecollection` in `show-project.hbs`. 

This PR changes `model.bbl_featurecollection` to `model.bbls` to check for array of BBLs. 

Closes #521 

