### PR TITLE
698: revise deduped hearings list

### DIFF
--- a/app/components/deduped-hearings-list.js
+++ b/app/components/deduped-hearings-list.js
@@ -1,0 +1,46 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default class DedupedHearingsListComponent extends Component {
+  // the actions "attribute" to display in the hearings list e.g. "ulurpnumber" or 'name'
+  // this is set when the component is rendered
+  attribute = '';
+
+  @computed('project')
+  get dedupedHearings() {
+    const dispositions = this.get('project.dispositions');
+    // an array of objects that have been reduced
+
+    // setting a new property on each disposition called hearingActions which is an array of objects
+    // this property hearingActions is initally set to an array of the current disposition's action model.
+    // During the reduce, if there is a duplicate in the array of dispositions,
+    // the actions model for that duplicate disposition is pushed into this array
+    dispositions.forEach(function(disposition) {
+      disposition.set('hearingActions', [disposition.action]);
+    });
+
+    // each disposition in the deduped list will have an array of its duplicate dispositions
+    dispositions.forEach(function(disposition) {
+      disposition.set('duplicateDisps', [disposition]);
+    });
+
+    // reduce method to deduplicate dispositions based on location and date of hearing
+    // TODO: move this reduce into own function
+    return dispositions.reduce((accumulatedDisps, currentDisp) => {
+      // object that represents a match between accumulatedDisps and the currentDisp
+      const duplicateObject = accumulatedDisps.find(item => item.dcpPublichearinglocation === currentDisp.dcpPublichearinglocation && item.dcpDateofpublichearing.toString() === currentDisp.dcpDateofpublichearing.toString());
+
+      // if an object exists in accumulatedDisps that matches the currentDisp
+      if (duplicateObject) {
+        // grab the actions model from the currentDisp
+        const currentDispAction = currentDisp.get('action');
+        // push this into the hearingActions array on the matched object in accumulatedDisps
+        duplicateObject.hearingActions.push(currentDispAction);
+        duplicateObject.duplicateDisps.push(currentDisp);
+
+        return accumulatedDisps;
+      } // if the properties DO NOT match, concatenate currentDisp object to array
+      return accumulatedDisps.concat([currentDisp]);
+    }, []);
+  }
+}

--- a/app/components/to-review-project-card.js
+++ b/app/components/to-review-project-card.js
@@ -1,48 +1,17 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { hearingsSubmitted } from 'labs-zap-search/helpers/hearings-submitted';
 
 export default class ToReviewProjectCardComponent extends Component {
   @service
   currentUser;
 
+  // hearingsSubmitted is a helper that iterates through each disposition
+  // and checks whether disposition has publichearinglocation and dateofpublichearing
   @computed('project')
-  get hearingsSubmitted() {
+  get hearingsSubmittedForProject() {
     const dispositions = this.get('project.dispositions');
-
-    // a function to check if each hearing location/date field is truthy
-    function infoExists(hearingInfo) {
-      return hearingInfo;
-    }
-
-    const dispositionHearingLocations = dispositions.map(disp => `${disp.dcpPublichearinglocation}`);
-    const dispositionHearingDates = dispositions.map(disp => disp.dcpDateofpublichearing);
-    // using function infoExists, fieldsFilled checks whether each item in array is truthy
-    const hearingsSubmitted = dispositionHearingLocations.every(infoExists) && dispositionHearingDates.every(infoExists);
-
-    return hearingsSubmitted;
-  }
-
-  @computed('hearingsSubmitted', 'project')
-  get dedupedHearings() {
-    const dispositions = this.get('project.dispositions');
-
-    let deduped;
-    const hearingsSubmitted = this.get('hearingsSubmitted');
-
-    if (hearingsSubmitted) {
-      deduped = dispositions.reduce((acc, current) => {
-        const matchingProps = acc.find(item => item.dcpPublichearinglocation === current.dcpPublichearinglocation && item.dcpDateofpublichearing.toString() === current.dcpDateofpublichearing.toString());
-
-        // if the properties DO match
-        if (matchingProps) {
-          // just return original object, WITHOUT concatenating the duplicate
-          return acc;
-        // if the properties DO NOT match
-        } return acc.concat([current]);
-      }, []);
-    }
-
-    return deduped;
+    return hearingsSubmitted(dispositions);
   }
 }

--- a/app/controllers/show-project.js
+++ b/app/controllers/show-project.js
@@ -4,6 +4,7 @@ import mapboxgl from 'mapbox-gl';
 import { action, computed } from '@ember/object';
 import turfBbox from '@turf/bbox';
 import turfBuffer from '@turf/buffer';
+import { hearingsSubmitted } from 'labs-zap-search/helpers/hearings-submitted';
 
 /**
  * The ShowProjectController is an EmberJS controller which handles the
@@ -52,45 +53,12 @@ export default class ShowProjectController extends Controller {
     } return false;
   }
 
+  // hearingsSubmitted is a helper that iterates through each disposition
+  // and checks whether disposition has dcpPublichearinglocation and dcpDateofpublichearing
   @computed('model')
-  get hearingsSubmitted() {
+  get hearingsSubmittedForProject() {
     const dispositions = this.get('model.dispositions');
-
-    // a function to check if each hearing location/date field is truthy
-    function infoExists(hearingInfo) {
-      return hearingInfo;
-    }
-
-    const dispositionHearingLocations = dispositions.map(disp => `${disp.dcpPublichearinglocation}`);
-    const dispositionHearingDates = dispositions.map(disp => disp.dcpDateofpublichearing);
-    // using function infoExists, fieldsFilled checks whether each item in array is truthy
-    const hearingsSubmitted = dispositionHearingLocations.every(infoExists) && dispositionHearingDates.every(infoExists);
-
-    return hearingsSubmitted;
-  }
-
-  @computed('hearingsSubmitted', 'model')
-  get dedupedHearings() {
-    const dispositions = this.get('model.dispositions');
-
-    let deduped;
-    const hearingsSubmitted = this.get('hearingsSubmitted');
-
-    if (hearingsSubmitted) {
-      deduped = dispositions.reduce((acc, current) => {
-        const matchingProps = acc.find(item => item.dcpPublichearinglocation === current.dcpPublichearinglocation && item.dcpDateofpublichearing.toString() === current.dcpDateofpublichearing.toString());
-
-        // if the properties DO match
-        if (matchingProps) {
-          // just return original object, WITHOUT concatenating the duplicate
-          return acc;
-        // if the properties DO NOT match
-        // concatenate the new object onto the array
-        } return acc.concat([current]);
-      }, []);
-    }
-
-    return deduped;
+    return hearingsSubmitted(dispositions);
   }
 
   @computed('model.bblFeaturecollection')

--- a/app/helpers/hearings-submitted.js
+++ b/app/helpers/hearings-submitted.js
@@ -1,0 +1,15 @@
+import { helper } from '@ember/component/helper';
+
+export function hearingsSubmitted(dispositions) {
+  // array of hearing locations
+  const dispositionHearingLocations = dispositions.map(disp => `${disp.dcpPublichearinglocation}`);
+  // array of hearing dates
+  const dispositionHearingDates = dispositions.map(disp => disp.dcpDateofpublichearing);
+
+  // hearingsSubmittedForProject checks whether each item in array is truthy
+  const hearingsSubmittedForProject = dispositionHearingLocations.every(location => !!location) && dispositionHearingDates.every(date => !!date);
+
+  return hearingsSubmittedForProject;
+}
+
+export default helper(hearingsSubmitted);

--- a/app/models/disposition.js
+++ b/app/models/disposition.js
@@ -61,7 +61,7 @@ export default class DispositionModel extends Model {
   // TODO: investigate the format server expects.
   // potentially switch back to "Date" attribute type, if compatible with
   // backend
-  @attr('string') dateofvote;
+  @attr('date', { defaultValue: null }) dateofvote;
 
   // sourced from statecode
   // "Active" vs "Inactive"

--- a/app/templates/components/deduped-hearings-list.hbs
+++ b/app/templates/components/deduped-hearings-list.hbs
@@ -1,0 +1,35 @@
+<h5 class="column-header">Hearing Information</h5>
+    <ul class="no-bullet">
+    {{#each dedupedHearings as |hearing|}}
+      <li class="grid-x">
+        <div class="cell shrink small-margin-right">
+          {{#if (is-before hearing.dcpDateofpublichearing)}}
+            {{fa-icon "calendar" class="light-gray" fixedWidth=true}}
+          {{else}}
+            {{fa-icon "check" class="blue" fixedWidth=true}}
+          {{/if}}
+        </div>
+        <div class="cell auto">
+          <strong data-test-hearing-location="{{hearing.id}}" class="display-block">
+            {{~hearing.dcpPublichearinglocation~}}
+          </strong>
+          <span data-test-hearing-date="{{hearing.id}}">
+            {{~moment-format hearing.dcpDateofpublichearing "MM/D/YYYY"~}}
+          </span>
+          <span class="light-gray">|</span>
+          <span data-test-hearing-time="{{hearing.id}}">
+            {{~moment-format hearing.dcpDateofpublichearing "h:mm A"~}}
+          </span>
+          <span data-test-hearing-actions-list="{{hearing.id}}" class="display-block text-tiny">
+            {{#each hearing.hearingActions as |action index|}}
+              {{#if (eq attribute "dcpUlurpnumber")}}
+                {{if (gt index 0) ", "}}{{action.dcpUlurpnumber}}
+              {{else if (eq attribute "dcpName")}}
+                {{if (gt index 0) ", "}}{{action.dcpName}},
+              {{/if}}
+            {{/each}}
+          </span>
+        </div>
+      </li>
+    {{/each}}
+    </ul>

--- a/app/templates/components/sign-in.hbs
+++ b/app/templates/components/sign-in.hbs
@@ -3,7 +3,7 @@
   otherwise show the "Sign In" button.
   --}}
 {{#if this.session.isAuthenticated}}
-  <li>{{link-to 'My Projects' 'my-projects'}}</li>
+  <li data-test-my-projects-button>{{link-to 'My Projects' 'my-projects'}}</li>
   <li class="auth--container">
     {{fa-icon 'user-circle' size='2x' class="auth--icon"}}
     <div>

--- a/app/templates/components/to-review-project-card.hbs
+++ b/app/templates/components/to-review-project-card.hbs
@@ -22,33 +22,8 @@
     <div class="cell medium-8 large-auto">
       <div class="grid-x grid-x-small-gutters">
         <div class="cell medium-6 large-auto">
-          {{#if hearingsSubmitted}}
-            <h5 class="column-header">Hearing Information</h5>
-                <ul class="no-bullet">
-                {{#each dedupedHearings as |hearing|}}
-                  <li class="grid-x">
-                    <div class="cell shrink small-margin-right">
-                      {{#if (is-before hearing.dcpDateofpublichearing)}}
-                        {{fa-icon "calendar" class="light-gray" fixedWidth=true}}
-                      {{else}}
-                        {{fa-icon "check" class="blue" fixedWidth=true}}
-                      {{/if}}
-                    </div>
-                    <div class="cell-auto">
-                      <strong class="display-block hearing-location">
-                        {{~hearing.dcpPublichearinglocation~}}
-                      </strong>
-                      <span class="hearing-date">
-                        {{~moment-format hearing.dcpDateofpublichearing "MM/D/YYYY"~}}
-                      </span>
-                      <span class="light-gray">|</span>
-                      <span class="hearing-time">
-                        {{~moment-format hearing.dcpDateofpublichearing "h:mm A"~}}
-                      </span>
-                    </div>
-                  </li>
-                {{/each}}
-                </ul>
+          {{#if hearingsSubmittedForProject}}
+            {{deduped-hearings-list project=project attribute="dcpUlurpnumber"}}
           {{else}}
             <LinkTo
               @route="my-projects.project.hearing.add"

--- a/app/templates/my-projects/project/hearing/add.hbs
+++ b/app/templates/my-projects/project/hearing/add.hbs
@@ -50,7 +50,7 @@
         checkIfMissing=checkIfMissing}}
     {{else if (eq allActions false)}}
       {{#each model.dispositions as |disposition|}}
-        <h4>{{disposition.action.name}}  <small class="dark-gray">{{disposition.action.ulurpnumber}}</small></h4>
+        <h4>{{disposition.action.dcpName}}  <small class="dark-gray">{{disposition.action.dcpUlurpnumber}}</small></h4>
         {{hearing-form
           disposition=disposition
           allActions=allActions
@@ -75,33 +75,25 @@
           <h3>Confirm hearing information</h3>
 
           {{#if allActions}}
-            <p>
-              <strong class="display-block hearing-location">
-                {{~dispositionForAllActions.dcpPublichearinglocation~}}
-              </strong>
-              <span class="hearing-date">
-                {{~moment-format dispositionForAllActions.dcpDateofpublichearing "MM/D/YYYY"~}}
-              </span>
-              <span class="light-gray">|</span>
-              <span class="hearing-time">
-                {{~moment-format dispositionForAllActions.dcpDateofpublichearing "h:mm A"~}}
-              </span>
-            </p>
-          {{else}}
-            {{#each model.dispositions as |disposition|}}
-              <p>
-                <strong class="display-block" data-test-hearing-location-confirmation="{{disposition.id}}">
-                  {{~disposition.dcpPublichearinglocation~}}
+            <li class="grid-x">
+              <div class="cell shrink small-margin-right">
+                  {{fa-icon "calendar" class="light-gray" fixedWidth=true}}
+              </div>
+              <div class="cell auto">
+                <strong class="display-block hearing-location">
+                  {{~dispositionForAllActions.dcpPublichearinglocation~}}
                 </strong>
-                <span data-test-hearing-date-confirmation="{{disposition.id}}">
-                  {{~moment-format disposition.dcpDateofpublichearing "MM/D/YYYY"~}}
+                <span class="hearing-date">
+                  {{~moment-format dispositionForAllActions.dcpDateofpublichearing "MM/D/YYYY"~}}
                 </span>
                 <span class="light-gray">|</span>
-                <span data-test-hearing-time-confirmation="{{disposition.id}}">
-                  {{~moment-format disposition.dcpDateofpublichearing "h:mm A"~}}
+                <span class="hearing-time">
+                  {{~moment-format dispositionForAllActions.dcpDateofpublichearing "h:mm A"~}}
                 </span>
-              </p>
-            {{/each}}
+              </div>
+            </li>
+          {{else}}
+            {{deduped-hearings-list project=model attribute="dcpUlurpnumber"}}
           {{/if}}
 
           <p class="callout warning text-small">

--- a/app/templates/my-projects/project/hearing/done.hbs
+++ b/app/templates/my-projects/project/hearing/done.hbs
@@ -4,12 +4,14 @@
 <LinkTo
   @route="show-project"
   @model={{this.model.id}}
+  data-test-button="back-to-project-profile"
 >
   &lt;&lt;&nbsp;Back to Project Profile
 </LinkTo>
 <br>
 <LinkTo
   @route="my-projects.to-review"
+  data-test-button="back-to-review"
 >
   &lt;&lt;&nbsp;Back to "To Review"
 </LinkTo>

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -170,38 +170,13 @@
                 <p class="text-small dark-gray"><strong>Ends 09/02/19</strong></p>
               </div>
             </div>
-              {{#if hearingsSubmitted}}
+              {{#if hearingsSubmittedForProject}}
                 {{#link-to "my-projects.project.recommendations.add" model.id}}
-                <span class="button expanded" disabled={{not hearingsSubmitted}} data-test-button-to-rec-form>
+                <span class="button expanded" disabled={{not hearingsSubmittedForProject}} data-test-button-to-rec-form>
                   Submit Participant Type Recommendation
                 </span>
                 {{/link-to}}
-                <h4 class="small-margin-bottom">Hearings</h4>
-                <ul class="no-bullet">
-                {{#each dedupedHearings as |hearing|}}
-                  <li class="grid-x">
-                    <div class="cell shrink small-margin-right">
-                      {{#if (is-before hearing.dcpDateofpublichearing)}}
-                        {{fa-icon "calendar" class="light-gray" fixedWidth=true}}
-                      {{else}}
-                        {{fa-icon "check" class="blue" fixedWidth=true}}
-                      {{/if}}
-                    </div>
-                    <div class="cell-auto">
-                      <strong class="display-block hearing-location">
-                        {{~hearing.dcpPublichearinglocation~}}
-                      </strong>
-                      <span class="hearing-date">
-                        {{~moment-format hearing.dcpDateofpublichearing "MM/D/YYYY"~}}
-                      </span>
-                      <span class="light-gray">|</span>
-                      <span class="hearing-time">
-                        {{~moment-format hearing.dcpDateofpublichearing "h:mm A"~}}
-                      </span>
-                    </div>
-                  </li>
-                {{/each}}
-                </ul>
+                {{deduped-hearings-list project=model attribute="dcpName"}}
               {{else}}
                 {{#link-to "my-projects.project.hearing.add" model.id}}
                   <span class="button expanded" data-test-button-to-hearing-form>

--- a/mirage/factories/action.js
+++ b/mirage/factories/action.js
@@ -10,7 +10,7 @@ export default Factory.extend({
   },
 
   dcpName(i) {
-    return faker.list.cycle('Zoning Special Permit', 'Zoning Text Amendment', 'Disposition of Non-Residential City-Owned Property', 'Change in City Map')(i);
+    return faker.list.cycle('Zoning Special Permit', 'Zoning Text Amendment', 'Business Improvement District', 'Change in City Map', 'Enclosed Sidewalk Cafe', 'Large Scale Special Permit', 'Zoning Certification')(i);
   },
 
   actioncode(i) {
@@ -26,7 +26,7 @@ export default Factory.extend({
   },
 
   dcpUlurpnumber(i) {
-    return faker.list.random('C780076TLK', 'N860877TCM', 'I030148MMQ')(i);
+    return faker.list.cycle('C780076TLK', 'N860877TCM', 'I030148MMQ', '200088ZMX', '190172ZMK', 'N190257ZRK', '190256ZMK')(i);
   },
 
   dcpZoningresolution(i) {

--- a/tests/acceptance/user-can-fill-out-hearing-form-test.js
+++ b/tests/acceptance/user-can-fill-out-hearing-form-test.js
@@ -135,13 +135,13 @@ module('Acceptance | user can save hearing form', function(hooks) {
     assert.notOk(find('[data-test-button="confirmHearing"]'));
 
     // ## DISPOSITION 2 #######################################################
-    await fillIn('[data-test-location-input="23"]', '135 Flowers Ave, Brooklyn, NY');
+    await fillIn('[data-test-location-input="23"]', '121 Bananas Ave, Queens, NY');
     await triggerEvent('[data-test-location-input="23"]', 'keyup');
     await click('[data-test-date-input="23"]');
-    await Pikaday.selectDate(new Date('2020-11-12T00:00:00'));
-    await fillIn('[data-test-hour-input="23"]', 5);
-    await fillIn('[data-test-minute-input="23"]', 45);
-    await selectChoose('[data-test-timeofday-dropdown="23"] .timeofday-dropdown', 'AM');
+    await Pikaday.selectDate(new Date('2020-10-21T00:00:00'));
+    await fillIn('[data-test-hour-input="23"]', 6);
+    await fillIn('[data-test-minute-input="23"]', 30);
+    await selectChoose('[data-test-timeofday-dropdown="23"] .timeofday-dropdown', 'PM');
 
     // assert that user cannot submit hearing form yet
     await click('[data-test-button="checkHearing"]');
@@ -176,12 +176,12 @@ module('Acceptance | user can save hearing form', function(hooks) {
     assert.notOk(find('[data-test-button="confirmHearing"]'));
 
     // ## DISPOSITION 5 #######################################################
-    await fillIn('[data-test-location-input="26"]', '182 Turtles Ave, Queens, NY');
+    await fillIn('[data-test-location-input="26"]', '121 Bananas Ave, Queens, NY');
     await triggerEvent('[data-test-location-input="26"]', 'keyup');
     await click('[data-test-date-input="26"]');
-    await Pikaday.selectDate(new Date('2020-11-12T00:00:00'));
-    await fillIn('[data-test-hour-input="26"]', 5);
-    await fillIn('[data-test-minute-input="26"]', 45);
+    await Pikaday.selectDate(new Date('2020-10-21T00:00:00'));
+    await fillIn('[data-test-hour-input="26"]', 6);
+    await fillIn('[data-test-minute-input="26"]', 30);
     await selectChoose('[data-test-timeofday-dropdown="26"] .timeofday-dropdown', 'PM');
 
     // assert that user cannot submit hearing form yet
@@ -194,9 +194,9 @@ module('Acceptance | user can save hearing form', function(hooks) {
       keyCode: 84, // t
     });
     await click('[data-test-date-input="27"]');
-    await Pikaday.selectDate(new Date('2020-11-12T00:00:00'));
-    await fillIn('[data-test-hour-input="27"]', 5);
-    await fillIn('[data-test-minute-input="27"]', 45);
+    await Pikaday.selectDate(new Date('2020-10-21T00:00:00'));
+    await fillIn('[data-test-hour-input="27"]', 6);
+    await fillIn('[data-test-minute-input="27"]', 30);
     await selectChoose('[data-test-timeofday-dropdown="27"] .timeofday-dropdown', 'PM');
 
     // assert that user cannot submit hearing form yet
@@ -204,32 +204,69 @@ module('Acceptance | user can save hearing form', function(hooks) {
     assert.notOk(find('[data-test-button="confirmHearing"]'));
 
     // ## DISPOSITION 7 #######################################################
-    await fillIn('[data-test-location-input="28"]', '902 Pine Tree Ave, Bronx, NY');
+    await fillIn('[data-test-location-input="28"]', '121 Bananas Ave, Queens, NY');
     await triggerEvent('[data-test-location-input="28"]', 'keyup');
     await click('[data-test-date-input="28"]');
-    await Pikaday.selectDate(new Date('2020-11-12T00:00:00'));
-    await fillIn('[data-test-hour-input="28"]', 5);
-    await fillIn('[data-test-minute-input="28"]', 45);
-    await selectChoose('[data-test-timeofday-dropdown="28"] .timeofday-dropdown', 'PM');
+    await Pikaday.selectDate(new Date('2020-10-21T00:00:00'));
+    await fillIn('[data-test-hour-input="28"]', 1);
+    await fillIn('[data-test-minute-input="28"]', 25);
+    await selectChoose('[data-test-timeofday-dropdown="28"] .timeofday-dropdown', 'AM');
 
-    // clicking on checkHearing button should open modal
+    // clicking on checkHearing button should open modal for user to review hearing input
     await click('[data-test-button="checkHearing"]');
 
-    // check that confirmHearing button in modal is present
-    assert.ok(find('[data-test-button="confirmHearing"]'));
+    // #####################################################################################################
+    // ######## Creating variables for checking if hearings list shows up correctly #########################
+    // assert that list of hearings text shows up correctly
+    const location22 = this.element.querySelector('[data-test-hearing-location="22"]').textContent;
+    const time22 = this.element.querySelector('[data-test-hearing-time="22"]').textContent;
+    const date22 = this.element.querySelector('[data-test-hearing-date="22"]').textContent;
+    const location28 = this.element.querySelector('[data-test-hearing-location="28"]').textContent;
+    const time28 = this.element.querySelector('[data-test-hearing-time="28"]').textContent;
+    const date28 = this.element.querySelector('[data-test-hearing-date="28"]').textContent;
+    // there will be three actions associated with hearing 22-- since hearing 22, 23, and 25 were duplicates
+    const action22 = this.element.querySelector('[data-test-hearing-actions-list="22"]').textContent;
+    const action23 = this.element.querySelector('[data-test-hearing-actions-list="22"]').textContent;
+    const action25 = this.element.querySelector('[data-test-hearing-actions-list="22"]').textContent;
+    // hearing 28 has the same location and date as hearing 22, but a differen time
+    const action28 = this.element.querySelector('[data-test-hearing-actions-list="28"]').textContent;
 
-    // assert that the hearing location in the modal equals the input value
-    assert.equal(this.element.querySelector('[data-test-hearing-location-confirmation="22"]').textContent, '121 Bananas Ave, Queens, NY');
-    assert.equal(this.element.querySelector('[data-test-hearing-time-confirmation="22"]').textContent, '6:30 PM');
-    assert.equal(this.element.querySelector('[data-test-hearing-date-confirmation="22"]').textContent, '10/21/2020');
+    // check that the hearing text content is correct
+    const location22Correct = location22 === '121 Bananas Ave, Queens, NY';
+    const time22Correct = time22 === '6:30 PM';
+    const date22Correct = date22 === '10/21/2020';
+    const location28Correct = location28 === '121 Bananas Ave, Queens, NY';
+    const time28Correct = time28 === '1:25 AM';
+    const date28Correct = date28 === '10/21/2020';
+    // sometimes the ulurp number is displayed, whereas sometimes the action name is displayed
+    const action22Correct = action22.includes('C780076TLK') || action22.includes('Zoning Special Permit');
+    const action23Correct = action23.includes('N860877TCM') || action23.includes('Zoning Text Amendment');
+    const action25Correct = action25.includes('190172ZMK') || action25.includes('Enclosed Sidewalk Cafe');
+    const action28Correct = action28.includes('190256ZMK') || action28.includes('Zoning Certification');
 
-    assert.equal(this.element.querySelector('[data-test-hearing-location-confirmation="25"]').textContent, '144 Piranha Ave, Manhattan, NY');
-    assert.equal(this.element.querySelector('[data-test-hearing-time-confirmation="25"]').textContent, '5:45 AM');
-    assert.equal(this.element.querySelector('[data-test-hearing-date-confirmation="25"]').textContent, '11/12/2020');
+    // variables to check all hearing and actions text at once
+    const hearingInfo = location22Correct && date22Correct && time22Correct && location28Correct && date28Correct && time28Correct;
+    const actionsInfo = action22Correct && action23Correct && action25Correct && action28Correct;
 
+    // ##################################################################################################################
+
+    // assert that hearing info in modal is correct
+    assert.ok(hearingInfo);
+    assert.ok(actionsInfo);
+
+    // officially saves the hearing info to the model
     await click('[data-test-button="confirmHearing"]');
 
     assert.equal(currentURL(), '/my-projects/4/hearing/done');
+
+    // clicking back to to-review
+    await click('[data-test-button="back-to-review"]');
+
+    assert.ok(hearingInfo);
+    assert.ok(actionsInfo);
+
+    // make sure that project 5 does not have a hearings list
+    assert.notOk(find('[data-test-hearing-location="29"]'));
   });
 
   test('user cannot submit hearing form if hour or minute contain invalid values', async function(assert) {

--- a/tests/integration/components/date-time-picker-test.js
+++ b/tests/integration/components/date-time-picker-test.js
@@ -1,4 +1,4 @@
-import { module, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -6,21 +6,44 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Component | date-time-picker', function(hooks) {
   setupRenderingTest(hooks);
 
-  skip('it renders', async function(assert) {
+  test('only date is shown on includeTimeInput=false', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`<DateTimePicker />`);
+    // Template block usage:
+    await render(hbs`
+      {{#date-time-picker
+        includeTimeInput=false}}
+      {{/date-time-picker}}
+    `);
 
-    assert.equal(this.element.textContent.trim(), '');
+    const dateTimePicker = this.element.textContent;
+    const dateCorrect = dateTimePicker.includes('Hearing Date');
+    const hourCorrect = dateTimePicker.includes('Hour');
+    const minuteCorrect = dateTimePicker.includes('Minute');
+
+    assert.ok(dateCorrect);
+    assert.notOk(hourCorrect || minuteCorrect);
+  });
+
+  test('time inputs are shown on includeTimeInput=true', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
 
     // Template block usage:
     await render(hbs`
-      <DateTimePicker>
-        template block text
-      </DateTimePicker>
+      {{#date-time-picker
+        includeTimeInput=true}}
+      {{/date-time-picker}}
     `);
 
-    assert.equal(this.element.textContent.trim(), 'template block text');
+    const dateTimePicker = this.element.textContent;
+    const dateCorrect = dateTimePicker.includes('Hearing Date');
+    const hourCorrect = dateTimePicker.includes('Hour');
+    const minuteCorrect = dateTimePicker.includes('Minute');
+
+    const timeIncluded = dateCorrect && hourCorrect && minuteCorrect;
+
+    assert.ok(timeIncluded);
   });
 });

--- a/tests/integration/components/deduped-hearings-list-test.js
+++ b/tests/integration/components/deduped-hearings-list-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | deduped-hearings-list', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('deduped-hearings-list is rendered', async function(assert) {
+    this.set('ourProject', { dispositions: [] });
+
+    await render(hbs`
+      {{deduped-hearings-list project=ourProject attribute="name" hearingsSubmitted=true}}
+    `);
+    assert.equal(this.element.textContent.trim(), 'Hearing Information');
+  });
+});

--- a/tests/integration/helpers/hearings-submitted-test.js
+++ b/tests/integration/helpers/hearings-submitted-test.js
@@ -1,0 +1,43 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { hearingsSubmitted } from 'labs-zap-search/helpers/hearings-submitted';
+
+module('Integration | Helper | hearingsSubmitted', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('returns true if hearings submitted for a project', async function(assert) {
+    const hearingDate = new Date('2020-10-21T00:00:00'); // Wednesday, October 21, 2020
+
+    this.set('dispositions', [
+      {
+        dcpPublichearinglocation: 'bananas',
+        dcpDateofpublichearing: hearingDate,
+      },
+      {
+        dcpPublichearinglocation: 'oranges',
+        dcpDateofpublichearing: hearingDate,
+      },
+    ]);
+
+    const areHearingsSubmitted = hearingsSubmitted(this.get('dispositions'));
+
+    assert.equal(areHearingsSubmitted, true);
+  });
+
+  test('returns false if hearings not submitted for a project', async function(assert) {
+    this.set('dispositions', [
+      {
+        dcpPublichearinglocation: '',
+        dcpDateofpublichearing: null,
+      },
+      {
+        dcpPublichearinglocation: '',
+        dcpDateofpublichearing: null,
+      },
+    ]);
+
+    const areHearingsSubmitted = hearingsSubmitted(this.get('dispositions'));
+
+    assert.equal(areHearingsSubmitted, false);
+  });
+});


### PR DESCRIPTION
**New Component**
- put `deduped-hearings-list` into separate component
- the deduped hearings list now concatenates action model objects for duplicate hearings --> these actions can be accessed as a new property called `hearingActions` on the `dedupedHearings` array 
- hearings list component displayed on `show-project`, `to-review`, and confirmation screen for hearing form

**New Helper**
- `hearings-submitted` is a new helper that checks whether every disposition for a project has `publichearinglocation` and `dateofpublichearing`

**Updated Tests**
- tests filled out for `date-time-picker`, `deduped-hearings-list`, `hearings-submitted`, and `user-can-fill-out-hearing-form`

TODO 1: continue to revise these tests to capture more edge cases
TODO 2: better design the list of actions in the deduped hearings list -- captured in issue #712

Closes #698 