### PR TITLE
some tabs details

### DIFF
--- a/app/styles/modules/_m-reveal-modal.scss
+++ b/app/styles/modules/_m-reveal-modal.scss
@@ -3,7 +3,11 @@
 // --------------------------------------------------
 
 .reveal-overlay {
-  position: absolute;
+  padding: 1rem;
+
+  @include breakpoint(medium) {
+    position: absolute;
+  }
 }
 
 .reveal {

--- a/app/templates/components/project-milestone.hbs
+++ b/app/templates/components/project-milestone.hbs
@@ -2,7 +2,7 @@
   {{#if (eq tense "past")}}
     <span class="milestone-icon fa-layers fa-fw">
       {{fa-icon 'circle' fixedWidth=true class='dark-gray'}}
-      {{fa-icon 'check' fixedWidth=true class='green-light' transform='shrink-6'}}
+      {{fa-icon 'check' fixedWidth=true class='blue-light' transform='shrink-6'}}
     </span>
   {{else if (eq tense "present")}}
     <span class="milestone-icon fa-layers fa-fw">

--- a/app/templates/components/to-review-project-card.hbs
+++ b/app/templates/components/to-review-project-card.hbs
@@ -26,7 +26,7 @@
             <h5 class="column-header">Hearing Information</h5>
                 <ul class="no-bullet">
                 {{#each dedupedHearings as |hearing|}}
-                  <li class="grid-x">
+                  <li class="grid-x small-margin-bottom">
                     <div class="cell shrink small-margin-right">
                       {{#if (is-before hearing.dateofpublichearing)}}
                         {{fa-icon "calendar" class="light-gray" fixedWidth=true}}

--- a/app/templates/my-projects/archive.hbs
+++ b/app/templates/my-projects/archive.hbs
@@ -13,7 +13,7 @@
     <div class="cell medium-4 large-shrink">
       <p class="text-center medium-margin-right medium-margin-left">
         <span class="display-block tiny-margin-bottom">Completed</span>
-        <span class="display-block lead small-margin-bottom"><strong class="display-inline-block">Approved</strong></span>
+        <strong class="display-block lead small-margin-bottom">Approved</strong>
         <span class="display-block">June 12, 2018</span>
       </p>
     </div>

--- a/app/templates/my-projects/archive.hbs
+++ b/app/templates/my-projects/archive.hbs
@@ -13,60 +13,71 @@
     <div class="cell medium-4 large-shrink">
       <p class="text-center medium-margin-right medium-margin-left">
         <span class="display-block tiny-margin-bottom">Completed</span>
-        <span class="display-block lead small-margin-bottom"><strong>Approved</strong></span>
+        <span class="display-block lead small-margin-bottom"><strong class="display-inline-block">Approved</strong></span>
         <span class="display-block">June 12, 2018</span>
       </p>
     </div>
     <div class="cell medium-auto">
       <ul class="no-bullet no-margin">
-        <li class="grid-x">
+        <li class="grid-x small-margin-bottom">
           <div class="cell shrink small-margin-right">
-            {{fa-icon 'thumbs-down' class='red-muted' fixedWidth=true}}
+            {{fa-icon 'check' class='blue' fixedWidth=true}}
           </div>
           <div class="cell auto">
-            <p class="small-margin-bottom">
-              <strong>Community Board</strong> Disapproved with changes
-            </p>
+            <strong class="display-inline-block">Community Board Review</strong>
+            <span class="display-inline-block">
+              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
+              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
+              {{fa-icon 'thumbs-down' class='red-muted' fixedWidth=true}}
+              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
+            </span>
+            <small class="display-inline-block">Smarch 3, 1999</small>
           </div>
         </li>
-        <li class="grid-x">
+        <li class="grid-x small-margin-bottom">
           <div class="cell shrink small-margin-right">
-            {{fa-icon 'comment-slash' class='gray' fixedWidth=true}}
+            {{fa-icon 'check' class='blue' fixedWidth=true}}
           </div>
           <div class="cell auto">
-            <p class="small-margin-bottom">
-              <strong>Borough President</strong> Waived Recommendation
-            </p>
+            <strong class="display-inline-block">Borough President Review</strong>
+            <span class="display-inline-block">
+              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
+              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
+              {{fa-icon 'thumbs-down' class='red-muted' fixedWidth=true}}
+              {{fa-icon 'comment-slash' class='gray' fixedWidth=true}}
+            </span>
+            <small class="display-inline-block">Smarch 13, 1999</small>
           </div>
         </li>
-        <li class="grid-x">
+        <li class="grid-x small-margin-bottom">
           <div class="cell shrink small-margin-right">
-            {{fa-icon 'thumbs-up' class='green-dark' fixedWidth=true}}
+            {{fa-icon 'check' class='blue' fixedWidth=true}}
           </div>
           <div class="cell auto">
-            <p class="small-margin-bottom">
-              <strong>City Planning Commission</strong> Approved with changes
-            </p>
+            <strong class="display-inline-block">City Planning Commission Review</strong>
+            <span class="display-inline-block">
+              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
+              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
+              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
+              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
+            </span>
+            <small class="display-inline-block">Smarch 23, 1999</small>
           </div>
         </li>
-        <li class="grid-x">
+        <li class="grid-x small-margin-bottom">
           <div class="cell shrink small-margin-right">
-            {{fa-icon 'thumbs-up' class='green-dark' fixedWidth=true}}
+            {{fa-icon 'hourglass-half' class='blue' fixedWidth=true}}
           </div>
           <div class="cell auto">
-            <p class="small-margin-bottom">
-              <strong>City Council</strong> Approved
-            </p>
+            <strong class="display-inline-block">City Council Review</strong>
           </div>
         </li>
-        <li class="grid-x">
+        <li class="grid-x small-margin-bottom">
           <div class="cell shrink small-margin-right">
-            {{fa-icon 'thumbs-up' class='green-dark' fixedWidth=true}}
+            {{fa-icon 'calendar' class='light-gray' fixedWidth=true}}
           </div>
           <div class="cell auto">
-            <p class="small-margin-bottom">
-              <strong>Mayor</strong> No Veto
-            </p>
+            <strong class="display-inline-block">Mayor Review</strong>
           </div>
         </li>
       </ul>

--- a/app/templates/my-projects/reviewed.hbs
+++ b/app/templates/my-projects/reviewed.hbs
@@ -21,7 +21,7 @@
               <div class="cell shrink small-margin-right">
                 {{#if (eq milestone.statuscode "Completed")}}
                   <span data-test={{if (string-includes milestone.milestonename "Referral") "reviewed-indicator"}}>
-                    {{fa-icon 'check' class='green-dark' fixedWidth=true}}
+                    {{fa-icon 'check' class='blue' fixedWidth=true}}
                   </span>
                 {{else if (eq milestone.statuscode "Overridden")}}
                   {{fa-icon 'stop' class='red-dark' fixedWidth=true}}

--- a/app/templates/my-projects/upcoming.hbs
+++ b/app/templates/my-projects/upcoming.hbs
@@ -24,7 +24,7 @@
       <div class="cell medium-auto">
         <ul class="no-bullet no-margin">
           {{#each project.milestones as |milestone|}}
-            <li class="grid-x">
+            <li class="grid-x small-margin-bottom">
               <div class="cell shrink small-margin-right">
                 {{#if (eq milestone.statuscode "Completed")}}
                   {{fa-icon 'check' class='blue' fixedWidth=true}}
@@ -37,10 +37,8 @@
                 {{/if}}
               </div>
               <div class="cell auto">
-                <p class="small-margin-bottom">
-                  <strong>{{milestone.milestonename}}</strong>
-                  <small class="display-block">{{milestone.displayDate}}</small>
-                </p>
+                <strong class="display-inline-block">{{milestone.milestonename}}</strong>
+                <small class="display-inline-block">{{milestone.displayDate}}</small>
               </div>
             </li>
           {{/each}}

--- a/app/templates/my-projects/upcoming.hbs
+++ b/app/templates/my-projects/upcoming.hbs
@@ -27,7 +27,7 @@
             <li class="grid-x">
               <div class="cell shrink small-margin-right">
                 {{#if (eq milestone.statuscode "Completed")}}
-                  {{fa-icon 'check' class='green-dark' fixedWidth=true}}
+                  {{fa-icon 'check' class='blue' fixedWidth=true}}
                 {{else if (eq milestone.statuscode "Overridden")}}
                   {{fa-icon 'stop' class='red-dark' fixedWidth=true}}
                 {{else if (eq milestone.statuscode "Not Started")}}

--- a/mirage/factories/project.js
+++ b/mirage/factories/project.js
@@ -91,7 +91,7 @@ export default Factory.extend({
   },
 
   dcp_projectbrief() {
-    return `${faker.lorem.sentences()}. [Test](https://google.com)`;
+    return faker.lorem.paragraph(7);
   },
 
   dcp_projectname() {


### PR DESCRIPTION
This PR fixes up some details in the My Projects tabs

- improve faker `dcp_projectbrief` to make it a more likely length of text
- use blue for milestone check (green implies good outcome)
- improve the markup in the hardcoded prototype for the archive tab, using right icons from the wireframe
- improve upcoming tab markup
- add bottom margin to hearings in to review tab
- fix modal layout on small screens