### PR TITLE
760: rec button only shows up on show-project if under to-review

### DIFF
--- a/app/routes/show-project.js
+++ b/app/routes/show-project.js
@@ -18,6 +18,7 @@ export default class ShowProjectRoute extends Route {
     super.setupController(controller, model);
     const userFromCurrentUser = await this.currentUser.get('user');
     controller.set('user', userFromCurrentUser);
+    controller.set('currentProjectTab', model.tab);
   }
 
   @action

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -159,24 +159,26 @@
             class="project--lup-section callout"
           >
             <h3 class="small-margin-bottom">Community Board Review</h3>
-            <div class="grid-x grid-x-small-gutters align-bottom">
-              <div class="cell medium-auto">
-                <p class="lead">
-                  <strong>8</strong>
-                  <small>of 60 days remain</small>
-                </p>
+            {{#if (eq this.currentProjectTab 'to-review')}}
+              <div class="grid-x grid-x-small-gutters align-bottom">
+                <div class="cell medium-auto">
+                  <p class="lead">
+                    <strong>8</strong>
+                    <small>of 60 days remain</small>
+                  </p>
+                </div>
+                <div class="cell medium-shrink medium-text-right">
+                  <p class="text-small dark-gray"><strong>Ends 09/02/19</strong></p>
+                </div>
               </div>
-              <div class="cell medium-shrink medium-text-right">
-                <p class="text-small dark-gray"><strong>Ends 09/02/19</strong></p>
-              </div>
-            </div>
-              {{#if hearingsSubmittedOrWaived}}
-                {{#link-to "my-projects.project.recommendations.add" model.id}}
-                <span class="button expanded" data-test-button-to-rec-form>
-                  Submit Participant Type Recommendation
-                </span>
-                {{/link-to}}
-              {{/if}}
+                {{#if hearingsSubmittedOrWaived}}
+                  {{#link-to "my-projects.project.recommendations.add" model.id}}
+                  <span class="button expanded" data-test-button-to-rec-form>
+                    Submit Participant Type Recommendation
+                  </span>
+                  {{/link-to}}
+                {{/if}}
+            {{/if}}
               {{#if hearingsSubmitted}}
                 {{#deduped-hearings-list project=model as |dedupedHearings|}}
                   <h5 class="column-header">Hearing Information</h5>

--- a/tests/acceptance/authenticated-user-sees-authenticated-features-test.js
+++ b/tests/acceptance/authenticated-user-sees-authenticated-features-test.js
@@ -83,4 +83,51 @@ module('Acceptance | authenticated user sees authenticated features', function(h
 
     assert.notOk(find('[data-test-hearing-rec-shortcuts]'));
   });
+
+  test('User does not see recommendation button unless project is under to-review tab', async function(assert) {
+    // user has to be signed in and assigned to that project (dcp_name matches)
+    const userProject1 = server.create('project', {
+      id: 1,
+      dcp_name: 'N2018Q077',
+      tab: 'upcoming',
+    });
+
+    const userProject2 = server.create('project', {
+      id: 2,
+      dcp_name: 'P2012M046',
+      tab: 'to-review',
+    });
+
+    this.server.create('project', {
+      id: 1,
+      dcp_name: 'N2018Q077',
+      tab: 'upcoming',
+    });
+
+    this.server.create('project', {
+      id: 2,
+      dcp_name: 'P2012M046',
+      tab: 'to-review',
+    });
+
+    this.server.create('user', {
+      emailaddress1: 'testuser@planning.nyc.gov',
+      projects: [userProject1, userProject2],
+    });
+
+    // simulate presence of location hash after OAUTH redirect
+    window.location.hash = '#access_token=test';
+
+    await visit('/login');
+
+    // project under 'upcoming' tab should NOT have recommendation button
+    await visit('/projects/1');
+
+    assert.notOk(find('[data-test-button-to-rec-form]'));
+
+    // project under 'to-review' tab should have recommendation button
+    await visit('/projects/2');
+
+    assert.ok(find('[data-test-button-to-rec-form]'));
+  });
 });

--- a/tests/acceptance/my-projects-tabs-filter-test.js
+++ b/tests/acceptance/my-projects-tabs-filter-test.js
@@ -6,7 +6,7 @@ import {
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { invalidateSession, authenticateSession } from 'ember-simple-auth/test-support';
+import { invalidateSession } from 'ember-simple-auth/test-support';
 
 // NOTE: This suite assumes user 1 is logged in.
 module('Acceptance | my projects tabs filter', function(hooks) {
@@ -25,20 +25,143 @@ module('Acceptance | my projects tabs filter', function(hooks) {
     await invalidateSession();
   });
 
-  hooks.beforeEach(async function() {
-    await authenticateSession();
+  test('Correct number of projects displayed in each tab based on tab property in projects', async function(assert) {
+    // ##### PROJECTS FOR USER ################################################
+    // upcoming
+    const userProject1 = server.create('project', {
+      id: 1,
+      dcp_name: 'N2018Q077',
+      tab: 'upcoming',
+    });
 
-    // this.server.get('/projects', function (schema) {
-    //   return schema.projects.all().slice(0, 2);
-    // });
-  });
+    // upcoming
+    const userProject2 = server.create('project', {
+      id: 2,
+      dcp_name: 'P2012M046',
+      tab: 'upcoming',
+    });
 
-  test('Upcoming tab displays only User upcoming projects', async function(assert) {
-    this.server.createList('project', 5, { tab: 'upcoming' });
+    // to-review
+    const userProject3 = server.create('project', {
+      id: 3,
+      dcp_name: 'K1993M046',
+      tab: 'to-review',
+    });
 
+    // to-review
+    const userProject4 = server.create('project', {
+      id: 4,
+      dcp_name: 'N2018Q077',
+      tab: 'to-review',
+    });
+
+    // to-review
+    const userProject5 = server.create('project', {
+      id: 5,
+      dcp_name: 'M2005Q077',
+      tab: 'to-review',
+    });
+
+    // reviewed
+    const userProject6 = server.create('project', {
+      id: 6,
+      dcp_name: 'P1982K004',
+      tab: 'reviewed',
+    });
+
+    // archive
+    const userProject7 = server.create('project', {
+      id: 7,
+      dcp_name: 'P2001B002',
+      tab: 'archive',
+    });
+
+    // ##### PROJECTS ################################################
+    // upcoming
+    this.server.create('project', {
+      id: 1,
+      dcp_name: 'N2018Q077',
+      tab: 'upcoming',
+    });
+
+    // upcoming
+    this.server.create('project', {
+      id: 2,
+      dcp_name: 'P2012M046',
+      tab: 'upcoming',
+    });
+
+    // to-review
+    this.server.create('project', {
+      id: 3,
+      dcp_name: 'K1993M046',
+      tab: 'to-review',
+    });
+
+    // to-review
+    this.server.create('project', {
+      id: 4,
+      dcp_name: 'N2018Q077',
+      tab: 'to-review',
+    });
+
+    // to-review
+    this.server.create('project', {
+      id: 5,
+      dcp_name: 'M2005Q077',
+      tab: 'to-review',
+    });
+
+    // reviewed
+    this.server.create('project', {
+      id: 6,
+      dcp_name: 'P1982K004',
+      tab: 'reviewed',
+    });
+
+    // archive
+    this.server.create('project', {
+      id: 7,
+      dcp_name: 'P2001B002',
+      tab: 'archive',
+    });
+
+    this.server.create('user', {
+      emailaddress1: 'testuser@planning.nyc.gov',
+      projects: [userProject1, userProject2, userProject3, userProject4, userProject5, userProject6, userProject7],
+    });
+
+    // simulate presence of location hash after OAUTH redirect
+    window.location.hash = '#access_token=test';
+
+    await visit('/login');
+
+    // ##### upcoming ##########################################################
     await visit('/my-projects/upcoming');
+
     assert.equal(currentURL(), '/my-projects/upcoming');
 
-    assert.equal(findAll('[data-test-project-card]').length, 5, 'Number of displayed projects is same as number of users Upcoming projects');
+    assert.equal(findAll('[data-test-project-card]').length, 2, 'Number of displayed projects is same as number of users upcoming projects');
+
+    // ##### to-review ##########################################################
+    await visit('/my-projects/to-review');
+
+    assert.equal(currentURL(), '/my-projects/to-review');
+
+    assert.equal(findAll('[data-test-project-card]').length, 3, 'Number of displayed projects is same as number of users to-review projects');
+
+    // ##### reviewed ##########################################################
+    await visit('/my-projects/archive');
+
+    assert.equal(currentURL(), '/my-projects/archive');
+
+    assert.equal(findAll('[data-test-project-card]').length, 1, 'Number of displayed projects is same as number of users reviewed projects');
+
+    // ##### archive ##########################################################
+    await visit('/my-projects/archive');
+
+    assert.equal(currentURL(), '/my-projects/archive');
+
+    assert.equal(findAll('[data-test-project-card]').length, 1, 'Number of displayed projects is same as number of users archive projects');
   });
 });

--- a/tests/acceptance/user-can-fill-out-hearing-form-test.js
+++ b/tests/acceptance/user-can-fill-out-hearing-form-test.js
@@ -372,7 +372,9 @@ module('Acceptance | user can save hearing form', function(hooks) {
   });
 
   test('if there is a server error when running .save(), user will see error message', async function(assert) {
-    this.server.create('disposition');
+    const disp1 = server.create('disposition', { dcpPublichearinglocation: '', dcpDateofpublichearing: null });
+    this.server.create('project', { id: 4, dispositions: [disp1] });
+
     this.server.patch('/dispositions/:id', { errors: ['server problem'] }, 500); // force mirage to error
 
     await visit('/my-projects/4/hearing/add');


### PR DESCRIPTION
### Changes
- Recommendation button only shows up on `show-project` page when the project is under the `to-review` tab -- meaning it is within the time period for the user's review process. 

### Tests
- new test to check for rec button only showing up on `show-project` page when the project is under the `to-review` tab
- fixed `my-projects-tabs-filter-test`
- fixed error handling test in `user-can-fill-out-hearing-form-test`

Closes #760 and #779 