### PR TITLE
Setup valid auth for fetch; add nyc.id invalidation

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -5,4 +5,10 @@ const { JSONAPIAdapter } = DS;
 
 export default class ApplicationAdapter extends JSONAPIAdapter {
   host = ENV.host;
+
+  ajax(url, method, hash = {}) {
+    hash.xhrFields = { withCredentials: true };
+
+    return super.ajax(url, method, hash);
+  }
 }

--- a/app/authenticators/zap-api-authenticator.js
+++ b/app/authenticators/zap-api-authenticator.js
@@ -38,7 +38,10 @@ export default class ZAPAuthenticator extends BaseAuthenticator {
     }
 
     // returns an http cookie to implicitly authenticate later requests
-    const response = await fetch(`${ENV.host}/login?accessToken=${access_token}`);
+    const response = await fetch(`${ENV.host}/login?accessToken=${access_token}`, {
+      mode: 'same-origin',
+      credentials: 'include',
+    });
 
     if (!response.ok) throw await response.json();
 

--- a/app/components/auth/do-logout.js
+++ b/app/components/auth/do-logout.js
@@ -1,0 +1,6 @@
+import Component from '@ember/component';
+import ENV from 'labs-zap-search/config/environment';
+
+export default class DoLogout extends Component {
+  nycIDHost = ENV.NYC_ID_HOST;
+}

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -28,6 +28,8 @@ export default class UserModel extends Model {
 
   @attr('string', { defaultValue: '' }) email;
 
+  @attr('string', { defaultValue: '' }) emailaddress1;
+
   // NOTE: Borough Presidents can have more than one participantType
   // Both a 'Borough President' and 'Borough Board' type
   // Whenever there is a 'Borough Board' participant listed (e.g. 'BXBB'),

--- a/app/templates/components/auth/do-logout.hbs
+++ b/app/templates/components/auth/do-logout.hbs
@@ -1,0 +1,5 @@
+{{!-- Implicit logout — this renders the logout domain --}}
+<iframe
+  src="{{this.nycIDHost}}/account/idpLogout.htm?x-frames-allow-from=zap-staging-lupp.planninglabs.nyc"
+  style="display: none;">
+</iframe>

--- a/app/templates/components/sign-in.hbs
+++ b/app/templates/components/sign-in.hbs
@@ -8,7 +8,7 @@
     {{fa-icon 'user-circle' size='2x' class="auth--icon"}}
     <div>
       <span data-test-auth-name class="auth--name">
-        {{this.session.data.authenticated.email}}
+        {{this.session.data.authenticated.emailaddress1}}
       </span>
       <a
         data-test-auth-logout-button

--- a/app/templates/login-error.hbs
+++ b/app/templates/login-error.hbs
@@ -10,6 +10,8 @@
           <p data-test-error-message={{idx}}>{{error.detail}}</p>
         {{/each}}
 
+        {{auth/do-logout}}
+
         <p>Please reach out to your contact at DCP, and we'll take care of it as soon as possible.</p>
       </div>
     </div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -13,6 +13,7 @@ module.exports = function(environment) {
     routerScroll: {
       scrollElement: '#scrolling-result-content',
     },
+    NYC_ID_HOST: 'https://accounts-nonprd.nyc.gov',
     host: ENVIRONMENTAL_HOST_API || '',
     OAUTH_ENDPOINT: 'https://accounts-nonprd.nyc.gov/account/api/oauth/authorize.htm?response_type=token&client_id=zap_staging',
     EmberENV: {

--- a/mirage/factories/user.js
+++ b/mirage/factories/user.js
@@ -1,7 +1,7 @@
 import { Factory, faker } from 'ember-cli-mirage';
 
 export default Factory.extend({
-  email(i) {
+  emailaddress1(i) {
     return faker.list.cycle('bxbp@planning.nyc.gov', 'bxbp@planning.nyc.gov', 'qncb5@planning.nyc.gov')(i);
   },
 

--- a/tests/acceptance/user-can-login-test.js
+++ b/tests/acceptance/user-can-login-test.js
@@ -23,7 +23,7 @@ module('Acceptance | user can login', function(hooks) {
 
   test('User can login - redirects from oauth', async function(assert) {
     this.server.create('user', {
-      email: 'testuser@planning.nyc.gov',
+      emailaddress1: 'testuser@planning.nyc.gov',
     });
 
     // simulate presence of location hash after OAUTH redirect

--- a/tests/integration/components/auth/do-logout-test.js
+++ b/tests/integration/components/auth/do-logout-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | auth/do-logout', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{auth/do-logout}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+  });
+});

--- a/tests/integration/components/sign-in-test.js
+++ b/tests/integration/components/sign-in-test.js
@@ -18,7 +18,7 @@ module('Integration | Component | sign-in', function(hooks) {
 
   test('it signs out', async function(assert) {
     await authenticateSession({
-      email: 'test@planning.nyc.gov',
+      emailaddress1: 'test@planning.nyc.gov',
     });
 
     await render(hbs`<SignIn />`);


### PR DESCRIPTION
This PR changes the way Ember adapters and the fetch call to /login work by specifying certain authentication options. 

This also adds an implicit NYC.ID _logout_ on CRM-handshake error.

The email address key is named differently from CRM. 