### PR TITLE
670: update error handling for hearing form

### DIFF
--- a/app/controllers/my-projects/project/hearing/add.js
+++ b/app/controllers/my-projects/project/hearing/add.js
@@ -85,28 +85,28 @@ export default class MyProjectsProjectHearingAddController extends Controller {
     const { dispositions } = this.model;
     const allActions = this.get('allActions');
 
-    try {
-      // if user is submitting ONE hearing for ALL actions
-      if (allActions) {
-        const allActionsDispHearingLocation = this.get('dispositionForAllActions.dcpPublichearinglocation');
-        const allActionsDispHearingDate = this.get('dispositionForAllActions.dcpDateofpublichearing');
+    // if user is submitting ONE hearing for ALL actions
+    if (allActions) {
+      const allActionsDispHearingLocation = this.get('dispositionForAllActions.dcpPublichearinglocation');
+      const allActionsDispHearingDate = this.get('dispositionForAllActions.dcpDateofpublichearing');
 
-        // iterate through each disposition on the modal
-        // set hearing location and date on each one with the single value that the user input
-        // this single value is saved on dispositionForAllActions object
-        dispositions.forEach(function(disposition) {
-          disposition.set('dcpPublichearinglocation', allActionsDispHearingLocation);
-          disposition.set('dcpDateofpublichearing', allActionsDispHearingDate);
-        });
-      }
-      await dispositions.save();
+      // iterate through each disposition on the modal
+      // set hearing location and date on each one with the single value that the user input
+      // this single value is saved on dispositionForAllActions object
+      dispositions.forEach(function(disposition) {
+        disposition.set('dcpPublichearinglocation', allActionsDispHearingLocation);
+        disposition.set('dcpDateofpublichearing', allActionsDispHearingDate);
+      });
+    }
 
+    dispositions.save().then(() => {
       this.set('hearingSubmitted', false);
       this.set('checkIfMissing', false);
       this.set('modalOpen', false);
       this.transitionToRoute('my-projects.project.hearing.done');
-    } catch (e) {
-      alert('Sorry about that, unable to connect to server, can you try again?'); // eslint-disable-line
-    }
+    }, (e) => {
+      this.set('error', e);
+      console.log('server error', e);
+    });
   }
 }

--- a/app/templates/my-projects/project/hearing/add.hbs
+++ b/app/templates/my-projects/project/hearing/add.hbs
@@ -69,87 +69,103 @@
         </button>
     {{/if}}
 
-      {{#confirmation-modal open=modalOpen}}
-        <h3>Confirm hearing information</h3>
-
-          {{#if allActions}}
-            <li class="grid-x">
-              <div class="cell shrink small-margin-right">
-                  {{fa-icon "calendar" class="light-gray" fixedWidth=true}}
-              </div>
-              <div class="cell auto">
-                <strong class="display-block hearing-location">
-                  {{~dispositionForAllActions.dcpPublichearinglocation~}}
-                </strong>
-                <span class="hearing-date">
-                  {{~moment-format dispositionForAllActions.dcpDateofpublichearing "MM/D/YYYY"~}}
-                </span>
-                <span class="light-gray">|</span>
-                <span class="hearing-time">
-                  {{~moment-format dispositionForAllActions.dcpDateofpublichearing "h:mm A"~}}
-                </span>
-              </div>
-            </li>
+        {{#confirmation-modal open=modalOpen}}
+          {{#if error}}
+            <div class="cell auto">
+              <span data-test-error-alert-message>
+                Oops something went wrong, can you try again?
+              </span>
+            </div>
+            <button
+              class="button clear"
+              data-test-button="backToHearingFormAfterError"
+              type="button"
+              onClick={{action "closeModal"}}
+            >
+              Back to hearing form
+            </button>
           {{else}}
-            {{#deduped-hearings-list project=model as |dedupedHearings|}}
-              <h5 class="column-header">Hearing Information</h5>
-                  <ul class="no-bullet">
-                  {{#each dedupedHearings as |hearing|}}
-                    <li class="grid-x small-margin-bottom">
-                      <div class="cell shrink small-margin-right">
-                        {{#if (is-before hearing.dcpDateofpublichearing)}}
-                          {{fa-icon "calendar" class="light-gray" fixedWidth=true}}
-                        {{else}}
-                          {{fa-icon "check" class="blue" fixedWidth=true}}
-                        {{/if}}
-                      </div>
-                      <div class="cell auto">
-                        <strong data-test-hearing-location="{{hearing.id}}" class="display-block">
-                          {{~hearing.dcpPublichearinglocation~}}
-                        </strong>
-                        <span data-test-hearing-date="{{hearing.id}}">
-                          {{~moment-format hearing.dcpDateofpublichearing "MM/D/YYYY"~}}
-                        </span>
-                        <span class="light-gray">|</span>
-                        <span data-test-hearing-time="{{hearing.id}}">
-                          {{~moment-format hearing.dcpDateofpublichearing "h:mm A"~}}
-                        </span>
-                        <span data-test-hearing-actions-list="{{hearing.id}}" class="display-block text-tiny">
-                          {{#each hearing.hearingActions as |action index|}}
-                            {{if (gt index 0) ", "}}{{action.dcpUlurpnumber}}
-                          {{/each}}
-                        </span>
-                      </div>
-                    </li>
-                  {{/each}}
-                  </ul>
-            {{/deduped-hearings-list}}
+            <h3>Confirm hearing information</h3>
+
+              {{#if allActions}}
+                <li class="grid-x">
+                  <div class="cell shrink small-margin-right">
+                      {{fa-icon "calendar" class="light-gray" fixedWidth=true}}
+                  </div>
+                  <div class="cell auto">
+                    <strong class="display-block hearing-location">
+                      {{~dispositionForAllActions.dcpPublichearinglocation~}}
+                    </strong>
+                    <span class="hearing-date">
+                      {{~moment-format dispositionForAllActions.dcpDateofpublichearing "MM/D/YYYY"~}}
+                    </span>
+                    <span class="light-gray">|</span>
+                    <span class="hearing-time">
+                      {{~moment-format dispositionForAllActions.dcpDateofpublichearing "h:mm A"~}}
+                    </span>
+                  </div>
+                </li>
+              {{else}}
+                {{#deduped-hearings-list project=model as |dedupedHearings|}}
+                  <h5 class="column-header">Hearing Information</h5>
+                      <ul class="no-bullet">
+                      {{#each dedupedHearings as |hearing|}}
+                        <li class="grid-x small-margin-bottom">
+                          <div class="cell shrink small-margin-right">
+                            {{#if (is-before hearing.dcpDateofpublichearing)}}
+                              {{fa-icon "calendar" class="light-gray" fixedWidth=true}}
+                            {{else}}
+                              {{fa-icon "check" class="blue" fixedWidth=true}}
+                            {{/if}}
+                          </div>
+                          <div class="cell auto">
+                            <strong data-test-hearing-location="{{hearing.id}}" class="display-block">
+                              {{~hearing.dcpPublichearinglocation~}}
+                            </strong>
+                            <span data-test-hearing-date="{{hearing.id}}">
+                              {{~moment-format hearing.dcpDateofpublichearing "MM/D/YYYY"~}}
+                            </span>
+                            <span class="light-gray">|</span>
+                            <span data-test-hearing-time="{{hearing.id}}">
+                              {{~moment-format hearing.dcpDateofpublichearing "h:mm A"~}}
+                            </span>
+                            <span data-test-hearing-actions-list="{{hearing.id}}" class="display-block text-tiny">
+                              {{#each hearing.hearingActions as |action index|}}
+                                {{if (gt index 0) ", "}}{{action.dcpUlurpnumber}}
+                              {{/each}}
+                            </span>
+                          </div>
+                        </li>
+                      {{/each}}
+                      </ul>
+                {{/deduped-hearings-list}}
+              {{/if}}
+
+            <p class="callout warning text-small">
+              Once you submit hearing information, you cannot edit it. You'll need to contact the Lead Planner to make any changes.
+            </p>
+
+            <p>
+              <button
+                class="button"
+                data-test-button="confirmHearing"
+                type="button"
+                onClick={{action "onConfirm"}}
+              >
+                Submit Hearing Information
+              </button>
+
+              <button
+                class="button clear"
+                data-test-button="closeModal"
+                type="button"
+                onClick={{action "closeModal"}}
+              >
+                Cancel <small>(continue editing)</small>
+              </button>
+            </p>
           {{/if}}
-
-        <p class="callout warning text-small">
-          Once you submit hearing information, you can not edit it. You'll need to contact the Lead Planner to make any changes.
-        </p>
-
-        <p>
-          <button
-            class="button"
-            data-test-button="confirmHearing"
-            type="button"
-            onClick={{action "onConfirm"}}
-          >
-            Submit Hearing Information
-          </button>
-
-          <button
-            class="button clear"
-            data-test-button="closeModal"
-            type="button"
-            onClick={{action "closeModal"}}
-          >
-            Cancel <small>(continue editing)</small>
-          </button>
-        </p>
-      {{/confirmation-modal}}
+        {{/confirmation-modal}}
   </div>
 </div>
 

--- a/tests/acceptance/user-can-fill-out-hearing-form-test.js
+++ b/tests/acceptance/user-can-fill-out-hearing-form-test.js
@@ -335,4 +335,37 @@ module('Acceptance | user can save hearing form', function(hooks) {
 
     assert.equal(currentURL(), '/my-projects/4/hearing/done');
   });
+
+  test('if there is a server error when running .save(), user will see error message', async function(assert) {
+    this.server.create('disposition');
+    this.server.patch('/dispositions/:id', { errors: ['server problem'] }, 500); // force mirage to error
+
+    await visit('/my-projects/4/hearing/add');
+
+    // user selects radio button for a SINGLE hearing for ALL actions
+    await click('[data-test-radio="all-action-yes"]');
+
+    await fillIn('[data-test-allactions-input="location"]', '121 Bananas Ave, Queens, NY');
+
+    // user triggers a keyup event (necessary for acceptance test)
+    await triggerEvent('[data-test-allactions-input="location"]', 'keyup');
+
+    await click('[data-test-allactions-input="date"]');
+
+    const hearingDate = new Date('2020-10-21T00:00:00'); // Wednesday, October 21, 2020
+    await Pikaday.selectDate(hearingDate);
+
+    await selectChoose('[data-test-allactions-dropdown="timeOfDay"]', 'AM');
+    await fillIn('[data-test-allactions-input="hour"]', 5);
+    await fillIn('[data-test-allactions-input="minute"]', 35);
+
+    // user triggers a keyup event (necessary for acceptance test)
+    await triggerEvent('[data-test-allactions-input="hour"]', 'keyup');
+
+    await click('[data-test-button="checkHearing"]');
+
+    await click('[data-test-button="confirmHearing"]');
+
+    assert.ok(find('[data-test-error-alert-message]'));
+  });
 });


### PR DESCRIPTION
First attempt at better error handling for submitting the hearing form. First time trying this out so feel free to edit/comment/suggest something better!

### Changes:
- update error handling on `hearing/add.js` for `.save()` method using`dispositions.save().then`
- if `error` --> show alert message in modal

### Tests:
- update `user-can-fill-out-hearing-form` acceptance test to have check for alert message when 500 error occurs

Addresses #670 