### PR TITLE
631 & 632  - Hide dev features in staging and prod, hide rec+hearing btns if not auth'd

### DIFF
--- a/app/controllers/show-project.js
+++ b/app/controllers/show-project.js
@@ -1,4 +1,5 @@
 import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
 import mapboxgl from 'mapbox-gl';
 import { action, computed } from '@ember/object';
 import turfBbox from '@turf/bbox';
@@ -10,6 +11,9 @@ import turfBuffer from '@turf/buffer';
  * computed property to alter the presetation of the project's milestones.
  */
 export default class ShowProjectController extends Controller {
+  @service
+  session
+
   bblFeatureCollectionLayerFill = {
     id: 'project-geometry-fill',
     type: 'fill',

--- a/app/helpers/in-array.js
+++ b/app/helpers/in-array.js
@@ -1,5 +1,10 @@
 import { helper } from '@ember/component/helper';
 
+/**
+ * @param { Any [] } arr
+ * @param { Any } elem
+ * returns true if elem is in arr
+ */
 export default helper(function inArray(params) {
   const [arr, elem] = params;
   return arr.includes(elem);

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,4 +1,5 @@
 import Route from '@ember/routing/route';
+import ENV from 'labs-zap-search/config/environment';
 
 export default class ApplicationRoute extends Route {
   beforeModel(transition) {
@@ -6,5 +7,10 @@ export default class ApplicationRoute extends Route {
     if (transition.intent.url === '/') {
       this.transitionTo('show-geography');
     }
+  }
+
+  setupController(controller, model){
+    super.setupController(controller, model);
+    controller.set('ENV', ENV);
   }
 }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -30,7 +30,9 @@
   {{#banner.nav}}
     <ul class="menu vertical large-horizontal">
       <li>{{link-to 'Search' 'show-geography'}}</li>
-      {{sign-in}}
+      {{#if (in-array (array "development" "test") this.ENV.environment)}}
+        {{sign-in}}
+      {{/if}}
     </ul>
   {{/banner.nav}}
 {{/labs-ui/site-header}}

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -154,37 +154,41 @@
 
       </div>
       <div class="cell large-5">
-
-        <div class="project--lup-section callout">
-          <h4 class="small-margin-bottom">Community Board Review</h4>
-          <div class="grid-x grid-x-small-gutters align-bottom">
-            <div class="cell medium-auto">
-              <p class="lead">
-                <strong>8</strong>
-                <small>of 60 days remain</small>
-              </p>
+        {{#if this.session.isAuthenticated}}
+          <div
+            data-test-hearing-rec-shortcuts
+            class="project--lup-section callout"
+          >
+            <h4 class="small-margin-bottom">Community Board Review</h4>
+            <div class="grid-x grid-x-small-gutters align-bottom">
+              <div class="cell medium-auto">
+                <p class="lead">
+                  <strong>8</strong>
+                  <small>of 60 days remain</small>
+                </p>
+              </div>
+              <div class="cell medium-shrink medium-text-right">
+                <p class="text-small dark-gray"><strong>Ends 09/02/19</strong></p>
+              </div>
             </div>
-            <div class="cell medium-shrink medium-text-right">
-              <p class="text-small dark-gray"><strong>Ends 09/02/19</strong></p>
+            <div class="grid-x grid-x-small-gutters">
+              <div class="cell medium-6 large-auto">
+                <a class="button multiline expanded no-margin">
+                  Submit<br>
+                  Participant&nbsp;Type
+                  <br>Hearing Info
+                </a>
+              </div>
+              <div class="cell medium-6 large-auto">
+                <a class="button multiline expanded no-margin">
+                  Submit<br>
+                  Participant&nbsp;Type
+                  <br>Recommendation
+                </a>
+              </div>
             </div>
           </div>
-          <div class="grid-x grid-x-small-gutters">
-            <div class="cell medium-6 large-auto">
-              <a class="button multiline expanded no-margin">
-                Submit<br>
-                Participant&nbsp;Type
-                <br>Hearing Info
-              </a>
-            </div>
-            <div class="cell medium-6 large-auto">
-              <a class="button multiline expanded no-margin">
-                Submit<br>
-                Participant&nbsp;Type
-                <br>Recommendation
-              </a>
-            </div>
-          </div>
-        </div>
+        {{/if}}
 
         {{#if hasBBLFeatureCollectionGeometry}}
           {{#mapbox-gl

--- a/tests/acceptance/authenticated-user-sees-authenticated-features-test.js
+++ b/tests/acceptance/authenticated-user-sees-authenticated-features-test.js
@@ -1,0 +1,43 @@
+import { module, test } from 'qunit';
+import {
+  visit,
+  find
+} from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { invalidateSession } from 'ember-simple-auth/test-support';
+
+module('Acceptance | authenticated user sees authenticated features', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+    window.location.hash = '';
+    await invalidateSession();
+
+    this.server.create('project', {
+      id: 1,
+    });
+  });
+
+  test('User does not see hearing and recommendation buttons on show-project if logged out', async function(assert) {
+    await visit('/projects/1');
+    assert.notOk(find('[data-test-hearing-rec-shortcuts]'));
+  });
+
+  test('User sees hearing and recommendation buttons on show-project if logged in', async function(assert) {
+    this.server.create('user', {
+      emailaddress1: 'testuser@planning.nyc.gov',
+    });
+
+    // simulate presence of location hash after OAUTH redirect
+    window.location.hash = '#access_token=test';
+
+    await visit('/login');
+
+    await visit('/projects/1');
+
+    assert.ok(find('[data-test-hearing-rec-shortcuts]'));
+  });
+});

--- a/tests/acceptance/dev-features-are-hidden-in-staging-and-prod-test.js
+++ b/tests/acceptance/dev-features-are-hidden-in-staging-and-prod-test.js
@@ -1,0 +1,91 @@
+import { module, test } from 'qunit';
+import {
+  visit,
+  find
+} from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { invalidateSession } from 'ember-simple-auth/test-support';
+
+module('Acceptance | dev features are hidden in staging and prod', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(async function() {
+    this.server.create('project', {
+      id: 1,
+    });
+
+    this.server.create('user', {
+      emailaddress1: 'testuser@planning.nyc.gov',
+    });
+
+    window.location.hash = '';
+
+    await invalidateSession();
+  });
+
+  test('Unauthenticated user sees sign-in feature if environment is development or test', async function(assert) {
+    await visit('/');
+    assert.ok(find('[data-test-auth-login-button]'));
+  });
+
+  test('Authenticated user sees sign-in feature if environment is development or test', async function(assert) {
+    // simulate presence of location hash after OAUTH redirect
+    window.location.hash = '#access_token=test';
+
+    await visit('/login');
+
+    assert.ok(find('[data-test-auth-name]'));
+    assert.ok(find('[data-test-auth-logout-button]'));
+  });
+
+  test('Unauthenticated user does not see sign-in feature if environment is staging or prod', async function(assert) {
+    // visit root route first to instantiate application controller
+    await visit('/');
+
+    const applicationController =  this.owner.lookup('controller:application');
+
+    applicationController.set('ENV', { environment: "staging" });
+
+    // reload page, since applicationController.ENV is not a computed
+    await visit('/');
+
+    assert.notOk(find('[data-test-auth-login-button]'));
+
+    applicationController.set('ENV', { environment: "production" });
+
+    await visit('/');
+
+    assert.notOk(find('[data-test-auth-login-button]'));
+  });
+
+  // A user could still "sign in" via api, but the sign-in feature would be visually hidden
+  test('Authenticated user does not see sign-in feature if environment is staging or prod', async function(assert) {
+    // visit root route first to instantiate application controller
+    await visit('/');
+
+    const applicationController =  this.owner.lookup('controller:application');
+
+    applicationController.set('ENV', { environment: "staging" });
+
+    // reload page, since applicationController.ENV is not a computed
+    await visit('/');
+
+    // simulate presence of location hash after OAUTH redirect
+    window.location.hash = '#access_token=test';
+
+    await visit('/login');
+
+    assert.notOk(find('[data-test-auth-name]'));
+    assert.notOk(find('[data-test-auth-logout-button]'));
+
+    applicationController.set('ENV', { environment: "production" });
+
+    await visit('/');
+
+    assert.notOk(find('[data-test-auth-name]'));
+    assert.notOk(find('[data-test-auth-logout-button]'));
+  });  
+});


### PR DESCRIPTION
- (#631) Adds ability to hide "Development" features when building to staging and production.
- (#632) This PR includes 1 rider: hiding rec+hearing buttons on `show-project` page if user not auth'd