### PR TITLE
add milestones to archive route

### DIFF
--- a/app/routes/my-projects/archive.js
+++ b/app/routes/my-projects/archive.js
@@ -10,6 +10,9 @@ export default class MyProjectsArchiveRoute extends Route {
 
   async model() {
     // Use this endpoint for now. This will need to be updated when the backend is finalized.
-    return this.store.query('project', { project_lup_status: 'archive' });
+    const archiveProjects = await this.store.query('project', { project_lup_status: 'archive', include: 'actions,milestones,dispositions.action' }, {
+      reload: true,
+    });
+    return archiveProjects;
   }
 }


### PR DESCRIPTION
Updates the archive route to obtain the necessary milestones when the tab is loaded. Now it matches the rest of the tab routes.