### PR TITLE
548: create models and mirage for LUPP refactor

### DIFF
--- a/app/models/action.js
+++ b/app/models/action.js
@@ -1,0 +1,42 @@
+import DS from 'ember-data';
+import { attr, hasMany, belongsTo } from '@ember-decorators/data';
+
+const { Model } = DS;
+
+export default class ActionModel extends Model {
+// DB table: dcp_projectaction
+
+  // One Project has Many Actions
+  @belongsTo('project') project;
+
+  // Many Actions to Many Recommendations
+  // Participants can submit ONE recommendation per action or ONE recommendation for all actions in a project
+  @hasMany('recommendation') recommendations;
+
+  // id sourced from dcp_action, unique action IDs--e.g. '566ede3a-dad0-e711-8125-1458d04e2f18'
+  @attr('string') actionId;
+
+  // Name of action e.g. "Zoning Text Amendment"
+  // sourced from dcp_name --> SUBSTRING(a.dcp_name FROM '-{1}\s*(.*)')
+  @attr('string') actionName;
+
+  // Action Code e.g. "ZR"
+  // sourced from dcp_name --> SUBSTRING(a.dcp_name FROM '^(\w+)')
+  @attr('string') actionCode;
+
+  // sourced from dcp_name-- e.g. 'ZR - Zoning Text Amendment'
+  // STRING_AGG(DISTINCT SUBSTRING(actions.dcp_name FROM '^(\\w+)'), ';') AS actiontypes
+  // list of action types separated by semicolon for dropdown selection
+  @attr('string') actionType;
+
+  // sourced from statuscode
+  // e.g. "Active", "Approved", "Certified", "Referred", "Terminated", "Withdrawn"
+  @attr('string ') status;
+
+  // sourced from statecode
+  // "Active" vs. "Inactive" projects
+  @attr('string') isActive;
+
+  // sourced from dcp_ulurpnumber
+  @attr('string') ulurpNumber;
+}

--- a/app/models/hearing.js
+++ b/app/models/hearing.js
@@ -1,0 +1,25 @@
+import DS from 'ember-data';
+import { attr, belongsTo } from '@ember-decorators/data';
+import { computed } from '@ember-decorators/object';
+
+const { Model } = DS;
+
+export default class HearingModel extends Model {
+// DB Table: dcp_communityboarddisposition
+
+  // One Hearing to One Project
+  @belongsTo('project') project;
+
+  // sourced from dcp_publichearinglocation
+  @attr('string', { defaultValue: '' }) location;
+
+  // sourced from dcp_dateofpublichearing
+  @attr('date') date;
+
+  @computed('date')
+  get isScheduled() {
+    const date = this.get('date');
+    const isScheduled = !!date;
+    return isScheduled;
+  }
+}

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -1,5 +1,5 @@
 import DS from 'ember-data';
-import { attr } from '@ember-decorators/data';
+import { attr, hasMany, belongsTo } from '@ember-decorators/data';
 import { computed } from '@ember-decorators/object';
 
 const { Model } = DS;
@@ -16,33 +16,34 @@ const EmptyFeatureCollection = {
 };
 
 export default class ProjectModel extends Model {
+  // Many Users to Many Projects
+  @hasMany('user') users;
+
+  // Many Actions to One Project
+  @hasMany('action') actions;
+
+  // ONE Project Has Many User Project Participant Types
+  @hasMany('userProjectParticipantType') userProjectParticipantTypes;
+
+  // One Project to One Hearing
+  @belongsTo('hearing') hearing;
+
   @attr() applicantteam;
 
   // array of applicant objects
   @attr() applicants;
 
-  // semicolon delimited applicant names
-  @attr('string') dcp_projectid;
-
   @attr('string') dcp_name;
-
-  @attr('string') dcp_alterationmapnumber;
 
   @attr() dcp_applicanttype;
 
   @attr() dcp_borough;
-
-  @attr('string') dcp_bsanumber;
 
   @attr('string') dcp_ceqrnumber;
 
   @attr() dcp_ceqrtype;
 
   @attr('string') dcp_certifiedreferred;
-
-  @attr('string') dcp_decpermitnumber;
-
-  @attr() dcp_easeis;
 
   @attr('boolean') dcp_femafloodzonea;
 
@@ -52,14 +53,6 @@ export default class ProjectModel extends Model {
 
   @attr('boolean') dcp_femafloodzonev;
 
-  @attr() dcp_leaddivision;
-
-  @attr('string') dcp_lpcnumber;
-
-  @attr('string') dcp_nydospermitnumber;
-
-  @attr('boolean') dcp_previousactiononsite;
-
   @attr('string') dcp_projectbrief;
 
   @attr('string') dcp_projectname;
@@ -68,13 +61,7 @@ export default class ProjectModel extends Model {
 
   @attr() dcp_hiddenprojectmetrictarget;
 
-  @attr('boolean') dcp_sischoolseat;
-
-  @attr('boolean') dcp_sisubdivision;
-
   @attr('string') dcp_ulurp_nonulurp;
-
-  @attr('string') dcp_wrpnumber;
 
   @attr() dcp_communitydistrict;
 
@@ -90,8 +77,6 @@ export default class ProjectModel extends Model {
   bbl_featurecollection
 
   @attr() milestones;
-
-  @attr() actions;
 
   @attr() addresses;
 

--- a/app/models/recommendation.js
+++ b/app/models/recommendation.js
@@ -1,0 +1,46 @@
+import DS from 'ember-data';
+import { attr, hasMany } from '@ember-decorators/data';
+
+const { Model } = DS;
+
+export default class RecommendationModel extends Model {
+// DB table: dcp_communityboarddisposition
+
+  // Many Actions to Many Recommendations
+  // Participants can submit ONE recommendation per action or ONE recommendation for all actions in a project
+  @hasMany('action') actions;
+
+  // Not needed
+  // @attr('string', { defaultValue: '' }) formCompleterName;
+
+  // Not needed
+  // @attr('string', { defaultValue: '' }) formCompleterTitle;
+
+  // #### Recommendation Type per Each of the 3 Participants ####
+  // sourced from dcp_boroughpresidentrecommendation
+  // e.g. 'Favorable', 'Conditional Favorable', 'Unfavorable', 'Conditional Unfavorable',
+  // 'Received after Clock Expired', 'No Objection', 'Waiver of Recommendation', N/A is defualt
+
+  // sourced from dcp_boroughboardrecommendation
+  // e.g. 'Favorable', 'Unfavorable', 'Waiver of Recommendation', 'Non-Complying', N/A as default
+
+  // sourced from dcp_communityboardrecommendation
+  // 'Approved', 'Approved with Modifications/Conditions', 'Disapproved', 'Disapproved with Modifications/Conditions',
+  // 'Non-Complying', 'Vote Quorum Not Present', 'Received after Clock Expired', 'No Objection', 'Waiver of Recommendation',
+  // N/A as default
+
+  @attr('string', { defaultValue: '' }) recommendation;
+
+  // sourced from dcp_consideration
+  // memo, exta information from participant
+  @attr('string', { defaultValue: '' }) consideration;
+
+  // sourced from dcp_votelocation
+  @attr('string', { defaultValue: '' }) voteLocation;
+
+  // calculate this upon form submission
+  @attr('date') dateReceived;
+
+  // source from dcp_dateofvote
+  @attr('date') dateVoted;
+}

--- a/app/models/recommendation/borough-board.js
+++ b/app/models/recommendation/borough-board.js
@@ -1,0 +1,7 @@
+import CommunityBoardModel from './community-board';
+
+export default class RecommendationBoroughBoardModel extends CommunityBoardModel {
+// extension of CommunityBoardModel with no changes
+// CommunityBoardModel is an extension of RecommendationModel with added attributes
+
+}

--- a/app/models/recommendation/borough-president.js
+++ b/app/models/recommendation/borough-president.js
@@ -1,0 +1,6 @@
+import RecommendationModel from '../recommendation';
+
+export default class RecommendationBoroughPresidentModel extends RecommendationModel {
+// extension of RecommendationModel
+
+}

--- a/app/models/recommendation/community-board.js
+++ b/app/models/recommendation/community-board.js
@@ -1,0 +1,21 @@
+import { attr } from '@ember-decorators/data';
+import RecommendationModel from '../recommendation';
+
+export default class RecommendationCommunityBoardModel extends RecommendationModel {
+// extension of RecommendationModel with added attributes
+
+  // sourced from dcp_votinginfavorrecommendation
+  @attr('number') votesInFavor;
+
+  // sourced from dcp_votingagainstrecommendation
+  @attr('number') votesAgainst;
+
+  // sourced from dcp_votingabstainingonrecommendation
+  @attr('number') votesAbstain;
+
+  // sourced from dcp_totalmembersappointedtotheboard
+  @attr('number') totalBoardMembers;
+
+  // sourced from dcp_wasaquorumpresent
+  @attr('boolean') didQuorumExist;
+}

--- a/app/models/user-project-participant-type.js
+++ b/app/models/user-project-participant-type.js
@@ -1,0 +1,23 @@
+import DS from 'ember-data';
+import { attr, belongsTo } from '@ember-decorators/data';
+
+const { Model } = DS;
+
+export default class UserProjectParticipantTypeModel extends Model {
+  // ONE Project Has Many User Project Participants
+  @belongsTo('project') project;
+
+  // ONE User Has Many User Project Participants
+  @belongsTo('user') user;
+
+  // NOTE: Borough Presidents can have more than one participantType
+  // Both a 'Borough President' and 'Borough Board' type
+  // Whenever there is a 'Borough Board' participant listed (e.g. 'BXBB'),
+  // this participant will be reassigned to 'BXBP',
+  // so a BP participant (e.g. BXBP) will show up twice with two different participantTypes (e.g. BB and BP)
+
+  // CB (community board), BB (borough board) or BP (borough president)
+  // could calculate this based on user.representing
+  // could calculate this from email e.g. 'bxbp@planning.nyc.gov' or 'qncb5@planning.nyc.gov'
+  @attr('string') participantType;
+}

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1,0 +1,47 @@
+import DS from 'ember-data';
+import { attr, hasMany } from '@ember-decorators/data';
+import { computed } from '@ember-decorators/object';
+
+const { Model } = DS;
+
+export default class UserModel extends Model {
+// DB table: dcp_projectlupteam
+
+  // user's internal id should be their email
+
+  // Many Projects to Many Users
+  @hasMany('project') projects;
+
+  // ONE User Has Many User Project Participant Types
+  @hasMany('userProjectParticipantType') userProjectParticipantTypes;
+
+  @attr('string', { defaultValue: '' }) landUseParticipant;
+
+  // sourced from fullname e.g. 'Regis Philbin'
+  @attr('string', { defaultValue: '' }) name;
+
+  // sourced from jobtitle e.g. 'district manager'
+  @attr('string', { defaultValue: '' }) title;
+
+  // NOTE: Borough Presidents can have more than one participantType
+  // Both a 'Borough President' and 'Borough Board' type
+  // Whenever there is a 'Borough Board' participant listed (e.g. 'BXBB'),
+  // this participant will be reassigned to 'BXBP',
+  // so a BP participant (e.g. BXBP) will show up twice with two different participantTypes (e.g. BB and BP)
+  // ONE participant can have multiple Participant Types
+
+  // specific organization that user is a part of, a.k.a affiliation
+  // e.g. BXCB1, BXBP, BXCB5
+  // could calculate this from email e.g. 'bxbp@planning.nyc.gov' or 'qncb5@planning.nyc.gov'
+
+  // participant computed reassigns borough board participants to borough president e.g. 'BXBB' will be reassigned to 'BXBP'
+  @computed('landUseParticipant')
+  get participant() {
+    const landUseParticipant = this.get('landUseParticipant');
+    const lastTwoLetters = /.{2}$/;
+    const participantLastTwoLetters = landUseParticipant.match(lastTwoLetters);
+    const participantReassigned = participantLastTwoLetters[0] === 'BB' ? landUseParticipant.replace(lastTwoLetters, 'BP') : landUseParticipant;
+
+    return participantReassigned;
+  }
+}

--- a/mirage/factories/action.js
+++ b/mirage/factories/action.js
@@ -1,0 +1,31 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  actionId() {
+    return '566ede3a-dad0-e711-8125-1458d04e2f18';
+  },
+
+  actionName() {
+    return faker.list.random('Zoning Special Permit', 'Zoning Text Amendment', 'Disposition of Non-Residential City-Owned Property', 'Change in City Map');
+  },
+
+  actionCode() {
+    return faker.list.random('ZS', 'ZR', 'PP', 'MM');
+  },
+
+  actionType() {
+    return ['Zoning Special Permit', 'Zoning Text Amendment', 'Disposition of Non-Residential City-Owned Property', 'Change in City Map'];
+  },
+
+  status() {
+    return faker.list.random('Active', 'Approved', 'Certified', 'Referred', 'Terminated', 'Withdrawn');
+  },
+
+  isActive() {
+    return faker.list.random('Active', 'inActive');
+  },
+
+  ulurpNumber() {
+    return faker.list.random('C780076TLK', 'N860877TCM', 'I030148MMQ');
+  },
+});

--- a/mirage/factories/hearing.js
+++ b/mirage/factories/hearing.js
@@ -1,0 +1,11 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  location() {
+    return faker.address.streetAddress();
+  },
+
+  date() {
+    return faker.date.past();
+  },
+});

--- a/mirage/factories/recommendation.js
+++ b/mirage/factories/recommendation.js
@@ -1,0 +1,57 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+
+  // #### Recommendation Type per Each of the 3 Participants ####
+  // sourced from dcp_boroughpresidentrecommendation
+  // e.g. 'Favorable', 'Conditional Favorable', 'Unfavorable', 'Conditional Unfavorable',
+  // 'Received after Clock Expired', 'No Objection', 'Waiver of Recommendation', N/A is defualt
+
+  // sourced from dcp_boroughboardrecommendation
+  // e.g. 'Favorable', 'Unfavorable', 'Waiver of Recommendation', 'Non-Complying', N/A as default
+
+  // sourced from dcp_communityboardrecommendation
+  // 'Approved', 'Approved with Modifications/Conditions', 'Disapproved', 'Disapproved with Modifications/Conditions',
+  // 'Non-Complying', 'Vote Quorum Not Present', 'Received after Clock Expired', 'No Objection', 'Waiver of Recommendation',
+  // N/A as default
+
+  recommendation() {
+    return faker.list.random('Favorable', 'Unfavorable', 'Waiver of Recommendation', 'Non-Complying');
+  },
+
+  consideration() {
+    return faker.Lorem.sentences();
+  },
+
+  voteLocation() {
+    return faker.Address.streetAddress();
+  },
+
+  dateReceived() {
+    return faker.Date.past();
+  },
+
+  dateVoted() {
+    return faker.Date.past();
+  },
+
+  votesInFavor() {
+    return 15;
+  },
+
+  votesAgainst() {
+    return 4;
+  },
+
+  votesAbstain() {
+    return 1;
+  },
+
+  totalBoardMembers() {
+    return 20;
+  },
+
+  didQuorumExist() {
+    return true;
+  },
+});

--- a/mirage/factories/user-project-participant-type.js
+++ b/mirage/factories/user-project-participant-type.js
@@ -1,0 +1,7 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  participantType() {
+    return faker.list.random('CB', 'BB', 'BP');
+  },
+});

--- a/mirage/factories/user.js
+++ b/mirage/factories/user.js
@@ -1,0 +1,19 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  email() {
+    return faker.list.random('bxbp@planning.nyc.gov', 'qncb5@planning.nyc.gov');
+  },
+
+  name() {
+    return faker.name.findName();
+  },
+
+  title() {
+    return faker.name.jobTitle();
+  },
+
+  landUseParticipant() {
+    return faker.list.random('BXBB', 'BXBP', 'QNCB5');
+  },
+});

--- a/mirage/models/action.js
+++ b/mirage/models/action.js
@@ -1,0 +1,6 @@
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
+
+export default Model.extend({
+  project: belongsTo(),
+  recommendation: hasMany(),
+});

--- a/mirage/models/hearing.js
+++ b/mirage/models/hearing.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  project: belongsTo(),
+});

--- a/mirage/models/project.js
+++ b/mirage/models/project.js
@@ -1,4 +1,8 @@
-import { Model } from 'ember-cli-mirage';
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
 
 export default Model.extend({
+  user: hasMany(),
+  action: hasMany(),
+  userProjectParticipantType: hasMany(),
+  hearing: belongsTo(),
 });

--- a/mirage/models/recommendation.js
+++ b/mirage/models/recommendation.js
@@ -1,0 +1,5 @@
+import { Model, hasMany } from 'ember-cli-mirage';
+
+export default Model.extend({
+  action: hasMany(),
+});

--- a/mirage/models/user-project-participant-type.js
+++ b/mirage/models/user-project-participant-type.js
@@ -1,0 +1,6 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  project: belongsTo(),
+  user: belongsTo(),
+});

--- a/mirage/models/user.js
+++ b/mirage/models/user.js
@@ -1,0 +1,6 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  project: belongsTo(),
+  user: belongsTo(),
+});

--- a/tests/unit/models/action-test.js
+++ b/tests/unit/models/action-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | action', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('action', {});
+    assert.ok(model);
+  });
+});

--- a/tests/unit/models/hearing-test.js
+++ b/tests/unit/models/hearing-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Unit | Model | hearing', function(hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  test('isScheduled depends on date being truthy', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const modelWithDate = store.createRecord('hearing', { date: 'banana' });
+    const modelWithoutDate = store.createRecord('hearing', { date: null });
+    assert.equal(modelWithDate.isScheduled, true);
+    assert.equal(modelWithoutDate.isScheduled, false);
+  });
+});

--- a/tests/unit/models/recommendation-test.js
+++ b/tests/unit/models/recommendation-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | recommendation', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('recommendation', {});
+    assert.ok(model);
+  });
+});

--- a/tests/unit/models/recommendation/borough-board-test.js
+++ b/tests/unit/models/recommendation/borough-board-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | recommendation/borough board', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('recommendation/borough-board', {});
+    assert.ok(model);
+  });
+});

--- a/tests/unit/models/recommendation/borough-president-test.js
+++ b/tests/unit/models/recommendation/borough-president-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | recommendation/borough president', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('recommendation/borough-president', {});
+    assert.ok(model);
+  });
+});

--- a/tests/unit/models/recommendation/community-board-test.js
+++ b/tests/unit/models/recommendation/community-board-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | recommendation/community board', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('recommendation/community-board', {});
+    assert.ok(model);
+  });
+});

--- a/tests/unit/models/user-project-participant-type-test.js
+++ b/tests/unit/models/user-project-participant-type-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | user project participant type', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('user-project-participant-type', {});
+    assert.ok(model);
+  });
+});

--- a/tests/unit/models/user-test.js
+++ b/tests/unit/models/user-test.js
@@ -1,0 +1,19 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Unit | Model | user', function(hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  // landUseParticipant that comes back as 'BXBB' will be reassigned to 'BXBP'
+  test('participant is reassigned', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const modelBoroughBoard = store.createRecord('user', { landUseParticipant: 'BXBB' });
+    const modelPresident = store.createRecord('user', { landUseParticipant: 'BXBP' });
+    const modelCommunityBoard = store.createRecord('user', { landUseParticipant: 'BXCB2' });
+    assert.equal(modelBoroughBoard.participant, 'BXBP');
+    assert.equal(modelPresident.participant, 'BXBP');
+    assert.equal(modelCommunityBoard.participant, 'BXCB2');
+  });
+});


### PR DESCRIPTION
- New Ember models for the LUPP refactor
- new models include `user`, `action`, `hearing`, `recommendation`, and `user-project-participant-type`
- accompanying mirage data and tests for computed attributes for `hearing.js` and `user.js`
- Comments throughout provide an overview of how frontend models/fields map to CRM models/fields 

You can view and comment on the model relationship [visualization](https://miro.com/welcomeonboard/AFpxIbORLIoIM5UF2pdnKcpBgYRYe8JFFkejggKEskW9B9eNl0BvlzCQ3LXJg9oA) (you need a Miro account)

Addresses #548 