### PR TITLE
547 send form content to zap crm

### DIFF
--- a/app/components/project-recommendations.js
+++ b/app/components/project-recommendations.js
@@ -1,0 +1,46 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+// This component yields the necessary Recommendation objects for the given
+// User and Project. Generally, only Borough Presidents with multiple
+// UserProjectParticipantTypes for a project will have two Recommendations
+// Glue template inputs to the yielded recommendations to update them before saving.
+export default class ProjectRecommendationsComponent extends Component {
+  @service
+  store;
+
+  user = {};
+
+  project = {};
+
+  @computed('user', 'project')
+  get userProjectParticipantTypes() {
+    if (this.user && this.project) {
+      const userProjectParticipantTypes = this.user.get('userProjectParticipantTypes').filterBy('project.id', this.project.get('id'));
+      return userProjectParticipantTypes.map(value => value.get('participantType'));
+    }
+    return [];
+  }
+
+  // The Recommendation type to create depends on UserProjectParticipantType.participantType
+  @computed('userProjectParticipantTypes')
+  get recommendations() {
+    return this.userProjectParticipantTypes.map((userParticipantType) => {
+      if (userParticipantType === 'BP') {
+        return this.store.createRecord('borough-president-recommendation', {
+          user: this.user,
+        });
+      }
+      if (userParticipantType === 'BB') {
+        return this.store.createRecord('borough-board-recommendation', {
+          user: this.user,
+        });
+      }
+      // if userParticipantType == 'CB'
+      return this.store.createRecord('community-board-recommendation', {
+        user: this.user,
+      });
+    });
+  }
+}

--- a/app/models/user-project-participant-type.js
+++ b/app/models/user-project-participant-type.js
@@ -1,6 +1,8 @@
 import DS from 'ember-data';
 
-const { Model, attr, belongsTo } = DS;
+const {
+  Model, attr, belongsTo,
+} = DS;
 
 export default class UserProjectParticipantTypeModel extends Model {
   // ONE Project Has Many User Project Participants

--- a/app/templates/components/project-recommendations.hbs
+++ b/app/templates/components/project-recommendations.hbs
@@ -1,0 +1,4 @@
+{{yield (hash 
+  participantTypes=this.userProjectParticipantTypes
+  list=this.recommendations
+)}}

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -54,6 +54,12 @@ export default function(server) {
 
   server.create('userProjectParticipantType', {
     user: seedBPUser,
+    project: seedBPUserProjects[0],
+    participantType: 'BP',
+  });
+
+  server.create('userProjectParticipantType', {
+    user: seedBPUser,
     project: seedBPUserProjects[1],
     participantType: 'BP',
   });

--- a/tests/integration/components/project-recommendations-test.js
+++ b/tests/integration/components/project-recommendations-test.js
@@ -1,0 +1,61 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import seedMirage from '../../../mirage/scenarios/default';
+
+module('Integration | Component | project-recommendations', function(hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+    this.store = this.owner.lookup('service:store');
+    seedMirage(server);
+  });
+
+  test('it renders', async function(assert) {
+    await render(hbs`<ProjectRecommendations />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      <ProjectRecommendations>
+        template block text
+      </ProjectRecommendations>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+
+
+  test('it generates a list of Recommendations', async function(assert) {
+    // TODO: Retrieve by email?
+    this.user = await this.store.findRecord('user', 2, {
+      include: 'userProjectParticipantTypes.project,projects',
+    });
+
+    this.project = await this.store.findRecord('project', 3, {
+      include: 'actions',
+    });
+
+    // User 2, Project 3, has two recommendations because it has two UserProjectParticipantTypes:
+    // 'BB' and 'BP'
+    await render(hbs`
+      <ProjectRecommendations
+        @user={{this.user}}
+        @project={{this.project}}
+        as |recommendations|>
+        {{#each recommendations.list as |recommendation|}}
+          A recommendation.
+        {{/each}}
+        {{#each recommendations.participantTypes as |participantType|}}
+          {{participantType}}.
+        {{/each}}
+      </ProjectRecommendations>
+    `);
+
+    assert.equal(this.element.textContent.replace(/ /g, '').replace(/(\r\n|\n|\r)/gm, '').trim(), 'Arecommendation.Arecommendation.BB.BP.');
+  });
+});


### PR DESCRIPTION
## What
- Introduces frontend logic for sending Recommendation data to Mirage.

## Todo:
- Connect new Recommendations to user inputed attributes (This will be handled by upcoming `533-` branch)
- Clarify if Recommendation (whether it is a BP, BB or CB rec) depends on `UserProjectParticipantTypes.participantType` ✅ 
- ~Merge with Andy's Recommendation templates~

