### PR TITLE
662 display milestone days remaining and duration on project cards

### DIFF
--- a/app/components/reviewed-project-card.js
+++ b/app/components/reviewed-project-card.js
@@ -1,0 +1,20 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+import moment from 'moment';
+
+export default class ReviewedProjectCardComponent extends Component {
+  @service
+  currentUser;
+
+  project = {};
+
+  @computed('project.reviewedMilestoneActualStartEndDates')
+  get timeDisplays() {
+    return this.project.reviewedMilestoneActualStartEndDates.map(startEndDate => ({
+      displayName: startEndDate.displayName,
+      timeRemaining: moment(startEndDate.dcpActualenddate).diff(moment().endOf('day'), 'days'),
+      timeDuration: moment(startEndDate.dcpActualenddate).diff(moment(startEndDate.dcpActualstartdate), 'days'),
+    }));
+  }
+}

--- a/app/components/to-review-project-card.js
+++ b/app/components/to-review-project-card.js
@@ -2,10 +2,23 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { hearingsSubmitted } from 'labs-zap-search/helpers/hearings-submitted';
+import moment from 'moment';
 
 export default class ToReviewProjectCardComponent extends Component {
   @service
   currentUser;
+
+  project = {};
+
+  @computed('project.toReviewMilestoneActualEndDate')
+  get timeRemaining() {
+    return moment(this.project.toReviewMilestoneActualEndDate).diff(moment().endOf('day'), 'days');
+  }
+
+  @computed('project.{toReviewMilestoneActualStartDate,toReviewMilestoneActualEndDate}')
+  get timeDuration() {
+    return moment(this.project.toReviewMilestoneActualEndDate).diff(moment(this.project.toReviewMilestoneActualStartDate), 'days');
+  }
 
   // hearingsSubmitted is a helper that iterates through each disposition
   // and checks whether disposition has publichearinglocation and dateofpublichearing

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -99,25 +99,15 @@ export default class ProjectModel extends Model {
   //   - these start/end dates come from the current In Progress milestone
   //   - an array of milestone dates is returned
   @computed('tab', 'teammemberrole', 'milestones')
-  get reviewedMilestoneActualStartDate() {
+  get reviewedMilestoneActualStartEndDates() {
     if (this.tab !== 'reviewed') {
       return null;
     }
     const inProgressMilestones = this.milestones.filter(milestone => milestone.statuscode === 'In Progress');
     return inProgressMilestones.map(milestone => ({
       milestone: milestone.dcpMilestone,
+      displayName: milestone.displayName,
       dcpActualstartdate: milestone.dcpActualstartdate,
-    }));
-  }
-
-  @computed('tab', 'teammemberrole', 'milestones')
-  get reviewedMilestoneActualEndDate() {
-    if (this.tab !== 'reviewed') {
-      return null;
-    }
-    const inProgressMilestones = this.milestones.filter(milestone => milestone.statuscode === 'In Progress');
-    return inProgressMilestones.map(milestone => ({
-      milestone: milestone.dcpMilestone,
       dcpActualenddate: milestone.dcpActualenddate,
     }));
   }

--- a/app/routes/my-projects/reviewed.js
+++ b/app/routes/my-projects/reviewed.js
@@ -8,13 +8,11 @@ export default class MyProjectsReviewedRoute extends Route {
   @service
   store;
 
-  // This route loads the user's projects according to their milestones and associated userProjectParticipantTypes.
-  // Specifically, a given user's project only shows up here if...
-  // 1) it has an "Review" (a.k.a. "Referral") milestone that has a statuscode of "Not Started"
-  // 2) it matches one of the project's -- and the current user's -- associated userProjectParticipantTypes
-  // For example, for a Borough President user, a project shows up here if it has an "Reviewed" Borough President Referral milestone.
   async model() {
-    // Use this endpoint for now. This will need to be updated when the backend is finalized.
-    return this.store.query('project', { project_lup_status: 'reviewed' });
+    const reviewedProjects = await this.store.query('project', { project_lup_status: 'reviewed', include: 'actions,milestones,dispositions.action' }, {
+      reload: true,
+    });
+
+    return reviewedProjects;
   }
 }

--- a/app/routes/my-projects/to-review.js
+++ b/app/routes/my-projects/to-review.js
@@ -8,14 +8,8 @@ export default class MyProjectsToReviewRoute extends Route {
   @service
   store;
 
-  // This route loads the user's projects according to their milestones and associated userProjectParticipantTypes.
-  // Specifically, a given user's project only shows up here if...
-  // 1) it has an "Review" (a.k.a. "Referral") milestone that has a statuscode of "In Progress"
-  // 2) it matches one of the project's -- and the current user's -- associated userProjectParticipantTypes
-  // For example, for a Borough President user, a project shows up here if it has an "In Progress" Borough President Referral milestone.
   async model() {
-    // Use this endpoint for now. This will need to be updated when the backend is finalized.
-    return this.store.query('project', { project_lup_status: 'to-review', include: 'actions,dispositions.action' }, {
+    return this.store.query('project', { project_lup_status: 'to-review', include: 'actions,milestones,dispositions.action' }, {
       reload: true,
     });
   }

--- a/app/routes/my-projects/upcoming.js
+++ b/app/routes/my-projects/upcoming.js
@@ -8,13 +8,10 @@ export default class MyProjectsUpcomingRoute extends Route {
   @service
   store;
 
-  // This route loads the user's projects according to their milestones and associated userProjectParticipantTypes.
-  // Specifically, a given user's project only shows up here if...
-  // 1) it has an "Review" (a.k.a. "Referral") milestone that has a statuscode of "Not Started"
-  // 2) it matches one of the project's -- and the current user's -- associated userProjectParticipantTypes
-  // For example, for a Borough President user, a project shows up here if it has an "Not Started" Borough President Referral milestone.
   async model() {
-    // Use this endpoint for now. This will need to be updated when the backend is finalized.
-    return this.store.query('project', { project_lup_status: 'upcoming' });
+    const upcomingProjects = await this.store.query('project', { project_lup_status: 'upcoming', include: 'actions,milestones,dispositions.action' }, {
+      reload: true,
+    });
+    return upcomingProjects;
   }
 }

--- a/app/templates/components/reviewed-project-card.hbs
+++ b/app/templates/components/reviewed-project-card.hbs
@@ -1,0 +1,56 @@
+<div
+    class="project-summary-card callout"
+    data-test-project-card
+  >
+    <div class="grid-x grid-x-small-gutters">
+      <div class="cell large-6">
+        <h3 class="tiny-margin-bottom">
+          {{#link-to 'show-project' this.projectid}}{{this.projectdcpProjectname}}{{/link-to}}
+          <small class="dark-gray">{{this.projectdcpUlurpNonulurp}}</small>
+        </h3>
+        <h5 class="applicant">{{this.projectapplicants}}</h5>
+        <p>{{this.projectdcpProjectbrief}}</p>
+      </div>
+      <div class="cell medium-4 large-shrink">
+        {{#each this.timeDisplays as |timeDisplay|}}
+          <div class="lup-countdown medium-margin-right medium-margin-left">
+            <p class="cert-date">{{timeDisplay.displayName}}</p>
+            <p class="days">{{timeDisplay.timeRemaining}}</p>
+            <p class="total">of {{timeDisplay.timeDuration}} days remain</p>
+            <p class="end-date">Ends {{moment-format this.project.actualenddate "M/D/YYYY"}}</p>
+          </div>
+        {{/each}}
+      </div>
+      <div class="cell medium-auto">
+        <ul class="no-bullet no-margin">
+          {{#each this.project.milestones as |milestone|}}
+            <li class="grid-x">
+              <div class="cell shrink small-margin-right">
+                {{#if (eq milestone.statuscode "Completed")}}
+                  <span data-test={{if (string-includes milestone.milestonename "Referral") "reviewed-indicator"}}>
+                    {{fa-icon 'check' class='blue' fixedWidth=true}}
+                  </span>
+                {{else if (eq milestone.statuscode "Overridden")}}
+                  {{fa-icon 'stop' class='red-dark' fixedWidth=true}}
+                {{else}}
+                  {{fa-icon 'calendar' class='light-gray' fixedWidth=true}}
+                {{/if}}
+              </div>
+              <div class="cell auto">
+                <p class="small-margin-bottom">
+                  <strong>{{milestone.milestonename}}</strong>
+                  <small class="display-block">{{milestone.displayDate}}</small>
+                </p>
+              </div>
+            </li>
+          {{/each}}
+        </ul>
+      </div>
+      <div class="cell medium-auto">
+        <ul class="no-bullet no-margin">
+          {{!-- TODO: Figure out what this loop was supposed to be --}}
+        </ul>
+      </div>
+    </div>
+  </div>
+  

--- a/app/templates/components/to-review-project-card.hbs
+++ b/app/templates/components/to-review-project-card.hbs
@@ -13,10 +13,10 @@
     </div>
     <div class="cell medium-4 large-shrink">
       <div class="lup-countdown medium-margin-right medium-margin-left">
-        <p class="cert-date">Certified 11/08/2019</p>
-        <p class="days">8</p>
-        <p class="total">of 60 days remain</p>
-        <p class="end-date">Ends 12/15/19</p>
+        <p class="cert-date">Community Board Review</p>
+        <p class="days">{{timeRemaining}}</p>
+        <p class="total">of {{timeDuration}} days remain</p>
+        <p class="end-date">Ends {{moment-format project.actualenddate "M/D/YYYY"}}</p>
       </div>
     </div>
     <div class="cell medium-8 large-auto">

--- a/app/templates/my-projects/reviewed.hbs
+++ b/app/templates/my-projects/reviewed.hbs
@@ -1,51 +1,7 @@
 <h5>Projects that you have reviewed which are still in the public review process</h5>
 
 {{#each this.model as |project|}}
-  <div
-    class="project-summary-card callout"
-    data-test-project-card
-  >
-    <div class="grid-x grid-x-small-gutters">
-      <div class="cell large-6">
-        <h3 class="tiny-margin-bottom">
-          {{#link-to 'show-project' project.id}}{{project.dcpProjectname}}{{/link-to}}
-          <small class="dark-gray">{{project.dcpUlurpNonulurp}}</small>
-        </h3>
-        <h5 class="applicant">{{project.applicants}}</h5>
-        <p>{{project.dcpProjectbrief}}</p>
-      </div>
-      <div class="cell medium-auto">
-        <ul class="no-bullet no-margin">
-          {{#each project.milestones as |milestone|}}
-            <li class="grid-x">
-              <div class="cell shrink small-margin-right">
-                {{#if (eq milestone.statuscode "Completed")}}
-                  <span data-test={{if (string-includes milestone.milestonename "Referral") "reviewed-indicator"}}>
-                    {{fa-icon 'check' class='blue' fixedWidth=true}}
-                  </span>
-                {{else if (eq milestone.statuscode "Overridden")}}
-                  {{fa-icon 'stop' class='red-dark' fixedWidth=true}}
-                {{else}}
-                  {{fa-icon 'calendar' class='light-gray' fixedWidth=true}}
-                {{/if}}
-              </div>
-              <div class="cell auto">
-                <p class="small-margin-bottom">
-                  <strong>{{milestone.milestonename}}</strong>
-                  <small class="display-block">{{milestone.displayDate}}</small>
-                </p>
-              </div>
-            </li>
-          {{/each}}
-        </ul>
-      </div>
-      <div class="cell medium-auto">
-        <ul class="no-bullet no-margin">
-          {{!-- TODO: Figure out what this loop was supposed to be --}}
-        </ul>
-      </div>
-    </div>
-  </div>
+  {{reviewed-project-card project=project}}
 {{/each}}
 
 {{outlet}}

--- a/app/templates/my-projects/upcoming.hbs
+++ b/app/templates/my-projects/upcoming.hbs
@@ -16,8 +16,26 @@
       </div>
       <div class="cell medium-4 large-shrink">
         <p class="text-center medium-margin-right medium-margin-left">
-          <span class="display-block tiny-margin-bottom">Public Review</span>
-          <span class="display-block lead small-margin-bottom"><strong>June 12, 2018</strong></span>
+          {{#if (eq project.upcomingMilestonePlannedStartDate)}}
+            <span class="display-block tiny-margin-bottom">
+              Borough President<br>
+              Review Begins
+            </span>
+            <span class="display-block lead small-margin-bottom">
+              <strong>
+                {{moment-format project.upcomingMilestonePlannedStartDate "M/D/YYYY"}}
+              </strong>
+            </span>
+          {{else}}
+            <span class="display-block tiny-margin-bottom">
+              Public Review Begins
+            </span>
+            <span class="display-block lead small-margin-bottom">
+              <strong>
+                {{moment-format project.publicReviewPlannedStartDate "M/D/YYYY"}}
+              </strong>
+            </span>
+          {{/if}}
           <span class="display-block text-tiny">(Estimated Start Date)</span>
         </p>
       </div>

--- a/tests/integration/components/reviewed-project-card-test.js
+++ b/tests/integration/components/reviewed-project-card-test.js
@@ -1,0 +1,19 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { find, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | reviewed-project-card', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    this.set('project', { reviewedMilestoneActualStartEndDates: [] });
+
+    await render(hbs`{{reviewed-project-card project=this.project}}`);
+
+    assert.ok(find('[data-test-project-card]'));
+  });
+});


### PR DESCRIPTION
Displays Milestone-based remaining/duration time on upcoming, to-review and reviewed tabs. Based off of the "ZAP LUP Tabs" wireframes. 

Note that on the upcoming page, since we only have mock data for the Borough President, the Borough President is hardcoded above the milestone remaining/duration time for the condition "in public review but not yet participant's review". Same for Community Board in the `to-review-proejct-card.hbs`.