### PR TITLE
773  remove participantType queryParam, use dcpTeammemberrole

### DIFF
--- a/app/controllers/my-projects/project/recommendations/add.js
+++ b/app/controllers/my-projects/project/recommendations/add.js
@@ -44,13 +44,14 @@ class DispositionForAllActions extends EmberObject {
 }
 
 export default class MyProjectsProjectRecommendationsAddController extends Controller {
-  queryParams = ['participantType'];
-
   @service
   store;
 
   @service
   currentUser;
+
+  @alias('model.dcpLupteammemberrole')
+  participantType;
 
   // the project is available through the model.
   @alias('model')

--- a/app/helpers/participant-type-label.js
+++ b/app/helpers/participant-type-label.js
@@ -1,0 +1,12 @@
+import { helper } from '@ember/component/helper';
+
+const PARTICIPANT_TYPE_LABEL_LOOKUP = {
+  BB: 'Borough Board',
+  BP: 'Borough President',
+  CB: 'Community Board',
+};
+
+export default helper(function participantTypeLabel(params) {
+  const [participantType] = params;
+  return PARTICIPANT_TYPE_LABEL_LOOKUP[participantType];
+});

--- a/app/templates/components/to-review-project-card.hbs
+++ b/app/templates/components/to-review-project-card.hbs
@@ -13,7 +13,7 @@
     </div>
     <div class="cell medium-4 large-shrink">
       <div class="lup-countdown medium-margin-right medium-margin-left">
-        <p class="cert-date">Community Board Review</p>
+        <p class="cert-date">{{participant-type-label project.dcpLupteammemberrole}} Review</p>
         <p class="days">{{timeRemaining}}</p>
         <p class="total">of {{timeDuration}} days remain</p>
         <p class="end-date">Ends {{moment-format project.toReviewMilestoneActualEndDate "M/D/YYYY"}}</p>
@@ -23,12 +23,11 @@
       {{#if project.hearingsSubmittedOrWaived}}
         <LinkTo @route="my-projects.project.recommendations.add"
           @model={{project.id}}
-          @query={{hash participantType="CB"}}
           class="button expanded"
           data-test-button="submitRecommendation"
         >
           {{fa-icon 'thumbs-up' prefix='far' fixedWidth=true size="lg"}}
-          Submit Community Board Recommendation
+          Submit {{participant-type-label project.dcpLupteammemberrole}} Recommendation
         </LinkTo>
       {{/if}}
       {{#if project.hearingsWaived}}
@@ -36,7 +35,7 @@
       {{/if}}
       {{#if project.hearingsSubmitted}}
         {{#deduped-hearings-list project=project as |dedupedHearings|}}
-          <h6>Community Board Hearings:</h6>
+          <h6>{{participant-type-label project.dcpLupteammemberrole}} Hearings:</h6>
               <ul class="no-bullet">
               {{#each dedupedHearings as |hearing|}}
                 <li class="grid-x small-margin-bottom">
@@ -77,7 +76,7 @@
           data-test-button="submitHearing"
         >
           {{fa-icon 'calendar-alt' prefix='far' fixedWidth=true size="lg"}}
-          Submit Community Board Hearing Info
+          Submit {{participant-type-label project.dcpLupteammemberrole}} Hearing Info
         </LinkTo>
         <p class="text-small text-right">
           <span class="display-inline-block">

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -15,7 +15,7 @@
       {{/if}}
       {{#if project.hearingsSubmitted}}
         {{#deduped-hearings-list project=project as |dedupedHearings|}}
-          <h6>Community Board Hearings:</h6>
+          <h6>{{participant-type-label project.dcpLupteammemberrole}} Hearings:</h6>
               <ul class="no-bullet">
               {{#each dedupedHearings as |hearing|}}
                 <li class="grid-x small-margin-bottom">
@@ -56,7 +56,7 @@
           data-test-button="submitHearing"
         >
           {{fa-icon 'calendar-alt' prefix='far' fixedWidth=true size="lg"}}
-          Submit Community Board Hearing Info
+          Submit {{participant-type-label project.dcpLupteammemberrole}} Hearing Info
         </LinkTo>
         <p class="text-small text-right">
           <span class="display-inline-block">

--- a/app/templates/components/waive-hearings-popup.hbs
+++ b/app/templates/components/waive-hearings-popup.hbs
@@ -2,7 +2,7 @@
   {{#confirmation-modal open=showPopup}}
 
     <h3>Opt out of hearings for: <br>{{project.dcpProjectname}}</h3>
-    <p class="text-small">Without proper notice of a public hearing, the Community Board's recommendation does not comply with City Charter requirements.
+    <p>Without proper notice of a public hearing, the {{participant-type-label project.dcpLupteammemberrole}}'s recommendation does not comply with City Charter requirements.
     NYC Planning will still accept a recommendation, but a disapproval will not trigger an automatic City Council call up.</p>
     <p><strong>Are you sure you want to opt out of submitting hearings?</strong></p>
     <button

--- a/app/templates/my-projects/project/hearing/add.hbs
+++ b/app/templates/my-projects/project/hearing/add.hbs
@@ -1,4 +1,4 @@
-<h2>Add Community Board Hearing</h2>
+<h2>Add {{participant-type-label model.dcpLupteammemberrole}} Hearing</h2>
 <div class="grid-x grid-margin-x">
   <div class="large-5 cell large-order-2">
     <p>Hearings to be submitted for:</p>

--- a/app/templates/my-projects/project/recommendations/add.hbs
+++ b/app/templates/my-projects/project/recommendations/add.hbs
@@ -13,14 +13,7 @@
   <div class="grid-container">
     <div class="grid-x grid-x-container">
       <h2>
-        Add
-        {{#if (eq participantType "BP")}}
-          Borough&nbsp;President
-        {{else if (eq participantType "BB")}}
-          Borough&nbsp;Board
-        {{else if (eq participantType "CB")}}
-          Community&nbsp;Board
-        {{/if}}Recommendation
+        Add {{participant-type-label project.dcpLupteammemberrole}} Recommendation
       </h2>
       <div class="grid-x grid-margin-x">
         <div class="large-5 cell large-order-2">
@@ -103,7 +96,7 @@
           {{#if project.hearingsWaived}}
             <div data-test-hearings-waived-message>
               <h5>Note: You have opted out of submitting hearings for this project.</h5>
-              <p class="text-small">Without proper notice of a public hearing, the [Participant Type]'s recommendation does not comply with City Charter requirements. NYC Planning will still accept a recommendation, but a disapproval will not trigger an automatic City Council call up.</p>
+              <p class="text-small">Without proper notice of a public hearing, the {{participant-type-label project.dcpLupteammemberrole}}'s recommendation does not comply with City Charter requirements. NYC Planning will still accept a recommendation, but a disapproval will not trigger an automatic City Council call up.</p>
             </div>
             <hr>
           {{/if}}

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -158,7 +158,9 @@
             data-test-hearing-rec-shortcuts
             class="project--lup-section callout"
           >
-            <h3 class="small-margin-bottom">Community Board Review</h3>
+            <h3 class="small-margin-bottom">
+              {{participant-type-label model.dcpLupteammemberrole}} Review
+            </h3>
             {{#if (eq this.currentProjectTab 'to-review')}}
               <div class="grid-x grid-x-small-gutters align-bottom">
                 <div class="cell medium-auto">
@@ -171,73 +173,73 @@
                   <p class="text-small dark-gray"><strong>Ends 09/02/19</strong></p>
                 </div>
               </div>
-                {{#if model.hearingsSubmittedOrWaived}}
-                  {{#link-to "my-projects.project.recommendations.add" model.id class="button expanded"}}
-                  <span data-test-button-to-rec-form>
-                    {{fa-icon 'thumbs-up' prefix='far' fixedWidth=true size="lg"}}
-                    Submit Participant Type Recommendation
-                  </span>
-                  {{/link-to}}
-                {{/if}}
-            {{/if}}
-              {{#if model.hearingsSubmitted}}
-                {{#deduped-hearings-list project=model as |dedupedHearings|}}
-                  <h5 class="column-header">Hearing Information</h5>
-                      <ul class="no-bullet">
-                      {{#each dedupedHearings as |hearing|}}
-                        <li class="grid-x small-margin-bottom">
-                          <div class="cell shrink small-margin-right">
-                            {{#if (is-before hearing.dcpDateofpublichearing)}}
-                              {{fa-icon "calendar" class="light-gray" fixedWidth=true}}
-                            {{else}}
-                              {{fa-icon "check" class="blue" fixedWidth=true}}
-                            {{/if}}
-                          </div>
-                          <div class="cell auto">
-                            <strong data-test-hearing-location="{{hearing.id}}" class="display-block">
-                              {{~hearing.dcpPublichearinglocation~}}
-                            </strong>
-                            <span data-test-hearing-date="{{hearing.id}}">
-                              {{~moment-format hearing.dcpDateofpublichearing "MM/D/YYYY"~}}
-                            </span>
-                            <span class="light-gray">|</span>
-                            <span data-test-hearing-time="{{hearing.id}}">
-                              {{~moment-format hearing.dcpDateofpublichearing "h:mm A"~}}
-                            </span>
-                            <span data-test-hearing-actions-list="{{hearing.id}}" class="display-block text-tiny">
-                              {{#each hearing.hearingActions as |action index|}}
-                                {{if (gt index 0) ", "}}{{action.dcpName}}
-                              {{/each}}
-                            </span>
-                          </div>
-                        </li>
-                      {{/each}}
-                      </ul>
-                {{/deduped-hearings-list}}
-              {{/if}}
-              {{#if model.hearingsWaived}}
-                <span data-test-hearings-waived-message>You have opted out of submitting hearings</span>
-              {{/if}}
-              {{#if model.hearingsNotSubmittedNotWaived}}
-                {{#link-to "my-projects.project.hearing.add" model.id class="button expanded"}}
-                  <span data-test-button-hearing-form>
-                    {{fa-icon 'calendar-alt' prefix='far' fixedWidth=true size="lg"}}
-                    Submit Participant Type Hearing Info
-                  </span>
+              {{#if model.hearingsSubmittedOrWaived}}
+                {{#link-to "my-projects.project.recommendations.add" model.id class="button expanded"}}
+                <span data-test-button-to-rec-form>
+                  {{fa-icon 'thumbs-up' prefix='far' fixedWidth=true size="lg"}}
+                  Submit {{participant-type-label model.dcpLupteammemberrole}} Recommendation
+                </span>
                 {{/link-to}}
-                <p class="text-small text-right">
-                  <span class="display-inline-block">
-                    <button
-                      class="button tiny clear no-margin"
-                      onClick={{action "openOptOutHearingPopup"}}
-                      data-test-button="optOutHearingOpenPopup"
-                    >
-                      Opt out of hearings
-                    </button>
-                    {{waive-hearings-popup project=model showPopup=showPopup}}
-                  </span>
-                </p>
               {{/if}}
+            {{/if}}
+            {{#if model.hearingsSubmitted}}
+              {{#deduped-hearings-list project=model as |dedupedHearings|}}
+                <h5 class="column-header">Hearing Information</h5>
+                <ul class="no-bullet">
+                {{#each dedupedHearings as |hearing|}}
+                  <li class="grid-x small-margin-bottom">
+                    <div class="cell shrink small-margin-right">
+                      {{#if (is-before hearing.dcpDateofpublichearing)}}
+                        {{fa-icon "calendar" class="light-gray" fixedWidth=true}}
+                      {{else}}
+                        {{fa-icon "check" class="blue" fixedWidth=true}}
+                      {{/if}}
+                    </div>
+                    <div class="cell auto">
+                      <strong data-test-hearing-location="{{hearing.id}}" class="display-block">
+                        {{~hearing.dcpPublichearinglocation~}}
+                      </strong>
+                      <span data-test-hearing-date="{{hearing.id}}">
+                        {{~moment-format hearing.dcpDateofpublichearing "MM/D/YYYY"~}}
+                      </span>
+                      <span class="light-gray">|</span>
+                      <span data-test-hearing-time="{{hearing.id}}">
+                        {{~moment-format hearing.dcpDateofpublichearing "h:mm A"~}}
+                      </span>
+                      <span data-test-hearing-actions-list="{{hearing.id}}" class="display-block text-tiny">
+                        {{#each hearing.hearingActions as |action index|}}
+                          {{if (gt index 0) ", "}}{{action.dcpName}}
+                        {{/each}}
+                      </span>
+                    </div>
+                  </li>
+                {{/each}}
+                </ul>
+              {{/deduped-hearings-list}}
+            {{/if}}
+            {{#if model.hearingsWaived}}
+              <span data-test-hearings-waived-message>You have opted out of submitting hearings</span>
+            {{/if}}
+            {{#if model.hearingsNotSubmittedNotWaived}}
+              {{#link-to "my-projects.project.hearing.add" model.id class="button expanded"}}
+                <span data-test-button-hearing-form>
+                  {{fa-icon 'calendar-alt' prefix='far' fixedWidth=true size="lg"}}
+                  Submit {{participant-type-label model.dcpLupteammemberrole}} Hearing Info
+                </span>
+              {{/link-to}}
+              <p class="text-small text-right">
+                <span class="display-inline-block">
+                  <button
+                    class="button tiny clear no-margin"
+                    onClick={{action "openOptOutHearingPopup"}}
+                    data-test-button="optOutHearingOpenPopup"
+                  >
+                    Opt out of hearings
+                  </button>
+                  {{waive-hearings-popup project=model showPopup=showPopup}}
+                </span>
+              </p>
+            {{/if}}
           </div>
         {{/if}}
 

--- a/tests/acceptance/dashboard-tab-links-test.js
+++ b/tests/acceptance/dashboard-tab-links-test.js
@@ -65,7 +65,7 @@ module('Acceptance | dashboard tab links', function(hooks) {
 
     await visit('/my-projects/to-review');
 
-    await visit('/my-projects/1/recommendations/add?participantType=CB');
+    await visit('/my-projects/1/recommendations/add');
 
     assert.notOk(find('[data-test-dashboard-tab-links]'));
 

--- a/tests/acceptance/user-can-submit-recommendation-form-test.js
+++ b/tests/acceptance/user-can-submit-recommendation-form-test.js
@@ -12,46 +12,47 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { invalidateSession, authenticateSession } from 'ember-simple-auth/test-support';
 import moment from 'moment';
 
-const NUM_CB_USER_PROJECTS = 2;
+const NUM_USER_PROJECTS = 2;
 
 // First project will have 3 dispos with hearings, second project will have 1 dispo without hearing
-function setUpCBProjectAndDispos(server) {
-  const seedCBUser = server.create('user', {
+function setUpProjectAndDispos(server, participantType) {
+  const seedUser = server.create('user', {
     id: 1,
+    // These two fields don't matter to these tests
     email: 'qncb5@planning.nyc.gov',
     landUseParticipant: 'QNCB5',
   });
-  const seedCBUserProjects = server.createList('project', NUM_CB_USER_PROJECTS, {
-    dcpLupteammemberrole: 'CB',
+  const seedUserProjects = server.createList('project', NUM_USER_PROJECTS, {
+    dcpLupteammemberrole: participantType,
   });
-  seedCBUser.projects = seedCBUserProjects;
+  seedUser.projects = seedUserProjects;
 
   let projectIdx = 0;
-  seedCBUserProjects[projectIdx].actions = server.createList('action', 3);
+  seedUserProjects[projectIdx].actions = server.createList('action', 3);
   for (let j = 0; j < 2; j += 1) {
     server.create('disposition', {
-      user: seedCBUser,
-      project: seedCBUserProjects[projectIdx],
-      action: seedCBUserProjects[projectIdx].actions.models[j],
+      user: seedUser,
+      project: seedUserProjects[projectIdx],
+      action: seedUserProjects[projectIdx].actions.models[j],
       dcpPublichearinglocation: 'Canal street',
       dcpDateofpublichearing: moment().subtract(22, 'days'),
     });
   }
 
   server.create('disposition', {
-    user: seedCBUser,
-    project: seedCBUserProjects[projectIdx],
-    action: seedCBUserProjects[projectIdx].actions.models[2],
+    user: seedUser,
+    project: seedUserProjects[projectIdx],
+    action: seedUserProjects[projectIdx].actions.models[2],
     dcpPublichearinglocation: 'Hudson Yards',
     dcpDateofpublichearing: moment().subtract(28, 'days'),
   });
 
   projectIdx = 1;
-  seedCBUserProjects[projectIdx].actions = server.createList('action', 1);
+  seedUserProjects[projectIdx].actions = server.createList('action', 1);
   server.create('disposition', {
-    user: seedCBUser,
-    project: seedCBUserProjects[projectIdx],
-    action: seedCBUserProjects[projectIdx].actions.models[0],
+    user: seedUser,
+    project: seedUserProjects[projectIdx],
+    action: seedUserProjects[projectIdx].actions.models[0],
     dcpPublichearinglocation: null,
     dcpDateofpublichearing: null,
   });
@@ -73,7 +74,7 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
   });
 
   test('CB User does not see quorum question if no hearings submitted', async function(assert) {
-    setUpCBProjectAndDispos(server);
+    setUpProjectAndDispos(server, 'CB');
 
     await authenticateSession();
 
@@ -84,7 +85,7 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
   });
 
   test('CB User does not see quorum question if no hearings submitted', async function(assert) {
-    setUpCBProjectAndDispos(server);
+    setUpProjectAndDispos(server, 'CB');
 
     await authenticateSession();
 
@@ -95,7 +96,7 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
   });
 
   test('CB User does not see "All Actions" question if project has only one disposition', async function(assert) {
-    setUpCBProjectAndDispos(server);
+    setUpProjectAndDispos(server, 'CB');
 
     await authenticateSession();
 
@@ -107,11 +108,11 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
   });
 
   test('CB User can submit one recommendation for all actions', async function(assert) {
-    setUpCBProjectAndDispos(server);
+    setUpProjectAndDispos(server, 'CB');
 
     await authenticateSession();
 
-    await visit('/my-projects/1/recommendations/add?participantType=CB');
+    await visit('/my-projects/1/recommendations/add');
 
     await click('[data-test-quorum-yes="0"]');
 
@@ -154,11 +155,11 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
   });
 
   test('CB User can submit a recommendation for each action', async function(assert) {
-    setUpCBProjectAndDispos(server);
+    setUpProjectAndDispos(server, 'CB');
 
     await authenticateSession();
 
-    await visit('/my-projects/1/recommendations/add?participantType=CB');
+    await visit('/my-projects/1/recommendations/add');
 
     await click('[data-test-quorum-no="0"]');
 
@@ -222,11 +223,11 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
   });
 
   test('BP User can submit one recommendation for all actions', async function(assert) {
-    setUpCBProjectAndDispos(server);
+    setUpProjectAndDispos(server, 'BP');
 
     await authenticateSession();
 
-    await visit('/my-projects/1/recommendations/add?participantType=BP');
+    await visit('/my-projects/1/recommendations/add');
 
     await click('[data-test-quorum-no="0"]');
 
@@ -248,11 +249,11 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
   });
 
   test('BP User can submit a recommendation for each action', async function(assert) {
-    setUpCBProjectAndDispos(server);
+    setUpProjectAndDispos(server, 'BP');
 
     await authenticateSession();
 
-    await visit('/my-projects/1/recommendations/add?participantType=BP');
+    await visit('/my-projects/1/recommendations/add');
 
     await click('[data-test-quorum-no="0"]');
 
@@ -286,11 +287,11 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
   });
 
   test('BP does not see vote fields', async function(assert) {
-    setUpCBProjectAndDispos(server);
+    setUpProjectAndDispos(server, 'BP');
 
     await authenticateSession();
 
-    await visit('/my-projects/1/recommendations/add?participantType=BP');
+    await visit('/my-projects/1/recommendations/add');
 
     await click('[data-test-quorum-no="0"]');
 
@@ -323,11 +324,11 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
   });
 
   test('BP does not see vote fields on confirmation modal', async function(assert) {
-    setUpCBProjectAndDispos(server);
+    setUpProjectAndDispos(server, 'BP');
 
     await authenticateSession();
 
-    await visit('/my-projects/1/recommendations/add?participantType=BP');
+    await visit('/my-projects/1/recommendations/add');
 
     await click('[data-test-quorum-yes="0"]');
 
@@ -378,11 +379,11 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
   });
 
   test('CB User can waive vote fields', async function(assert) {
-    setUpCBProjectAndDispos(server);
+    setUpProjectAndDispos(server, 'CB');
 
     await authenticateSession();
 
-    await visit('/my-projects/1/recommendations/add?participantType=CB');
+    await visit('/my-projects/1/recommendations/add');
 
     await click('[data-test-quorum-yes="0"]');
 

--- a/tests/acceptance/user-can-waive-hearings-test.js
+++ b/tests/acceptance/user-can-waive-hearings-test.js
@@ -62,7 +62,7 @@ module('Acceptance | user can waive hearings', function(hooks) {
 
     await click('[data-test-button="submitRecommendation"]');
 
-    assert.equal(currentURL(), '/my-projects/4/recommendations/add?participantType=CB');
+    assert.equal(currentURL(), '/my-projects/4/recommendations/add');
 
     assert.ok(find('[data-test-hearings-waived-message]'));
   });

--- a/tests/integration/components/to-review-project-card-test.js
+++ b/tests/integration/components/to-review-project-card-test.js
@@ -35,6 +35,7 @@ module('Integration | Component | to-review-project-card', function(hooks) {
     const project = store.createRecord('project', {
       id: 1,
       dispositions: [disp1, disp2, disp3],
+      dcpLupteammemberrole: 'CB',
     });
 
     this.set('project', project);
@@ -80,6 +81,7 @@ module('Integration | Component | to-review-project-card', function(hooks) {
     const project = store.createRecord('project', {
       id: 1,
       dispositions: [disp1, disp2, disp3],
+      dcpLupteammemberrole: 'CB',
     });
 
     this.set('project', project);
@@ -124,6 +126,7 @@ module('Integration | Component | to-review-project-card', function(hooks) {
     const project = store.createRecord('project', {
       id: 1,
       dispositions: [disp1, disp2, disp3],
+      dcpLupteammemberrole: 'CB',
     });
 
     this.set('project', project);

--- a/tests/integration/helpers/participant-type-label-test.js
+++ b/tests/integration/helpers/participant-type-label-test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | participant-type-label', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`{{participant-type-label "CB"}}`);
+
+    assert.equal(this.element.textContent.trim(), 'Community Board');
+
+    await render(hbs`{{participant-type-label "BB"}}`);
+
+    assert.equal(this.element.textContent.trim(), 'Borough Board');
+
+    await render(hbs`{{participant-type-label "BP"}}`);
+
+    assert.equal(this.element.textContent.trim(), 'Borough President');
+  });
+});

--- a/tests/unit/controllers/my-projects/project/recommendations/add-test.js
+++ b/tests/unit/controllers/my-projects/project/recommendations/add-test.js
@@ -107,7 +107,7 @@ module('Unit | Controller | my-projects/project/recommendations/add', function(h
 
     controller.set('allActions', true);
 
-    controller.set('participantType', 'CB');
+    controller.set('model', { dcpLupteammemberrole: 'CB' });
 
     controller.send('setDispositionRec', controller.dispositionForAllActionsChangeset, 'Disapproved');
 
@@ -120,7 +120,7 @@ module('Unit | Controller | my-projects/project/recommendations/add', function(h
 
     controller.set('allActions', false);
 
-    controller.set('participantType', 'CB');
+    controller.set('model', { dcpLupteammemberrole: 'CB' });
 
     controller.set('dispositions', server.createList('disposition', 3));
     controller.send('setDispositionRec', controller.dispositionsChangesets[0], 'Disapproved');
@@ -129,7 +129,7 @@ module('Unit | Controller | my-projects/project/recommendations/add', function(h
     assert.equal(controller.dispositionsChangesets[0].get('dcpBoroughboardrecommendation'), undefined);
     assert.equal(controller.dispositionsChangesets[0].get('dcpBoroughpresidentrecommendation'), undefined);
 
-    controller.set('participantType', 'BB');
+    controller.set('model', { dcpLupteammemberrole: 'BB' });
 
     controller.send('setDispositionRec', controller.dispositionsChangesets[1], 'Approved');
 
@@ -137,7 +137,7 @@ module('Unit | Controller | my-projects/project/recommendations/add', function(h
     assert.equal(controller.dispositionsChangesets[1].get('dcpBoroughboardrecommendation'), 'Approved');
     assert.equal(controller.dispositionsChangesets[1].get('dcpBoroughpresidentrecommendation'), undefined);
 
-    controller.set('participantType', 'BP');
+    controller.set('model', { dcpLupteammemberrole: 'BP' });
 
     controller.send('setDispositionRec', controller.dispositionsChangesets[2], 'Waived');
 
@@ -154,7 +154,7 @@ module('Unit | Controller | my-projects/project/recommendations/add', function(h
 
     controller.set('allActions', true);
 
-    controller.set('participantType', 'CB');
+    controller.set('model', { dcpLupteammemberrole: 'CB' });
 
     controller.set('dispositions', [EmberObject.create(), EmberObject.create()]);
 
@@ -201,7 +201,7 @@ module('Unit | Controller | my-projects/project/recommendations/add', function(h
 
     controller.set('allActions', false);
 
-    controller.set('participantType', 'CB');
+    controller.set('model', { dcpLupteammemberrole: 'CB' });
 
     controller.set('dispositions', [EmberObject.create(), EmberObject.create()]);
 


### PR DESCRIPTION
Removes use of participantType queryParam for the recommendation form, and uses `project.dcpTeammemberrole`

# Rider:
Introduces some complimentary template work to remove [Participant Type] placeholders and make them dynamic based on dcpTeammemberrole.

# TODO:
 After #714. is complete, we need to again modify these references to `dcpTeammemberrole`.

Otherwise, we should be replacing `project.dcpLupteammemberrole` or `model.dcpLupteammemberrole` with `assignment.dcpLupteammemberrole`

On show-project.hbs, we'll probably replace `project.dcpLupteammemberrole` with something like `project.assignments[0].dcpLupteammemberrole`