### PR TITLE
720 mirage endpoints for tabs

### DIFF
--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -608,8 +608,8 @@ export default function(server) {
 
   // "SEVENTH" CB PROJECT (Archived)
   seedCBUserProjects[6].update({
-    tab: 'archived',
-    dcpPublicstatusSimp: 'approved',
+    tab: 'archive',
+    dcp_publicstatus_simp: 'approved',
   });
 
   server.create('milestone', 'certifiedReferred', {


### PR DESCRIPTION
Sets up a Mirage endpoint mimicking ZAP-API's endpoint for projects filtered by tab.

Current only loads projects for a CB user. If we build out Mirage functionality for logging in as different users, we should update this endpoint to filter to the logged in user.

Note that the "Upcoming" and the "Archive" tab needs some more code in its Route to dynamically feed the tab a list of projects. They should  be tackled in #662 and  #627, respectively