### PR TITLE
Fix milestone attr names to align with CRM

### DIFF
--- a/app/components/project-milestone.js
+++ b/app/components/project-milestone.js
@@ -17,10 +17,10 @@ export default class ProjectMilestoneComponent extends Component {
   }
 
   // one of 'past', 'present', or 'future'
-  @computed('milestone.display_date,milestone.display_date_2')
+  @computed('milestone.displayDate,milestone.displayDate2')
   get tense() {
-    const date1 = this.get('milestone.display_date');
-    const date2 = this.get('milestone.display_date_2');
+    const date1 = this.get('milestone.displayDate');
+    const date2 = this.get('milestone.displayDate2');
 
     if (!date2 && moment(date1).isBefore()) { return 'past'; }
 
@@ -33,11 +33,11 @@ export default class ProjectMilestoneComponent extends Component {
     return 'future';
   }
 
-  @computed('tense,milestone.display_date,milestone.display_date_2')
+  @computed('tense,milestone.displayDate,milestone.displayDate2')
   get timeRelativeToNow() {
     const tense = this.get('tense');
-    const date1 = this.get('milestone.display_date');
-    const date2 = this.get('milestone.display_date_2');
+    const date1 = this.get('milestone.displayDate');
+    const date2 = this.get('milestone.displayDate2');
 
     if (!date1) {
       return '';

--- a/app/models/milestone.js
+++ b/app/models/milestone.js
@@ -9,33 +9,32 @@ export default class MilestoneModel extends Model {
   @belongsTo('project') project;
 
   // --> ZAP-API:zap_id
-  // --> CRM:dcp_projectmilestone. e.g. 923BEEC4-DAD0-E711-8116-1458D04E2FB8
   // This is the Milestone ID that identifies a specific milestone
-  @attr('string') projectMilestone;
+  @attr('string') milestone;
 
   // --> CRM:dcp_name. e.g. 'ZC - Land Use Fee Payment '
   @attr('string') name;
 
   // --> CRM:milestonename | e.g. 'Land Use Fee Payment'
-  @attr('string') milestoneName;
+  @attr('string') milestonename;
 
   // --> CRM:dcp_plannedstartdate | e.g. '2018-10-31T01:21:46'
-  @attr('string') plannedStartDate;
+  @attr('string') plannedstartdate;
 
   // --> CRM:dcp_plannedcompletiondate | e.g. '2018-11-02T01:21:46'
-  @attr('string') plannedCompletionDate;
+  @attr('string') plannedcompletiondate;
 
   // --> CRM:dcp_actualstartdate | e.g. '2018-05-11T04:00:00'
-  @attr('string') actualStartDate;
+  @attr('string') actualstartdate;
 
   // --> CRM:dcp_actualenddate | e.g. '2018-05-12T04:00:00'
-  @attr('string') actualEndDate;
+  @attr('string') actualenddate;
 
   // --> CRM:statuscode | e.g. 'Not Started', 'In Progress', 'Completed', 'Overridden'
-  @attr('string') statusCode;
+  @attr('string') statuscode;
 
   // --> CRM:dcp_milestonesequence | e.g. 28
-  @attr('string') milestoneSequence;
+  @attr('string') milestonesequence;
 
   // --> ZAP-API:displayDescription | e.g. 'Land Use Fee Payment'
   @attr('string') displayDescription;
@@ -50,7 +49,7 @@ export default class MilestoneModel extends Model {
   @attr('string') displayDate2;
 
   // --> CRM:dcp_milestoneoutcome
-  @attr('string') milestoneOutcome;
+  @attr('string') milestoneoutcome;
 
   // --> ZAP-API:milestoneLinks
   @attr() milestoneLinks;

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -26,7 +26,7 @@ export default class ProjectModel extends Model {
   // ONE Project Has Many User Project Participant Types
   @hasMany('userProjectParticipantType') userProjectParticipantTypes;
 
-  @hasMany('miletone') milestones;
+  @hasMany('milestone', { async: false }) milestones;
 
   // One Project to One Hearing
   @belongsTo('hearing') hearing;

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -26,6 +26,8 @@ export default class ProjectModel extends Model {
   // ONE Project Has Many User Project Participant Types
   @hasMany('userProjectParticipantType') userProjectParticipantTypes;
 
+  @hasMany('miletone') milestones;
+
   // One Project to One Hearing
   @belongsTo('hearing') hearing;
 

--- a/app/templates/components/project-milestone.hbs
+++ b/app/templates/components/project-milestone.hbs
@@ -17,7 +17,15 @@
   {{/if}}
 </div>
 <div class="cell auto {{if (or (eq tense 'past') (eq tense 'present')) '' 'gray'}}">
-  <h5 class="no-margin">{{milestone.displayName}}{{#if milestone.displayDescription}}<sup class="gray">{{icon-tooltip tip=milestone.displayDescription}}</sup>{{/if}}</h5>
+  <h5 class="no-margin">
+    {{milestone.displayName}}
+
+    {{#if milestone.displaydescription}}
+      <sup class="gray">
+        {{icon-tooltip tip=milestone.displaydescription}}
+      </sup>
+    {{/if}}
+  </h5>
   {{#if milestone.displayDate}}
     <div class="milestone-dates">
       {{#if milestone.displayDate}}
@@ -30,12 +38,12 @@
         <div class="milestone-offset">{{timeRelativeToNow}}</div>
       {{/if}}
     </div>
-    {{#if milestone.milestoneOutcome}} <span class="label dark-gray" style="font-size: 0.7rem;">{{milestone.milestoneOutcome}}</span> {{/if}}
+    {{#if milestone.milestoneoutcome}} <span class="label dark-gray" style="font-size: 0.7rem;">{{milestone.milestoneoutcome}}</span> {{/if}}
     <ul class="milestone-links">
-      {{#if (eq milestone.projectMilestone "9e3beec4-dad0-e711-8116-1458d04e2fb8")}}
+      {{#if (eq milestone.projectmilestone "9e3beec4-dad0-e711-8116-1458d04e2fb8")}}
         <li><a href="https://www1.nyc.gov/site/planning/about/commission-meetings.page" target="_blank">{{fa-icon "external-link-alt"}} CPC Public Meeting Calendar</a></li>
       {{/if}}
-      {{#if (eq milestone.projectMilestone "a43beec4-dad0-e711-8116-1458d04e2fb8")}}
+      {{#if (eq milestone.projectmilestone "a43beec4-dad0-e711-8116-1458d04e2fb8")}}
         <li><a href="http://a030-cpc.nyc.gov/html/cpc/index.aspx" target="_blank">{{fa-icon "external-link-alt"}} CPC Reports</a></li>
       {{/if}}
       {{#each milestone.milestoneLinks as |link|}}


### PR DESCRIPTION
Part of 571...
This PR's commit is almost the same as `571-alignment-milestones`. The small differences include:
  - change `projectMilestone` attr to `milestone`
  - Retain camelcasing for the `milestoneLinks` attribute, since zap-api provides the camelcasing.