### PR TITLE
627: plug in mirage data on archive tab

### DIFF
--- a/app/models/project.js
+++ b/app/models/project.js
@@ -153,7 +153,11 @@ export default class ProjectModel extends Model {
 
   @attr('string') dcpProjectname;
 
+  @attr('string', { defaultValue: '' }) publicStatus;
+
   @attr('string', { defaultValue: '' }) dcpPublicstatusSimp;
+
+  @attr('string') projectCompleted;
 
   @attr() dcpHiddenprojectmetrictarget;
 

--- a/app/routes/my-projects/archive.js
+++ b/app/routes/my-projects/archive.js
@@ -1,4 +1,15 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class MyProjectsArchiveRoute extends Route {
+  @service
+  currentUser;
+
+  @service
+  store;
+
+  async model() {
+    // Use this endpoint for now. This will need to be updated when the backend is finalized.
+    return this.store.query('project', { project_lup_status: 'archive' });
+  }
 }

--- a/app/templates/my-projects/archive.hbs
+++ b/app/templates/my-projects/archive.hbs
@@ -1,88 +1,50 @@
 <h5>Archive of projects that you have reviewed which are no longer in the public review process</h5>
 
-<div class="project-summary-card callout">
-  <div class="grid-x grid-x-small-gutters">
-    <div class="cell large-6">
-      <h3 class="tiny-margin-bottom">
-        <a>101 Fleet Place Rezoning</a>
-        <small class="dark-gray">ULURP</small>
-      </h3>
-      <h5 class="applicant">Fleet Center, Inc.</h5>
-      <p>This is a private application by Fleet Center, Inc. for a zoning map amendment from R6 to C6-4 and zoning text amendment to expand the Special Downtown Brooklyn district and create a new MIH area to facilitate a new 205,000 square foot commercial office building at 101 Fleet Place in the Downtown Brooklyn area of Brooklyn Community District 2.</p>
-    </div>
-    <div class="cell medium-4 large-shrink">
-      <p class="text-center medium-margin-right medium-margin-left">
-        <span class="display-block tiny-margin-bottom">Completed</span>
-        <strong class="display-block lead small-margin-bottom">Approved</strong>
-        <span class="display-block">June 12, 2018</span>
-      </p>
-    </div>
-    <div class="cell medium-auto">
-      <ul class="no-bullet no-margin">
-        <li class="grid-x small-margin-bottom">
-          <div class="cell shrink small-margin-right">
-            {{fa-icon 'check' class='blue' fixedWidth=true}}
-          </div>
-          <div class="cell auto">
-            <strong class="display-inline-block">Community Board Review</strong>
-            <span class="display-inline-block">
-              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
-              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
-              {{fa-icon 'thumbs-down' class='red-muted' fixedWidth=true}}
-              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
-            </span>
-            <small class="display-inline-block">Smarch 3, 1999</small>
-          </div>
-        </li>
-        <li class="grid-x small-margin-bottom">
-          <div class="cell shrink small-margin-right">
-            {{fa-icon 'check' class='blue' fixedWidth=true}}
-          </div>
-          <div class="cell auto">
-            <strong class="display-inline-block">Borough President Review</strong>
-            <span class="display-inline-block">
-              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
-              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
-              {{fa-icon 'thumbs-down' class='red-muted' fixedWidth=true}}
-              {{fa-icon 'comment-slash' class='gray' fixedWidth=true}}
-            </span>
-            <small class="display-inline-block">Smarch 13, 1999</small>
-          </div>
-        </li>
-        <li class="grid-x small-margin-bottom">
-          <div class="cell shrink small-margin-right">
-            {{fa-icon 'check' class='blue' fixedWidth=true}}
-          </div>
-          <div class="cell auto">
-            <strong class="display-inline-block">City Planning Commission Review</strong>
-            <span class="display-inline-block">
-              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
-              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
-              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
-              {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
-            </span>
-            <small class="display-inline-block">Smarch 23, 1999</small>
-          </div>
-        </li>
-        <li class="grid-x small-margin-bottom">
-          <div class="cell shrink small-margin-right">
-            {{fa-icon 'hourglass-half' class='blue' fixedWidth=true}}
-          </div>
-          <div class="cell auto">
-            <strong class="display-inline-block">City Council Review</strong>
-          </div>
-        </li>
-        <li class="grid-x small-margin-bottom">
-          <div class="cell shrink small-margin-right">
-            {{fa-icon 'calendar' class='light-gray' fixedWidth=true}}
-          </div>
-          <div class="cell auto">
-            <strong class="display-inline-block">Mayor Review</strong>
-          </div>
-        </li>
-      </ul>
+{{#each this.model as |project|}}
+  <div
+    class="project-summary-card callout"
+    data-test-project-card
+  >
+    <div class="grid-x grid-x-small-gutters">
+      <div class="cell large-6">
+        <h3 class="tiny-margin-bottom">
+          {{#link-to 'show-project' project.id}}{{project.dcpProjectname}}{{/link-to}}
+          <small class="dark-gray">{{project.dcpUlurpNonulurp}}</small>
+        </h3>
+        <h5 class="applicant">{{project.applicants}}</h5>
+        <p>{{project.dcpProjectbrief}}</p>
+      </div>
+      <div class="cell medium-4 large-shrink">
+        <p class="text-center medium-margin-right medium-margin-left">
+          <strong class="display-block lead small-margin-bottom">{{project.publicStatus}}</strong>
+          <span class="display-block">{{moment-format project.projectCompleted "M/D/YYYY"}}</span>
+        </p>
+      </div>
+      <div class="cell medium-auto">
+        <ul class="no-bullet no-margin">
+          {{#each project.milestones as |milestone|}}
+            <li class="grid-x small-margin-bottom">
+              <div class="cell shrink small-margin-right">
+                {{#if (eq milestone.statuscode "Completed")}}
+                  {{fa-icon 'check' class='blue' fixedWidth=true}}
+                {{else if (eq milestone.statuscode "Overridden")}}
+                  {{fa-icon 'stop' class='red-dark' fixedWidth=true}}
+                {{else if (eq milestone.statuscode "Not Started")}}
+                  <span data-test={{if (string-includes milestone.milestonename "Referral") "upcoming-indicator"}}>
+                    {{fa-icon 'calendar' class='light-gray' fixedWidth=true}}
+                  </span>
+                {{/if}}
+              </div>
+              <div class="cell auto">
+                <strong class="display-inline-block">{{milestone.milestonename}}</strong>
+                <small class="display-inline-block">{{milestone.displayDate}}</small>
+              </div>
+            </li>
+          {{/each}}
+        </ul>
+      </div>
     </div>
   </div>
-</div>
+{{/each}}
 
 {{outlet}}

--- a/mirage/factories/project.js
+++ b/mirage/factories/project.js
@@ -101,12 +101,16 @@ export default Factory.extend({
     `;
   },
 
-  dcpPublicstatus() {
+  publicStatus() {
     return faker.random.arrayElement(['Active', 'Approved', 'Withdrawn']);
   },
 
   dcpPublicstatusSimp() {
-    return faker.random.arrayElement(['Active', 'Approved', 'Withdrawn']);
+    return faker.random.arrayElement(['Filed', 'In Public Review', 'Completed']);
+  },
+
+  projectCompleted() {
+    return faker.date.past();
   },
 
   dcpHiddenprojectmetrictarget() {

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -609,7 +609,8 @@ export default function(server) {
   // "SEVENTH" CB PROJECT (Archived)
   seedCBUserProjects[6].update({
     tab: 'archive',
-    dcp_publicstatus_simp: 'approved',
+    publicStatus: 'Approved',
+    projectCompleted: moment().subtract(15, 'days'),
   });
 
   server.create('milestone', 'certifiedReferred', {


### PR DESCRIPTION
This PR:
- Updates the "Archive" template and route so that it uses project and milestone model values
- Adds two new attributes to the project model. **Note: These will require API changes, since neither of them are currently provided by the API (Attn: @allthesignals )**
  - `publicStatus` maps to `dcp_publicstatus` in the CRM project entity. It provides values like 'Approved' or 'Withdrawn' which the API recodes into `dcpPublicstatusSimp` = 'Completed'. We need more granularity than the simplified 'Completed' value provided in `dcpPublicstatusSimp`
  - `projectCompleted` maps to `dcp_projectcompleted` in the CRM project entity. It provides the date that the project became complete
- Updates mirage data to provide attributes for `publicStatus` and `projectCompleted`

Addresses #627 