### PR TITLE
660: user only sees rec and hearing buttons if project is assigned to user

### DIFF
--- a/app/controllers/show-project.js
+++ b/app/controllers/show-project.js
@@ -35,6 +35,23 @@ export default class ShowProjectController extends Controller {
     },
   }
 
+  @computed('user', 'model')
+  get isUserAssignedToProject() {
+    // user is from currentUser Service
+    // currentUser Service injected in show-project route on setUpController
+    if (this.session.isAuthenticated) {
+      const user = this.get('user');
+      const currentProject = this.get('model');
+
+      const userProjectIds = user.projects.map(proj => proj.dcp_name);
+
+      // check that current project is in userProjectIds array
+      const isUserAssigned = userProjectIds.includes(currentProject.dcp_name);
+
+      return isUserAssigned;
+    } return false;
+  }
+
   @computed('model')
   get hearingsSubmitted() {
     const dispositions = this.get('model.dispositions');

--- a/app/routes/show-project.js
+++ b/app/routes/show-project.js
@@ -1,13 +1,23 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class ShowProjectRoute extends Route {
+  @service
+  currentUser
+
   async model({ id }) {
     const project = await this.store.findRecord('project', id, {
       reload: true,
-      include: 'actions,milestones,dispositions',
+      include: 'actions,milestones,dispositions,users',
     });
     return project;
+  }
+
+  async setupController(controller, model) {
+    super.setupController(controller, model);
+    const userFromCurrentUser = await this.currentUser.get('user');
+    controller.set('user', userFromCurrentUser);
   }
 
   @action

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -153,7 +153,7 @@
 
       </div>
       <div class="cell large-5">
-        {{#if this.session.isAuthenticated}}
+        {{#if (and this.session.isAuthenticated isUserAssignedToProject)}}
           <div
             data-test-hearing-rec-shortcuts
             class="project--lup-section callout"

--- a/tests/acceptance/authenticated-user-sees-authenticated-features-test.js
+++ b/tests/acceptance/authenticated-user-sees-authenticated-features-test.js
@@ -24,20 +24,27 @@ module('Acceptance | authenticated user sees authenticated features', function(h
     await invalidateSession();
   });
 
-  hooks.beforeEach(async function() {
-    this.server.create('project', {
-      id: 1,
-    });
-  });
-
   test('User does not see hearing and recommendation buttons on show-project if logged out', async function(assert) {
     await visit('/projects/1');
+
     assert.notOk(find('[data-test-hearing-rec-shortcuts]'));
   });
 
-  test('User sees hearing and recommendation buttons on show-project if logged in', async function(assert) {
+  test('User sees hearing and recommendation buttons on show-project if logged in and project assigned to them', async function(assert) {
+    // user has to be signed in and assigned to that project (dcp_name matches)
+    const userProject = server.create('project', {
+      id: 1,
+      dcp_name: 'P2012M046',
+    });
+
+    this.server.create('project', {
+      id: 1,
+      dcp_name: 'P2012M046',
+    });
+
     this.server.create('user', {
       emailaddress1: 'testuser@planning.nyc.gov',
+      projects: [userProject],
     });
 
     // simulate presence of location hash after OAUTH redirect
@@ -48,5 +55,32 @@ module('Acceptance | authenticated user sees authenticated features', function(h
     await visit('/projects/1');
 
     assert.ok(find('[data-test-hearing-rec-shortcuts]'));
+  });
+
+  test('User does not see hearing and recommendation buttons on show-project if project is not assigned to them', async function(assert) {
+    // user has to be signed in and assigned to that project (dcp_name matches)
+    const userProject = server.create('project', {
+      id: 2,
+      dcp_name: 'N2018Q077',
+    });
+
+    this.server.create('project', {
+      id: 1,
+      dcp_name: 'P2012M046',
+    });
+
+    this.server.create('user', {
+      emailaddress1: 'testuser@planning.nyc.gov',
+      projects: [userProject],
+    });
+
+    // simulate presence of location hash after OAUTH redirect
+    window.location.hash = '#access_token=test';
+
+    await visit('/login');
+
+    await visit('/projects/1');
+
+    assert.notOk(find('[data-test-hearing-rec-shortcuts]'));
   });
 });

--- a/tests/unit/controllers/show-project-test.js
+++ b/tests/unit/controllers/show-project-test.js
@@ -67,4 +67,62 @@ module('Unit | Controller | show-project', function(hooks) {
 
     assert.equal(hasEmptyFeatures, 0);
   });
+
+  test('isUserAssignedToProject is false when user project ids do not match current project id', async function(assert) {
+    const controller = this.owner.lookup('controller:show-project');
+    assert.ok(controller);
+
+    const user = {
+      id: 1,
+      projects: [
+        {
+          dcp_name: 'P2012M046',
+        },
+        {
+          dcp_name: 'N2014Q176',
+        },
+      ],
+    };
+
+    const project = server.create('project', {
+      dcp_name: 'P2003B056',
+    });
+
+    const projectModel = await this.owner.lookup('service:store').findRecord('project', project.id);
+
+    controller.model = projectModel;
+    controller.user = user;
+    controller.set('session.isAuthenticated', true);
+
+    assert.equal(controller.isUserAssignedToProject, false);
+  });
+
+  test('isUserAssignedToProject is true when user project ids match current project id', async function(assert) {
+    const controller = this.owner.lookup('controller:show-project');
+    assert.ok(controller);
+
+    const user = {
+      id: 1,
+      projects: [
+        {
+          dcp_name: 'N2014Q176',
+        },
+        {
+          dcp_name: 'P2012M046',
+        },
+      ],
+    };
+
+    const project = server.create('project', {
+      dcp_name: 'P2012M046',
+    });
+
+    const projectModel = await this.owner.lookup('service:store').findRecord('project', project.id);
+
+    controller.model = projectModel;
+    controller.user = user;
+    controller.set('session.isAuthenticated', true);
+
+    assert.equal(controller.isUserAssignedToProject, true);
+  });
 });


### PR DESCRIPTION
Only show rec and hearing shortcut buttons on `show-project` route  if user IS assigned to project

- inject `currentUser` service into `show-project` route
- in computed property `isUserAssignedToProject` on `show-project` controller, check whether user's assigned projects' `dcp_name` attributes match the current project page `dcp_name` 

Closes #660 