### PR TITLE
733 format milestone dates, display dispo datereceived

### DIFF
--- a/app/components/archive-project-milestone-list-item.js
+++ b/app/components/archive-project-milestone-list-item.js
@@ -1,0 +1,47 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default class ArchiveProjectMilestoneListItemComponent extends Component {
+  @service
+  milestoneConstants;
+
+  project = {};
+
+  milestone = {};
+
+  @computed('project.dispositions')
+  get communityBoardDispositions() {
+    return this.project.dispositions.filter(disposition => disposition.communityboardrecommendation);
+  }
+
+  // Since all CB dispositions should have the same "datereceived", get the first one that's defined.
+  // TODO: Later, if we break out review outcomes by community board (for projects with multiple CBs),
+  // we should also get community board dispositions datereceived per community board.
+  @computed('communityBoardDispositions')
+  get anyCommunityBoardDispositionDateReceived() {
+    return this.communityBoardDispositions.map(disposition => disposition.datereceived).find(datereceived => !!datereceived);
+  }
+
+  @computed('project.dispositions')
+  get boroughBoardDispositions() {
+    return this.project.dispositions.filter(disposition => disposition.boroughboardrecommendation);
+  }
+
+  // The comment for anyCommunityBoardDispositionDateReceived applies here as well.
+  @computed('boroughBoardDispositions')
+  get anyBoroughBoardDispositionDateReceived() {
+    return this.boroughBoardDispositions.map(disposition => disposition.datereceived).find(datereceived => !!datereceived);
+  }
+
+  @computed('project.dispositions')
+  get boroughPresidentDispositions() {
+    return this.project.dispositions.filter(disposition => disposition.boroughpresidentrecommendation);
+  }
+
+  // The comment for anyCommunityBoardDispositionDateReceived applies here as well.
+  @computed('boroughPresidentDispositions')
+  get anyBoroughPresidentDispositionDateReceived() {
+    return this.boroughPresidentDispositions.map(disposition => disposition.datereceived).find(datereceived => !!datereceived);
+  }
+}

--- a/app/components/recommendation-result-icon.js
+++ b/app/components/recommendation-result-icon.js
@@ -1,0 +1,7 @@
+import Component from '@ember/component';
+
+export default class RecommendationResultIconComponent extends Component {
+  tagName = '';
+
+  recommendation = '';
+}

--- a/app/components/reviewed-project-card.js
+++ b/app/components/reviewed-project-card.js
@@ -7,9 +7,6 @@ export default class ReviewedProjectCardComponent extends Component {
   @service
   currentUser;
 
-  @service
-  milestoneConstants;
-
   project = {};
 
   @computed('project.reviewedMilestoneActualStartEndDates')

--- a/app/components/reviewed-project-milestone-list-item.js
+++ b/app/components/reviewed-project-milestone-list-item.js
@@ -1,0 +1,47 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
+
+export default class ReviewedProjectMilestoneListItemComponent extends Component {
+  @service
+  milestoneConstants;
+
+  project = {};
+
+  milestone = {};
+
+  @computed('project.dispositions')
+  get communityBoardDispositions() {
+    return this.project.dispositions.filter(disposition => disposition.communityboardrecommendation);
+  }
+
+  // Since all CB dispositions should have the same "datereceived", get the first one that's defined.
+  // TODO: Later, if we break out review outcomes by community board (for projects with multiple CBs),
+  // we should also get community board dispositions datereceived per community board.
+  @computed('communityBoardDispositions')
+  get anyCommunityBoardDispositionDateReceived() {
+    return this.communityBoardDispositions.map(disposition => disposition.datereceived).find(datereceived => !!datereceived);
+  }
+
+  @computed('project.dispositions')
+  get boroughBoardDispositions() {
+    return this.project.dispositions.filter(disposition => disposition.boroughboardrecommendation);
+  }
+
+  // The comment for anyCommunityBoardDispositionDateReceived applies here as well.
+  @computed('boroughBoardDispositions')
+  get anyBoroughBoardDispositionDateReceived() {
+    return this.boroughBoardDispositions.map(disposition => disposition.datereceived).find(datereceived => !!datereceived);
+  }
+
+  @computed('project.dispositions')
+  get boroughPresidentDispositions() {
+    return this.project.dispositions.filter(disposition => disposition.boroughpresidentrecommendation);
+  }
+
+  // The comment for anyCommunityBoardDispositionDateReceived applies here as well.
+  @computed('boroughPresidentDispositions')
+  get anyBoroughPresidentDispositionDateReceived() {
+    return this.boroughPresidentDispositions.map(disposition => disposition.datereceived).find(datereceived => !!datereceived);
+  }
+}

--- a/app/templates/components/archive-project-card.hbs
+++ b/app/templates/components/archive-project-card.hbs
@@ -20,61 +20,10 @@
     <div class="cell medium-auto">
       <ul class="no-bullet no-margin">
         {{#each this.project.tabSpecificMilestones as |milestone|}}
-          <li class="grid-x small-margin-bottom">
-            <div class="cell shrink small-margin-right">
-              {{#if (eq milestone.statuscode "Completed")}}
-                {{fa-icon 'check' class='blue' fixedWidth=true}}
-              {{else if (eq milestone.statuscode "Overridden")}}
-                {{fa-icon 'stop' class='red-dark' fixedWidth=true}}
-              {{else if (eq milestone.statuscode "Not Started")}}
-                <span data-test={{if (string-includes milestone.milestonename "Referral") "upcoming-indicator"}}>
-                  {{fa-icon 'calendar' class='light-gray' fixedWidth=true}}
-                </span>
-              {{/if}}
-            </div>
-            <div class="cell auto {{if (eq milestone.statuscode "Not Started") 'gray'}}">
-              <strong>
-                {{milestone.milestonename}}
-              </strong>
-              {{#each this.project.dispositions as |disposition|}}
-                {{#if (eq milestone.dcpMilestone this.milestoneConstants.COMMUNITY_BOARD_REFERRAL)}}
-                  {{#if (or (eq disposition.communityboardrecommendation "Approved") (eq disposition.communityboardrecommendation "Approved with Modifications/Conditions"))}}
-                    {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
-                  {{/if}}
-                  {{#if (or (eq disposition.communityboardrecommendation "Disapproved") (eq disposition.communityboardrecommendation "Disapproved with Modifications/Conditions"))}}
-                    {{fa-icon 'thumbs-down' class='red-muted' fixedWidth=true}}
-                  {{/if}}
-                  {{#if (eq disposition.communityboardrecommendation "Waived")}}
-                    {{fa-icon 'comment-slash' class='gray' fixedWidth=true}}
-                  {{/if}}
-                {{/if}}
-                {{#if (eq milestone.dcpMilestone this.milestoneConstants.BOROUGH_BOARD_REFERRAL)}}
-                  {{#if (or (eq disposition.boroughboardrecommendation "Approved") (eq disposition.boroughboardrecommendation "Approved with Modifications/Conditions"))}}
-                    {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
-                  {{/if}}
-                  {{#if (or (eq disposition.boroughboardrecommendation "Disapproved") (eq disposition.boroughboardrecommendation "Disapproved with Modifications/Conditions"))}}
-                    {{fa-icon 'thumbs-down' class='red-muted' fixedWidth=true}}
-                  {{/if}}
-                  {{#if (eq disposition.boroughboardrecommendation "Waived")}}
-                    {{fa-icon 'comment-slash' class='gray' fixedWidth=true}}
-                  {{/if}}
-                {{/if}}
-                {{#if (eq milestone.dcpMilestone this.milestoneConstants.BOROUGH_PRESIDENT_REFERRAL)}}
-                  {{#if (or (eq disposition.boroughpresidentrecommendation "Approved") (eq disposition.boroughpresidentrecommendation "Approved with Modifications/Conditions"))}}
-                    {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
-                  {{/if}}
-                  {{#if (or (eq disposition.boroughpresidentrecommendation "Disapproved") (eq disposition.boroughpresidentrecommendation "Disapproved with Modifications/Conditions"))}}
-                    {{fa-icon 'thumbs-down' class='red-muted' fixedWidth=true}}
-                  {{/if}}
-                  {{#if (eq disposition.boroughpresidentrecommendation "Waived")}}
-                    {{fa-icon 'comment-slash' class='gray' fixedWidth=true}}
-                  {{/if}}
-                {{/if}}
-              {{/each}}
-              <br>
-              <small class="display-inline-block">{{milestone.displayDate}}</small>
-            </div>
-          </li>
+          <ArchiveProjectMilestoneListItem
+            @project={{this.project}}
+            @milestone={{milestone}}
+          />
         {{/each}}
       </ul>
     </div>

--- a/app/templates/components/archive-project-milestone-list-item.hbs
+++ b/app/templates/components/archive-project-milestone-list-item.hbs
@@ -1,0 +1,59 @@
+<li class="grid-x small-margin-bottom"
+  data-test-milestone-list-item
+>
+  <div class="cell shrink small-margin-right">
+    {{#if (eq this.milestone.statuscode "Completed")}}
+      {{fa-icon 'check' class='blue' fixedWidth=true}}
+    {{else if (eq this.milestone.statuscode "Overridden")}}
+      {{fa-icon 'stop' class='red-dark' fixedWidth=true}}
+    {{else if (eq this.milestone.statuscode "Not Started")}}
+      <span data-test={{if (string-includes this.milestone.milestonename "Referral") "upcoming-indicator"}}>
+        {{fa-icon 'calendar' class='light-gray' fixedWidth=true}}
+      </span>
+    {{/if}}
+  </div>
+  <div class="cell auto {{if (eq this.milestone.statuscode "Not Started") 'gray'}}">
+    <strong>
+      {{this.milestone.milestonename}}
+    </strong>
+    {{#if (eq this.milestone.dcpMilestone this.milestoneConstants.COMMUNITY_BOARD_REFERRAL)}}
+      {{#each this.communityBoardDispositions as |disposition|}}
+        <RecommendationResultIcon
+          @recommendation={{disposition.communityboardrecommendation}}
+        />
+      {{/each}}
+      <br>
+      <small class="display-block">
+        Recommendation submitted&nbsp;{{~moment-format this.anyCommunityBoardDispositionDateReceived "MM/D/YYYY"~}}
+      </small>
+    {{else if (eq this.milestone.dcpMilestone this.milestoneConstants.BOROUGH_BOARD_REFERRAL)}}
+      {{#each this.boroughBoardDispositions as |disposition|}}
+        <RecommendationResultIcon
+          @recommendation={{disposition.boroughboardrecommendation}}
+        />
+      {{/each}}
+      <br>
+      <small class="display-block">
+        Recommendation submitted&nbsp;{{~moment-format this.anyBoroughBoardDispositionDateReceived "MM/D/YYYY"~}}
+      </small>
+    {{else if (eq this.milestone.dcpMilestone this.milestoneConstants.BOROUGH_PRESIDENT_REFERRAL)}}
+      {{#each this.boroughPresidentDispositions as |disposition|}}
+        <RecommendationResultIcon
+          @recommendation={{disposition.boroughpresidentrecommendation}}
+        />
+      {{/each}}
+      <br>
+      <small class="display-block">
+        Recommendation submitted&nbsp;{{~moment-format this.anyBoroughPresidentDispositionDateReceived "MM/D/YYYY"~}}
+      </small>
+    {{else}}
+      <br>
+      <small class="display-block">
+        {{#if (eq this.milestone.statuscode "Not Started")}}
+          Estimated
+        {{/if}}
+        {{~moment-format this.milestone.displayDate "MM/D/YYYY"~}}
+      </small>
+    {{/if}}
+  </div>
+</li>

--- a/app/templates/components/recommendation-result-icon.hbs
+++ b/app/templates/components/recommendation-result-icon.hbs
@@ -1,0 +1,9 @@
+{{#if (or (eq this.recommendation "Approved") (eq this.recommendation "Approved with Modifications/Conditions"))}}
+  {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
+{{/if}}
+{{#if (or (eq this.recommendation "Disapproved") (eq this.recommendation "Disapproved with Modifications/Conditions"))}}
+  {{fa-icon 'thumbs-down' class='red-muted' fixedWidth=true}}
+{{/if}}
+{{#if (eq this.recommendation "Waived")}}
+  {{fa-icon 'comment-slash' class='gray' fixedWidth=true}}
+{{/if}}

--- a/app/templates/components/reviewed-project-card.hbs
+++ b/app/templates/components/reviewed-project-card.hbs
@@ -24,65 +24,10 @@
       <div class="cell medium-auto">
         <ul class="no-bullet no-margin">
           {{#each this.project.tabSpecificMilestones as |milestone|}}
-            <li class="grid-x">
-              <div class="cell shrink small-margin-right">
-                {{#if (eq milestone.statuscode "Completed")}}
-                  <span data-test={{if (string-includes milestone.milestonename "Referral") "reviewed-indicator"}}>
-                    {{fa-icon 'check' class='blue' fixedWidth=true}}
-                  </span>
-                {{else if (eq milestone.statuscode "In Progress")}}
-                  {{fa-icon 'hourglass-half' class='blue' fixedWidth=true}}
-                {{else if (eq milestone.statuscode "Overridden")}}
-                  {{fa-icon 'times' class='red-muted' fixedWidth=true}}
-                {{else}}
-                  {{fa-icon 'calendar' class='light-gray' fixedWidth=true}}
-                {{/if}}
-              </div>
-              <div class="cell auto {{if (eq milestone.statuscode "Not Started") 'gray'}}">
-                <p class="small-margin-bottom">
-                  <strong>
-                    {{milestone.milestonename}}
-                  </strong>
-                  {{#each this.project.dispositions as |disposition|}}
-                    {{#if (eq milestone.dcpMilestone this.milestoneConstants.COMMUNITY_BOARD_REFERRAL)}}
-                      {{#if (or (eq disposition.communityboardrecommendation "Approved") (eq disposition.communityboardrecommendation "Approved with Modifications/Conditions"))}}
-                        {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
-                      {{/if}}
-                      {{#if (or (eq disposition.communityboardrecommendation "Disapproved") (eq disposition.communityboardrecommendation "Disapproved with Modifications/Conditions"))}}
-                        {{fa-icon 'thumbs-down' class='red-muted' fixedWidth=true}}
-                      {{/if}}
-                      {{#if (eq disposition.communityboardrecommendation "Waived")}}
-                        {{fa-icon 'comment-slash' class='gray' fixedWidth=true}}
-                      {{/if}}
-                    {{/if}}
-                    {{#if (eq milestone.dcpMilestone this.milestoneConstants.BOROUGH_BOARD_REFERRAL)}}
-                      {{#if (or (eq disposition.boroughboardrecommendation "Approved") (eq disposition.boroughboardrecommendation "Approved with Modifications/Conditions"))}}
-                        {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
-                      {{/if}}
-                      {{#if (or (eq disposition.boroughboardrecommendation "Disapproved") (eq disposition.boroughboardrecommendation "Disapproved with Modifications/Conditions"))}}
-                        {{fa-icon 'thumbs-down' class='red-muted' fixedWidth=true}}
-                      {{/if}}
-                      {{#if (eq disposition.boroughboardrecommendation "Waived")}}
-                        {{fa-icon 'comment-slash' class='gray' fixedWidth=true}}
-                      {{/if}}
-                    {{/if}}
-                    {{#if (eq milestone.dcpMilestone this.milestoneConstants.BOROUGH_PRESIDENT_REFERRAL)}}
-                      {{#if (or (eq disposition.boroughpresidentrecommendation "Approved") (eq disposition.boroughpresidentrecommendation "Approved with Modifications/Conditions"))}}
-                        {{fa-icon 'thumbs-up' class='green-muted' fixedWidth=true}}
-                      {{/if}}
-                      {{#if (or (eq disposition.boroughpresidentrecommendation "Disapproved") (eq disposition.boroughpresidentrecommendation "Disapproved with Modifications/Conditions"))}}
-                        {{fa-icon 'thumbs-down' class='red-muted' fixedWidth=true}}
-                      {{/if}}
-                      {{#if (eq disposition.boroughpresidentrecommendation "Waived")}}
-                        {{fa-icon 'comment-slash' class='gray' fixedWidth=true}}
-                      {{/if}}
-                    {{/if}}
-                  {{/each}}
-                  <br>
-                  <small class="display-block">{{milestone.displayDate}}</small>
-                </p>
-              </div>
-            </li>
+            <ReviewedProjectMilestoneListItem
+              @project={{project}}
+              @milestone={{milestone}}
+            />
           {{/each}}
         </ul>
       </div>

--- a/app/templates/components/reviewed-project-milestone-list-item.hbs
+++ b/app/templates/components/reviewed-project-milestone-list-item.hbs
@@ -1,0 +1,63 @@
+<li class="grid-x"
+  data-test-milestone-list-item
+>
+  <div class="cell shrink small-margin-right">
+    {{#if (eq this.milestone.statuscode "Completed")}}
+      <span data-test={{if (string-includes this.milestone.milestonename "Referral") "reviewed-indicator"}}>
+        {{fa-icon 'check' class='blue' fixedWidth=true}}
+      </span>
+    {{else if (eq this.milestone.statuscode "In Progress")}}
+      {{fa-icon 'hourglass-half' class='blue' fixedWidth=true}}
+    {{else if (eq this.milestone.statuscode "Overridden")}}
+      {{fa-icon 'times' class='red-muted' fixedWidth=true}}
+    {{else}}
+      {{fa-icon 'calendar' class='light-gray' fixedWidth=true}}
+    {{/if}}
+  </div>
+  <div class="cell auto {{if (eq this.milestone.statuscode "Not Started") 'gray'}}">
+    <p class="small-margin-bottom">
+      <strong>
+        {{this.milestone.milestonename}}
+      </strong>
+      {{#if (eq this.milestone.dcpMilestone this.milestoneConstants.COMMUNITY_BOARD_REFERRAL)}}
+        {{#each this.communityBoardDispositions as |disposition|}}
+          <RecommendationResultIcon
+            @recommendation={{disposition.communityboardrecommendation}}
+          />
+        {{/each}}
+        <br>
+        <small class="display-block">
+          Recommendation submitted&nbsp;{{~moment-format this.anyCommunityBoardDispositionDateReceived "MM/D/YYYY"~}}
+        </small>
+      {{else if (eq this.milestone.dcpMilestone this.milestoneConstants.BOROUGH_BOARD_REFERRAL)}}
+        {{#each this.boroughBoardDispositions as |disposition|}}
+          <RecommendationResultIcon
+            @recommendation={{disposition.boroughboardrecommendation}}
+          />
+        {{/each}}
+        <br>
+        <small class="display-block">
+          Recommendation submitted&nbsp;{{~moment-format this.anyBoroughBoardDispositionDateReceived "MM/D/YYYY"~}}
+        </small>
+      {{else if (eq this.milestone.dcpMilestone this.milestoneConstants.BOROUGH_PRESIDENT_REFERRAL)}}
+        {{#each this.boroughPresidentDispositions as |disposition|}}
+          <RecommendationResultIcon
+            @recommendation={{disposition.boroughpresidentrecommendation}}
+          />
+        {{/each}}
+        <br>
+        <small class="display-block">
+          Recommendation submitted&nbsp;{{~moment-format this.anyBoroughPresidentDispositionDateReceived "MM/D/YYYY"~}}
+        </small>
+      {{else}}
+        <br>
+        <small class="display-block">
+          {{#if (eq this.milestone.statuscode "Not Started")}}
+            Estimated
+          {{/if}}
+          {{~moment-format this.milestone.displayDate "MM/D/YYYY"~}}
+        </small>
+      {{/if}}
+    </p>
+  </div>
+</li>

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -119,7 +119,7 @@
                 {{#if (eq milestone.statuscode "Not Started")}}
                   Estimated
                 {{/if}}
-                {{milestone.displayDate}}
+                {{~moment-format milestone.displayDate "MM/D/YYYY"~}}
               </small>
             </div>
           </li>

--- a/mirage/factories/disposition.js
+++ b/mirage/factories/disposition.js
@@ -14,16 +14,14 @@ export default Factory.extend({
   // 'Non-Complying', 'Vote Quorum Not Present', 'Received after Clock Expired', 'No Objection', 'Waiver of Recommendation',
   // N/A as default
 
+  datereceived: null,
+
   consideration() {
     return faker.lorem.sentences();
   },
 
   votelocation() {
     return faker.address.streetAddress();
-  },
-
-  datereceived() {
-    return faker.date.past();
   },
 
   dateofvote() {

--- a/mirage/scenarios/default.js
+++ b/mirage/scenarios/default.js
@@ -83,6 +83,9 @@ export default function(server) {
         action: seedCBUserProjects[i].actions.models[j],
         dcpPublichearinglocation: (i < 3) ? 'Canal street' : null,
         dcpDateofpublichearing: (i < 3) ? moment().subtract(22, 'days') : null,
+        // In reality this should fall within the community board review's duration,
+        // so this mock date may not be accurate.
+        datereceived: moment().subtract(80, 'days'),
       });
       if (i > 4) {
         server.create('disposition', 'boroughPresidentDisposition', {
@@ -91,6 +94,9 @@ export default function(server) {
           action: seedCBUserProjects[i].actions.models[j],
           dcpPublichearinglocation: 'Nassau street',
           dcpDateofpublichearing: moment().subtract(10, 'days'),
+          // In reality this should fall within the president's review duration,
+          // so this mock date may not be accurate.
+          datereceived: moment().subtract(120, 'days'),
         });
         server.create('disposition', 'boroughBoardDisposition', {
           user: seedBBUser,
@@ -99,6 +105,9 @@ export default function(server) {
           dcpPublichearinglocation: 'Fulton street',
           dcpDateofpublichearing: moment().subtract(10, 'days'),
           boroughboardrecommendation: 'Approved',
+          // In reality this should fall within the board's review duration,
+          // so this mock date may not be accurate.
+          datereceived: moment().subtract(100, 'days'),
         });
       }
     }
@@ -231,6 +240,7 @@ export default function(server) {
     project: seedCBUserProjects[0],
     statuscode: 'Not Started',
     dcpPlannedstartdate: moment().add(32, 'days'),
+    displayDate: moment().add(32, 'days'),
   });
 
   // "SECOND" CB PROJECT (Upcoming)
@@ -289,6 +299,7 @@ export default function(server) {
     project: seedCBUserProjects[1],
     statuscode: 'Not Started',
     dcpPlannedstartdate: moment().add(52, 'days'),
+    displayDate: moment().add(52, 'days'),
   });
 
   // "THIRD" CB PROJECT (Upcoming)
@@ -401,6 +412,7 @@ export default function(server) {
     project: seedCBUserProjects[2],
     statuscode: 'Not Started',
     dcpPlannedstartdate: moment().add(90, 'days'),
+    displayDate: moment().add(90, 'days'),
   });
 
   // "FOURTH" CB PROJECT (To Review)

--- a/tests/integration/components/archive-project-milestone-list-item-test.js
+++ b/tests/integration/components/archive-project-milestone-list-item-test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { find, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | archive-project-milestone-list-item', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('project', { dispositions: [] });
+
+    this.set('milestone', {});
+
+    await render(hbs`<ArchiveProjectMilestoneListItem @project={{this.project}} @milestone={{this.milestone}}/>`);
+
+    assert.ok(find('[data-test-milestone-list-item]'));
+  });
+});

--- a/tests/integration/components/recommendation-result-icon-test.js
+++ b/tests/integration/components/recommendation-result-icon-test.js
@@ -1,0 +1,30 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { find, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | recommendation-result-icon', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders correct icon for a recommendation', async function(assert) {
+    await render(hbs`<RecommendationResultIcon @recommendation="Approved"/>`);
+
+    assert.ok(find('[data-icon="thumbs-up"]'));
+
+    await render(hbs`<RecommendationResultIcon @recommendation="Approved with Modifications/Conditions"/>`);
+
+    assert.ok(find('[data-icon="thumbs-up"]'));
+
+    await render(hbs`<RecommendationResultIcon @recommendation="Disapproved"/>`);
+
+    assert.ok(find('[data-icon="thumbs-down"]'));
+
+    await render(hbs`<RecommendationResultIcon @recommendation="Disapproved with Modifications/Conditions"/>`);
+
+    assert.ok(find('[data-icon="thumbs-down"]'));
+
+    await render(hbs`<RecommendationResultIcon @recommendation="Waived"/>`);
+
+    assert.ok(find('[data-icon="comment-slash"]'));
+  });
+});

--- a/tests/integration/components/reviewed-project-milestone-list-item-test.js
+++ b/tests/integration/components/reviewed-project-milestone-list-item-test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { find, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | reviewed-project-milestone-list-item', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    this.set('project', { dispositions: [] });
+
+    this.set('milestone', {});
+
+    await render(hbs`<ReviewedProjectMilestoneListItem @project={{this.project}} @milestone={{this.milestone}}/>`);
+
+    assert.ok(find('[data-test-milestone-list-item]'));
+  });
+});


### PR DESCRIPTION
# What
- Formats dates under milestones in project card milestone lists. 
- Displays "Recommendation submitted" dates  (i.e. any `datereceived` values defined among the concerned participantType dispositions) under each Review milestone. (See ZAP LUP Tabs wireframes)
- Toggles "Expected" date labels for milestones in reviewed and archive tabs. 

# Rider:
Refactores Milestone lists and recommendation outcome icon lists into smaller components.