### PR TITLE
add icons to LUP buttons

### DIFF
--- a/app/templates/components/to-review-project-card.hbs
+++ b/app/templates/components/to-review-project-card.hbs
@@ -27,6 +27,7 @@
           class="button expanded"
           data-test-button="submitRecommendation"
         >
+          {{fa-icon 'thumbs-up' prefix='far' fixedWidth=true size="lg"}}
           Submit Community Board Recommendation
         </LinkTo>
       {{/if}}
@@ -75,6 +76,7 @@
           class="button expanded tiny-margin-bottom"
           data-test-button="submitHearing"
         >
+          {{fa-icon 'calendar-alt' prefix='far' fixedWidth=true size="lg"}}
           Submit Community Board Hearing Info
         </LinkTo>
         <p class="text-small text-right">

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -55,6 +55,7 @@
           class="button expanded tiny-margin-bottom"
           data-test-button="submitHearing"
         >
+          {{fa-icon 'calendar-alt' prefix='far' fixedWidth=true size="lg"}}
           Submit Community Board Hearing Info
         </LinkTo>
         <p class="text-small text-right">

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -172,8 +172,9 @@
                 </div>
               </div>
                 {{#if hearingsSubmittedOrWaived}}
-                  {{#link-to "my-projects.project.recommendations.add" model.id}}
-                  <span class="button expanded" data-test-button-to-rec-form>
+                  {{#link-to "my-projects.project.recommendations.add" model.id class="button expanded"}}
+                  <span data-test-button-to-rec-form>
+                    {{fa-icon 'thumbs-up' prefix='far' fixedWidth=true size="lg"}}
                     Submit Participant Type Recommendation
                   </span>
                   {{/link-to}}
@@ -218,8 +219,9 @@
                 <span data-test-hearings-waived-message>You have opted out of submitting hearings</span>
               {{/if}}
               {{#if hearingsNotSubmittedNotWaived}}
-                {{#link-to "my-projects.project.hearing.add" model.id}}
-                  <span class="button expanded" data-test-button-hearing-form>
+                {{#link-to "my-projects.project.hearing.add" model.id class="button expanded"}}
+                  <span data-test-button-hearing-form>
+                    {{fa-icon 'calendar-alt' prefix='far' fixedWidth=true size="lg"}}
                     Submit Participant Type Hearing Info
                   </span>
                 {{/link-to}}


### PR DESCRIPTION
This PR adds icons to the LUP's hearing/recommendation buttons so they look less identical. So when you add or opt-out of hearings, the recommendation button is more noticeably different. 

![image](https://user-images.githubusercontent.com/409279/66658040-ac8b0500-ec0e-11e9-87bc-df138aa31dac.png)
