### PR TITLE
763: remove seedMirage from tests

### DIFF
--- a/tests/acceptance/my-projects-tabs-filter-test.js
+++ b/tests/acceptance/my-projects-tabs-filter-test.js
@@ -7,8 +7,6 @@ import {
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { invalidateSession, authenticateSession } from 'ember-simple-auth/test-support';
-import seedMirage from '../../mirage/scenarios/default';
-
 
 // NOTE: This suite assumes user 1 is logged in.
 module('Acceptance | my projects tabs filter', function(hooks) {
@@ -28,21 +26,19 @@ module('Acceptance | my projects tabs filter', function(hooks) {
   });
 
   hooks.beforeEach(async function() {
-    // TODO: Remove this dependency on default Mirage scenario if it becomes too much overhead
-    // to update these tests to align with them.
-    seedMirage(server);
-
     await authenticateSession();
 
-    this.server.get('/projects', function (schema) {
-      return schema.projects.all().slice(0, 2);
-    });
+    // this.server.get('/projects', function (schema) {
+    //   return schema.projects.all().slice(0, 2);
+    // });
   });
 
   test('Upcoming tab displays only User upcoming projects', async function(assert) {
+    this.server.createList('project', 5, { tab: 'upcoming' });
+
     await visit('/my-projects/upcoming');
     assert.equal(currentURL(), '/my-projects/upcoming');
 
-    assert.equal(findAll('[data-test-project-card]').length, 2, 'Number of displayed projects is same as number of users Upcoming projects');
+    assert.equal(findAll('[data-test-project-card]').length, 5, 'Number of displayed projects is same as number of users Upcoming projects');
   });
 });

--- a/tests/acceptance/user-can-fill-out-hearing-form-test.js
+++ b/tests/acceptance/user-can-fill-out-hearing-form-test.js
@@ -12,7 +12,6 @@ import { Interactor as Pikaday } from 'ember-pikaday/test-support';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { selectChoose } from 'ember-power-select/test-support';
 import { invalidateSession, authenticateSession } from 'ember-simple-auth/test-support';
-import seedMirage from '../../mirage/scenarios/default';
 
 module('Acceptance | user can save hearing form', function(hooks) {
   setupApplicationTest(hooks);
@@ -31,14 +30,12 @@ module('Acceptance | user can save hearing form', function(hooks) {
   });
 
   hooks.beforeEach(async function() {
-    // TODO: Remove this dependency on default Mirage scenario if it becomes too much overhead
-    // to update these tests to align with them.
-    seedMirage(server);
-
     await authenticateSession();
   });
 
   test('user cannot submit hearing form until all inputs are filled for AllActions', async function(assert) {
+    this.server.create('project', { id: 4, tab: 'to-review' });
+
     await visit('/my-projects/4/hearing/add');
 
     // make sure that the submit button is not showing up until a user selects a radio button
@@ -109,6 +106,42 @@ module('Acceptance | user can save hearing form', function(hooks) {
   });
 
   test('user cannot submit hearing form until all inputs are filled for ONE action per hearing', async function(assert) {
+    const disp1 = server.create('disposition', {
+      id: 17,
+      action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+    });
+    const disp2 = server.create('disposition', {
+      id: 18,
+      action: server.create('action', { dcpName: 'Zoning Text Amendment', dcpUlurpnumber: 'N860877TCM' }),
+    });
+    const disp3 = server.create('disposition', {
+      id: 19,
+      action: server.create('action', { dcpName: 'Business Improvement District', dcpUlurpnumber: 'I030148MMQ' }),
+    });
+    const disp4 = server.create('disposition', {
+      id: 20,
+      action: server.create('action', { dcpName: 'Change in City Map', dcpUlurpnumber: '200088ZMX' }),
+    });
+    const disp5 = server.create('disposition', {
+      id: 21,
+      action: server.create('action', { dcpName: 'Enclosed Sidewalk Cafe', dcpUlurpnumber: '190172ZMK' }),
+    });
+    const disp6 = server.create('disposition', {
+      id: 22,
+      action: server.create('action', { dcpName: 'Large Scale Special Permit', dcpUlurpnumber: 'N190257ZRK' }),
+    });
+    const disp7 = server.create('disposition', {
+      id: 23,
+      action: server.create('action', { dcpName: 'Zoning Certification', dcpUlurpnumber: '190256ZMK' }),
+    });
+
+    this.server.create('project', {
+      id: 5,
+      tab: 'to-review',
+      actions: server.createList('action', 7),
+      dispositions: [disp1, disp2, disp3, disp4, disp5, disp6, disp7],
+    });
+
     await visit('/my-projects/5/hearing/add');
 
     // make sure that the submit button is not showing up until a user selects a radio button
@@ -224,10 +257,10 @@ module('Acceptance | user can save hearing form', function(hooks) {
     const location23 = this.element.querySelector('[data-test-hearing-location="23"]').textContent;
     const time23 = this.element.querySelector('[data-test-hearing-time="23"]').textContent;
     const date23 = this.element.querySelector('[data-test-hearing-date="23"]').textContent;
-    // there will be three actions associated with hearing 22-- since hearing 17, 18, 20 were duplicates
+    // there will be three actions associated with hearing 22-- since hearing 17, 18, 21 were duplicates
     const action17 = this.element.querySelector('[data-test-hearing-actions-list="17"]').textContent;
     const action18 = this.element.querySelector('[data-test-hearing-actions-list="17"]').textContent;
-    const action20 = this.element.querySelector('[data-test-hearing-actions-list="17"]').textContent;
+    const action21 = this.element.querySelector('[data-test-hearing-actions-list="17"]').textContent;
     // hearing 23 has the same location and date as hearing 22, but a differen time
     const action23 = this.element.querySelector('[data-test-hearing-actions-list="23"]').textContent;
 
@@ -239,11 +272,11 @@ module('Acceptance | user can save hearing form', function(hooks) {
     assert.equal(time23, '1:25 AM', "correct text for data-test-hearing-time='23'");
     assert.equal(date23, '10/21/2020', "correct text for data-test-hearing-date='23'");
     // sometimes the ulurp number is displayed, whereas sometimes the action name is displayed
-    assert.ok(action17.includes('I030148MMQ') || action17.includes('Business Improvement District'), 'action17 includes correct ulurp info');
-    assert.ok(action18.includes('200088ZMX') || action18.includes('Change in City Map'), 'action18 includes correct ulurp info');
-    assert.ok(action20.includes('190256ZMK') || action20.includes('Zoning Certification'), 'action20 includes correct ulurp info');
-    assert.ok(action23.includes('N860877TCM') || action23.includes('Zoning Text Amendment '), 'action23 includes correct ulurp info');
+    assert.ok(action17.includes('C780076TLK') || action17.includes('Zoning Special Permit'), 'action17 includes correct ulurp info');
+    assert.ok(action18.includes('N860877TCM') || action17.includes('Zoning Text Amendment'), 'action17 includes correct ulurp info');
+    assert.ok(action21.includes('190172ZMK') || action17.includes('Enclosed Sidewalk Cafe'), 'action17 includes correct ulurp info');
 
+    assert.ok(action23.includes('190256ZMK') || action23.includes('Zoning Certification'), 'action23 includes correct ulurp info');
 
     // ##################################################################################################################
 
@@ -262,6 +295,8 @@ module('Acceptance | user can save hearing form', function(hooks) {
   });
 
   test('user cannot submit hearing form if hour or minute contain invalid values', async function(assert) {
+    this.server.create('project', { id: 4, tab: 'to-review' });
+
     await visit('/my-projects/4/hearing/add');
 
     // user selects radio button for a SINGLE hearing for ALL actions

--- a/tests/acceptance/user-can-waive-hearings-test.js
+++ b/tests/acceptance/user-can-waive-hearings-test.js
@@ -8,7 +8,6 @@ import {
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { invalidateSession, authenticateSession } from 'ember-simple-auth/test-support';
-import seedMirage from '../../mirage/scenarios/default';
 
 module('Acceptance | user can waive hearings', function(hooks) {
   setupApplicationTest(hooks);
@@ -27,7 +26,18 @@ module('Acceptance | user can waive hearings', function(hooks) {
   });
 
   test('user can waive hearings on to-review page', async function(assert) {
-    seedMirage(server);
+    const disp1 = server.create('disposition', {
+      id: 17,
+      dcpPublichearinglocation: '',
+      dcpDateofpublichearing: null,
+      action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+    });
+
+    this.server.create('project', {
+      id: 4,
+      tab: 'to-review',
+      dispositions: [disp1],
+    });
 
     await authenticateSession();
 
@@ -59,23 +69,32 @@ module('Acceptance | user can waive hearings', function(hooks) {
 
   test('User can waive hearings on the show-project page', async function(assert) {
     await authenticateSession();
+
+    const disp1 = server.create('disposition', {
+      id: 17,
+      dcpPublichearinglocation: '',
+      dcpDateofpublichearing: null,
+      action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+    });
     // user has to be signed in and assigned to that project (dcp_name matches)
     const userProject = server.create('project', {
-      id: 1,
+      id: 5,
       dcp_name: 'P2012M046',
+      tab: 'to-review',
+      dispositions: [disp1],
     });
 
     this.server.create('project', {
-      id: 1,
+      id: 5,
       dcp_name: 'P2012M046',
+      tab: 'to-review',
+      dispositions: [disp1],
     });
 
     this.server.create('user', {
       emailaddress1: 'testuser@planning.nyc.gov',
       projects: [userProject],
     });
-
-    seedMirage(server);
 
     // simulate presence of location hash after OAUTH redirect
     window.location.hash = '#access_token=test';
@@ -110,11 +129,20 @@ module('Acceptance | user can waive hearings', function(hooks) {
   });
 
   test('user can waive hearings on upcoming page', async function(assert) {
+    const disp1 = server.create('disposition', {
+      id: 17,
+      dcpPublichearinglocation: '',
+      dcpDateofpublichearing: null,
+      action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+    });
+
+    this.server.create('project', {
+      id: 4,
+      tab: 'upcoming',
+      dispositions: [disp1],
+    });
+
     await authenticateSession();
-
-    seedMirage(server);
-
-    this.server.create('disposition', { id: 1, dcpPublichearinglocation: '', dcpDateofpublichearing: null });
 
     await visit('/my-projects/upcoming');
 
@@ -135,26 +163,34 @@ module('Acceptance | user can waive hearings', function(hooks) {
     assert.ok(find('[data-test-hearings-waived-message]'));
   });
 
-  test('User waives hearings on show-project page and they appears on to-review', async function(assert) {
+  test('User waives hearings on show-project page and they appear on to-review', async function(assert) {
     await authenticateSession();
     // user has to be signed in and assigned to that project (dcp_name matches)
+    const disp1 = server.create('disposition', {
+      id: 17,
+      dcpPublichearinglocation: '',
+      dcpDateofpublichearing: null,
+      action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+    });
+    // user has to be signed in and assigned to that project (dcp_name matches)
     const userProject = server.create('project', {
-      id: 1,
+      id: 5,
       dcp_name: 'P2012M046',
+      tab: 'to-review',
+      dispositions: [disp1],
     });
 
     this.server.create('project', {
-      id: 1,
+      id: 5,
       dcp_name: 'P2012M046',
+      tab: 'to-review',
+      dispositions: [disp1],
     });
 
     this.server.create('user', {
       emailaddress1: 'testuser@planning.nyc.gov',
       projects: [userProject],
     });
-
-    seedMirage(server);
-
     // simulate presence of location hash after OAUTH redirect
     window.location.hash = '#access_token=test';
 
@@ -170,5 +206,55 @@ module('Acceptance | user can waive hearings', function(hooks) {
 
     assert.ok(find('[data-test-hearings-waived-message="5"]'));
     assert.notOk(find('[data-test-hearings-waived-message="4"]'));
+  });
+
+  test('User waives hearings on to-review page and they appear on show-project', async function(assert) {
+    await authenticateSession();
+    // user has to be signed in and assigned to that project (dcp_name matches)
+    const disp1 = server.create('disposition', {
+      id: 17,
+      dcpPublichearinglocation: '',
+      dcpDateofpublichearing: null,
+      action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+    });
+    // user has to be signed in and assigned to that project (dcp_name matches)
+    const userProject = server.create('project', {
+      id: 5,
+      dcp_name: 'P2012M046',
+      tab: 'to-review',
+      dispositions: [disp1],
+    });
+
+    this.server.create('project', {
+      id: 5,
+      dcp_name: 'P2012M046',
+      tab: 'to-review',
+      dispositions: [disp1],
+    });
+
+    this.server.create('user', {
+      emailaddress1: 'testuser@planning.nyc.gov',
+      projects: [userProject],
+    });
+    // simulate presence of location hash after OAUTH redirect
+    window.location.hash = '#access_token=test';
+
+    await visit('/login');
+
+    await visit('/my-projects/to-review');
+
+    assert.ok('[data-test-button="submitHearing"]');
+
+    await click('[data-test-button="optOutHearingOpenPopup"]');
+
+    await click('[data-test-button="onConfirmOptOutHearing"]');
+
+    assert.ok(find('[data-test-hearings-waived-message]'));
+
+    await click('[data-test-project-profile-button="5"]');
+
+    assert.notOk(find('[data-test-button-hearing-form]'));
+    assert.ok(find('[data-test-hearings-waived-message]'));
+    assert.ok(find('[data-test-button-to-rec-form]'));
   });
 });


### PR DESCRIPTION
Remove `seedMirage` from three acceptance tests and instead use `this.server.create`

Closes #763 

Opened new issue to address other problems with test: #779 