### PR TITLE
545 - LUP login instructions

### DIFF
--- a/app/components/confirmation-modal.js
+++ b/app/components/confirmation-modal.js
@@ -1,5 +1,11 @@
 import Component from '@ember/component';
+import { action } from '@ember/object';
 
 export default class ConfirmationModalComponent extends Component {
   open = false;
+
+  @action
+  closeModal() {
+    this.set('open', false);
+  }
 }

--- a/app/components/sign-in.js
+++ b/app/components/sign-in.js
@@ -8,6 +8,8 @@ import ENV from 'labs-zap-search/config/environment';
 export default class SignInComponent extends Component {
   oauthEndpoint = ENV.OAUTH_ENDPOINT;
 
+  showAuthModal = false;
+
   @service
   session
 
@@ -19,5 +21,10 @@ export default class SignInComponent extends Component {
     this.session.invalidate();
 
     this.router.transitionTo('logout');
+  }
+
+  @action
+  toggleAuthModal() {
+    this.set('showAuthModal', !this.get('showAuthModal'));
   }
 }

--- a/app/styles/modules/_m-auth.scss
+++ b/app/styles/modules/_m-auth.scss
@@ -33,9 +33,9 @@
   }
 }
 .site-header .menu a.auth--login-button {
-  color: $a11y-orange;
+  // color: $a11y-orange;
 
   .fa-user-circle {
-    margin-right: rem-calc(6);
+    margin-right: rem-calc(4);
   }
 }

--- a/app/styles/modules/_m-reveal-modal.scss
+++ b/app/styles/modules/_m-reveal-modal.scss
@@ -2,11 +2,16 @@
 // Module: Reveal Modal
 // --------------------------------------------------
 
+#reveal-modal-container {
+  z-index: 3;
+}
+
 .reveal-overlay {
   padding: 1rem;
 
   @include breakpoint(medium) {
-    position: absolute;
+    padding: 4rem 1rem;
+    // position: absolute;
   }
 }
 
@@ -17,10 +22,5 @@
 
   &:focus {
     outline: none;
-  }
-
-  @include breakpoint(medium) {
-    margin-top: 2rem;
-    margin-bottom: 4rem;
   }
 }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -40,3 +40,6 @@
 <div class="site-main grid-x grid-padding-x route-{{currentRouteName}}">
   {{outlet}}
 </div>
+
+<div id="reveal-modal-container">
+</div>

--- a/app/templates/components/confirmation-modal.hbs
+++ b/app/templates/components/confirmation-modal.hbs
@@ -1,7 +1,10 @@
 {{#if open}}
   <div class="reveal-overlay" style="display:block;">
     <div class="reveal" role="dialog" aria-hidden="false" tabindex="-1" style="display:block;">
-        {{yield}}
+      {{yield}}
+      <button {{action closeModal}} class="close-button" aria-label="Close modal" type="button">
+        <span aria-hidden="true">&times;</span>
+      </button>
     </div>
   </div>
 {{/if}}

--- a/app/templates/components/sign-in.hbs
+++ b/app/templates/components/sign-in.hbs
@@ -22,13 +22,41 @@
 {{else}}
   <li>
     <a
-      data-test-auth-login-button
+      data-test-auth-login-button 
       class="auth--login-button"
-      href={{this.oauthEndpoint}}
-    >
+      {{action toggleAuthModal}}
+      >
       {{fa-icon 'user-circle' class="light-gray"}}
       Sign In
-      <sup>{{fa-icon 'external-link-alt'}}</sup>
     </a>
   </li>
 {{/if}}
+
+{{#ember-wormhole to="reveal-modal-container"}}
+  {{#confirmation-modal open=showAuthModal}}
+    <h2 class="large-margin-right small-margin-bottom">Borough&nbsp;Presidents &amp;&nbsp;Community&nbsp;Boards,</h2>
+    <p class="lead">
+      <strong>Use your NYC.ID account to connect to the Zoning Application Portal.</strong>
+      <small><a href="https://www1.nyc.gov/assets/nyc4d/html/services-nycid/user-features-benefits.shtml" class="no-wrap">What is NYC.ID?</a></small>
+    </p>
+    <p class="small-margin-bottom">Log in with the email address associated with the Zoning Application Portal.</p>
+    <p>If you're unsure which email address to use, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or 212-720-3300.</p>
+    <ul class="text-small">
+      <li>
+        <p class="small-margin-bottom">For NYC.GOV credentials, select the "NYC Employees" option</p>
+      </li>
+      <li>
+        <p>For non-NYC.GOV email addresses, enter your existing NYC.ID credentials (you may need to create an NYC.ID account)</p>
+      </li>
+    </ul>
+    <p>Once you're logged in, you'll be redirected back to the Zoning Application Portal, where you'll see your list of assigned projects.</p>
+
+    <a
+      class="button large expanded"
+      href={{this.oauthEndpoint}}
+    >
+      Sign in with NYC.ID
+      <sup>{{fa-icon 'external-link-alt'}}</sup>
+    </a>
+  {{/confirmation-modal}}
+{{/ember-wormhole}}

--- a/app/templates/components/waive-hearings-popup.hbs
+++ b/app/templates/components/waive-hearings-popup.hbs
@@ -1,15 +1,17 @@
-{{#ember-popover isShown=showPopup event="none" side="left"}}
-  <div class="text-small" style="max-width: 30rem;">
-    <p>Without proper notice of a public hearing, the Community Board's recommendation does not comply with City Charter requirements.
+{{#ember-wormhole to="reveal-modal-container"}}
+  {{#confirmation-modal open=showPopup}}
+
+    <h3>Opt out of hearings for: <br>{{project.dcpProjectname}}</h3>
+    <p class="text-small">Without proper notice of a public hearing, the Community Board's recommendation does not comply with City Charter requirements.
     NYC Planning will still accept a recommendation, but a disapproval will not trigger an automatic City Council call up.</p>
-    <p><strong>Are you sure you want to opt out of submitting hearings for this project?</strong></p>
+    <p><strong>Are you sure you want to opt out of submitting hearings?</strong></p>
     <button
       class="button small"
       data-test-button="onConfirmOptOutHearing"
       type="button"
       onClick={{action "onConfirmOptOutHearing" project.dispositions}}
     >
-      Opt out of Hearings
+      Opt Out
     </button>
     <button
       class="button small clear"
@@ -19,5 +21,6 @@
     >
       Cancel
     </button>
-  </div>
-{{/ember-popover}}
+
+  {{/confirmation-modal}}
+{{/ember-wormhole}}

--- a/app/templates/logout.hbs
+++ b/app/templates/logout.hbs
@@ -4,11 +4,10 @@
   <div class="grid-container">
     <div class="grid-x grid-padding-x grid-padding-y align-middle" style="min-height: 50vh">
       <div class="cell large-6 large-offset-3 text-center">
-        <h2>Successfully logged out</h2>
+        <h2>You have successfully signed out.</h2>
       </div>
     </div>
   </div>
 </div>
 
 {{outlet}}
-

--- a/app/templates/my-projects/project/hearing/add.hbs
+++ b/app/templates/my-projects/project/hearing/add.hbs
@@ -69,6 +69,7 @@
         </button>
     {{/if}}
 
+    {{#ember-wormhole to="reveal-modal-container"}}
       {{#confirmation-modal open=modalOpen}}
         <h3>Confirm hearing information</h3>
 
@@ -150,6 +151,7 @@
           </button>
         </p>
       {{/confirmation-modal}}
+    {{/ember-wormhole}}
   </div>
 </div>
 

--- a/app/templates/my-projects/project/recommendations/add.hbs
+++ b/app/templates/my-projects/project/recommendations/add.hbs
@@ -473,6 +473,18 @@
               </label>
               <input type="file" id="exampleFileUpload_2" class="show-for-sr">
             </div>
+            <fieldset class="medium-margin-bottom">
+              <button
+                class="button large-margin-top"
+                type="button"
+                onClick={{this.onContinue}}
+              >
+                Continue
+              </button>
+            </fieldset>
+          {{/if}}
+
+          {{#ember-wormhole to="reveal-modal-container"}}
             {{#confirmation-modal open=modalOpen}}
               <h3>Confirm recommendation information</h3>
                 <h5>
@@ -571,16 +583,8 @@
                 </button>
               </p>
             {{/confirmation-modal}}
-            <fieldset class="medium-margin-bottom">
-              <button
-                class="button large-margin-top"
-                type="button"
-                onClick={{this.onContinue}}
-              >
-                Continue
-              </button>
-            </fieldset>
-          {{/if}}
+          {{/ember-wormhole}}
+
         </div>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "ember-test-selectors": "^2.1.0",
     "ember-truth-helpers": "2.0.0",
     "ember-welcome-page": "^4.0.0",
+    "ember-wormhole": "^0.5.5",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^13.0.0",
     "eslint-plugin-ember": "^6.2.0",

--- a/tests/integration/components/confirmation-modal-test.js
+++ b/tests/integration/components/confirmation-modal-test.js
@@ -6,7 +6,7 @@ import hbs from 'htmlbars-inline-precompile';
 module('Integration | Component | confirmation-modal', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function(assert) {
+  test('the confirmation modal has a close button', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
@@ -17,6 +17,6 @@ module('Integration | Component | confirmation-modal', function(hooks) {
       {{/confirmation-modal}}
     `);
 
-    assert.equal(this.element.textContent.trim(), 'template block text');
+    assert.equal(this.element.querySelector('.close-button').hasAttribute('aria-label'), true);
   });
 });

--- a/tests/integration/components/sign-in-test.js
+++ b/tests/integration/components/sign-in-test.js
@@ -18,7 +18,7 @@ module('Integration | Component | sign-in', function(hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`<SignIn />`);
+    await render(hbs`<SignIn /><div id="reveal-modal-container"></div>`);
 
     assert.equal(this.element.textContent.trim(), 'Sign In');
   });
@@ -28,7 +28,7 @@ module('Integration | Component | sign-in', function(hooks) {
       emailaddress1: 'test@planning.nyc.gov',
     });
 
-    await render(hbs`<SignIn />`);
+    await render(hbs`<SignIn /><div id="reveal-modal-container"></div>`);
 
     assert.equal(find('[data-test-auth-name]').textContent.trim(), 'test@planning.nyc.gov');
 

--- a/tests/integration/components/to-review-project-card-test.js
+++ b/tests/integration/components/to-review-project-card-test.js
@@ -45,6 +45,7 @@ module('Integration | Component | to-review-project-card', function(hooks) {
     await render(hbs`
       {{#to-review-project-card project=project}}
       {{/to-review-project-card}}
+      <div id="reveal-modal-container"></div>
     `);
 
     const card = this.element.textContent.trim();
@@ -92,6 +93,7 @@ module('Integration | Component | to-review-project-card', function(hooks) {
     await render(hbs`
       {{#to-review-project-card project=project}}
       {{/to-review-project-card}}
+      <div id="reveal-modal-container"></div>
     `);
 
     const card = this.element.textContent.trim();
@@ -136,6 +138,7 @@ module('Integration | Component | to-review-project-card', function(hooks) {
     await render(hbs`
       {{#to-review-project-card project=project}}
       {{/to-review-project-card}}
+      <div id="reveal-modal-container"></div>
     `);
 
     const card = this.element.textContent.trim();

--- a/tests/integration/components/upcoming-project-card-test.js
+++ b/tests/integration/components/upcoming-project-card-test.js
@@ -45,6 +45,7 @@ module('Integration | Component | upcoming-project-card', function(hooks) {
     await render(hbs`
       {{#to-review-project-card project=project}}
       {{/to-review-project-card}}
+      <div id="reveal-modal-container"></div>
     `);
 
     const card = this.element.textContent.trim();
@@ -91,6 +92,7 @@ module('Integration | Component | upcoming-project-card', function(hooks) {
     await render(hbs`
       {{#upcoming-project-card project=project}}
       {{/upcoming-project-card}}
+      <div id="reveal-modal-container"></div>
     `);
 
     const card = this.element.textContent.trim();
@@ -135,6 +137,7 @@ module('Integration | Component | upcoming-project-card', function(hooks) {
     await render(hbs`
       {{#upcoming-project-card project=project}}
       {{/upcoming-project-card}}
+      <div id="reveal-modal-container"></div>
     `);
 
     const card = this.element.textContent.trim();

--- a/tests/integration/components/waive-hearings-popup-test.js
+++ b/tests/integration/components/waive-hearings-popup-test.js
@@ -17,11 +17,12 @@ module('Integration | Component | waive-hearings-popup', function(hooks) {
       {{#waive-hearings-popup
         showPopup=true}}
       {{/waive-hearings-popup}}
+      <div id="reveal-modal-container"></div>
     `);
 
     const waiveHearingsMessageOnPopup = this.element.textContent.trim();
 
-    const messageVisible = waiveHearingsMessageOnPopup.includes('Are you sure you want to opt out of submitting hearings for this project?');
+    const messageVisible = waiveHearingsMessageOnPopup.includes('Are you sure you want to opt out of submitting hearings?');
 
     assert.ok(messageVisible);
   });


### PR DESCRIPTION
This PR… 

- Adds instructions to the sign in process. Now when you click the sign in button, a modal opens with instructions for LUPs. The button in the modal goes to NYC.ID. Closes #545. 
- Refactors the way modals work. Before they were difficult to style, being positioned relative to their various nested containers. Now there's one place in the `application.hbs` markup where we send all modals via `ember-wormhole`. 
- The modal now has a built-in close button that can be used in addition to any cancel button passed into the block. 
- Modal styles are simplified to not unnecessarily override Foundation's defaults. 
- Opt-out of hearings button now uses modal instead of `ember-popover`. Closes #752. 
- Fixes confirmation modal in the recommendations/add template which was wrongly nested inside an if condition. 

![image](https://user-images.githubusercontent.com/409279/66605255-b4e72f80-eb7d-11e9-910d-0e82f4629674.png)

![image](https://user-images.githubusercontent.com/409279/66605286-c3354b80-eb7d-11e9-8dd9-a9a1faac0fe5.png)
