### PR TITLE
526: No Map Available should show up if project does not have bbl geometries

### DIFF
--- a/app/controllers/show-project.js
+++ b/app/controllers/show-project.js
@@ -61,6 +61,12 @@ export default class ShowProjectController extends Controller {
     });
   }
 
+  @computed('model.bbl_featurecollection')
+  get hasBBLFeatureCollectionGeometry() {
+    return this.model.bbl_featurecollection.features.length
+    && this.model.bbl_featurecollection.features[0].geometry;
+  }
+
   @action
   handleMapLoad(map) { // eslint-disable-line
     window.map = map;

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -4,6 +4,17 @@ import { computed } from '@ember-decorators/object';
 
 const { Model } = DS;
 
+const EmptyFeatureCollection = {
+  type: 'FeatureCollection',
+  features: [{
+    type: 'Feature',
+    geometry: null,
+    properties: {
+      isEmptyDefault: true,
+    },
+  }],
+};
+
 export default class ProjectModel extends Model {
   @attr() applicantteam;
 
@@ -75,7 +86,8 @@ export default class ProjectModel extends Model {
 
   @attr() bbls;
 
-  @attr() bbl_featurecollection;
+  @attr({ defaultValue: () => EmptyFeatureCollection })
+  bbl_featurecollection
 
   @attr() milestones;
 

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -154,7 +154,7 @@
 
       </div>
       <div class="cell large-5">
-        {{#if model.bbls}}
+        {{#if hasBBLFeatureCollectionGeometry}}
           {{#mapbox-gl
               id='project-map'
               initOptions=(hash

--- a/tests/unit/controllers/show-project-test.js
+++ b/tests/unit/controllers/show-project-test.js
@@ -1,10 +1,11 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 
 module('Unit | Controller | show-project', function(hooks) {
   setupTest(hooks);
+  setupMirage(hooks);
 
-  // Replace this with your real tests.
   test('it runs handleMapLoad', function(assert) {
     const controller = this.owner.lookup('controller:show-project');
     assert.ok(controller);
@@ -26,5 +27,44 @@ module('Unit | Controller | show-project', function(hooks) {
       addControl() {},
       fitBounds() {},
     });
+  });
+
+  test('hasBBLFeatureCollectionGeometry is null when geometry is null', async function(assert) {
+    const controller = this.owner.lookup('controller:show-project');
+    assert.ok(controller);
+
+    const project = server.create('project', {
+      bbl_featurecollection: {
+        features: [{
+          type: 'Feature',
+          geometry: null,
+        }],
+      },
+    });
+    const projectModel = await this.owner.lookup('service:store').findRecord('project', project.id);
+
+    controller.model = projectModel;
+
+    const hasNoGeometry = controller.hasBBLFeatureCollectionGeometry;
+
+    assert.equal(hasNoGeometry, null);
+  });
+
+  test('hasBBLFeatureCollectionGeometry is 0 when features is empty', async function(assert) {
+    const controller = this.owner.lookup('controller:show-project');
+    assert.ok(controller);
+
+    const project = server.create('project', {
+      bbl_featurecollection: {
+        features: [],
+      },
+    });
+    const projectModel = await this.owner.lookup('service:store').findRecord('project', project.id);
+
+    controller.model = projectModel;
+
+    const hasEmptyFeatures = controller.hasBBLFeatureCollectionGeometry;
+
+    assert.equal(hasEmptyFeatures, 0);
   });
 });


### PR DESCRIPTION
I originally assumed when fixing this bug that all projects with a list of BBLs would have associated geometry, but some projects might have a list of BBLs but do NOT have associated BBL geometry (for example, older projects).

Currently, "No Map Available" is based on whether a project has a list of bbls `model.bbls` rather than if a project has bbl geometries `this.model.bbl_featurecollection.features[0].geometry`. This PR just edits it to check for geometry AND to check if a feature collection exists at all `this.model.bbl_featurecollection.features.length`, instead of checking for a list.

This PR also adds a default value to the `bbl_featurecollection` attribute in the projects model. 

Closes #526 