### PR TITLE
762: refactor checking hearings status

### DIFF
--- a/app/components/to-review-project-card.js
+++ b/app/components/to-review-project-card.js
@@ -21,46 +21,6 @@ export default class ToReviewProjectCardComponent extends Component {
     return moment(this.project.toReviewMilestoneActualEndDate).diff(moment(this.project.toReviewMilestoneActualStartDate), 'days');
   }
 
-  // if the each dcpPublichearinglocation and dcpDateofpublichearing properties are filled in dispositions array,
-  // then hearings have been submitted for that project
-  @computed('project.dispositions.@each.{dcpPublichearinglocation,dcpDateofpublichearing}')
-  get hearingsSubmitted() {
-    const dispositions = this.get('project.dispositions');
-    // array of hearing locations
-    const dispositionHearingLocations = dispositions.map(disp => `${disp.dcpPublichearinglocation}`);
-    // array of hearing dates
-    const dispositionHearingDates = dispositions.map(disp => disp.dcpDateofpublichearing);
-    // hearingsSubmittedForProject checks whether each item in array is truthy
-    const hearingsSubmittedForProject = dispositionHearingLocations.every(location => !!location) && dispositionHearingDates.every(date => !!date);
-    return hearingsSubmittedForProject;
-  }
-
-  // if all dcpPublichearinglocation in dispositions array equal "waived",
-  // then hearings have been waived
-  @computed('project.dispositions.@each.dcpPublichearinglocation')
-  get hearingsWaived() {
-    const dispositions = this.get('project.dispositions');
-    // array of hearing locations
-    const dispositionHearingLocations = dispositions.map(disp => `${disp.dcpPublichearinglocation}`);
-    // each location field equal to 'waived'
-    const hearingsWaived = dispositionHearingLocations.every(location => location === 'waived');
-    return hearingsWaived;
-  }
-
-  @computed('hearingsSubmitted', 'hearingsWaived')
-  get hearingsSubmittedOrWaived() {
-    const hearingsSubmitted = this.get('hearingsSubmitted');
-    const hearingsWaived = this.get('hearingsWaived');
-    return !!hearingsSubmitted || !!hearingsWaived;
-  }
-
-  @computed('hearingsSubmitted', 'hearingsWaived')
-  get hearingsNotSubmittedNotWaived() {
-    const hearingsSubmitted = this.get('hearingsSubmitted');
-    const hearingsWaived = this.get('hearingsWaived');
-    return !hearingsSubmitted && !hearingsWaived;
-  }
-
   @action
   openOptOutHearingPopup() {
     this.set('showPopup', true);

--- a/app/components/upcoming-project-card.js
+++ b/app/components/upcoming-project-card.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed, action } from '@ember/object';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class UpcomingProjectCardComponent extends Component {
@@ -7,46 +7,6 @@ export default class UpcomingProjectCardComponent extends Component {
   currentUser;
 
   showPopup = false;
-
-  // if the each dcpPublichearinglocation and dcpDateofpublichearing properties are filled in dispositions array,
-  // then hearings have been submitted for that project
-  @computed('project.dispositions.@each.{dcpPublichearinglocation,dcpDateofpublichearing}')
-  get hearingsSubmitted() {
-    const dispositions = this.get('project.dispositions');
-    // array of hearing locations
-    const dispositionHearingLocations = dispositions.map(disp => `${disp.dcpPublichearinglocation}`);
-    // array of hearing dates
-    const dispositionHearingDates = dispositions.map(disp => disp.dcpDateofpublichearing);
-    // hearingsSubmittedForProject checks whether each item in array is truthy
-    const hearingsSubmittedForProject = dispositionHearingLocations.every(location => !!location) && dispositionHearingDates.every(date => !!date);
-    return hearingsSubmittedForProject;
-  }
-
-  // if all dcpPublichearinglocation in dispositions array equal "waived",
-  // then hearings have been waived
-  @computed('project.dispositions.@each.dcpPublichearinglocation')
-  get hearingsWaived() {
-    const dispositions = this.get('project.dispositions');
-    // array of hearing locations
-    const dispositionHearingLocations = dispositions.map(disp => `${disp.dcpPublichearinglocation}`);
-    // each location field equal to 'waived'
-    const hearingsWaived = dispositionHearingLocations.every(location => location === 'waived');
-    return hearingsWaived;
-  }
-
-  @computed('hearingsSubmitted', 'hearingsWaived')
-  get hearingsSubmittedOrWaived() {
-    const hearingsSubmitted = this.get('hearingsSubmitted');
-    const hearingsWaived = this.get('hearingsWaived');
-    return !!hearingsSubmitted || !!hearingsWaived;
-  }
-
-  @computed('hearingsSubmitted', 'hearingsWaived')
-  get hearingsNotSubmittedNotWaived() {
-    const hearingsSubmitted = this.get('hearingsSubmitted');
-    const hearingsWaived = this.get('hearingsWaived');
-    return !hearingsSubmitted && !hearingsWaived;
-  }
 
   @action
   openOptOutHearingPopup() {

--- a/app/controllers/my-projects/project/recommendations/add.js
+++ b/app/controllers/my-projects/project/recommendations/add.js
@@ -64,26 +64,6 @@ export default class MyProjectsProjectRecommendationsAddController extends Contr
 
   minDate = MINIMUM_VOTE_DATE;
 
-  // if the first object dcpPublichearinglocation and dcpDateofpublichearing properties are filled,
-  // then hearings have been submitted for that project
-  @computed('model.dispositions.firstObject.{dcpPublichearinglocation,dcpDateofpublichearing}')
-  get hearingsSubmitted() {
-    const location = this.get('model.dispositions.firstObject.dcpPublichearinglocation');
-    const date = this.get('model.dispositions.firstObject.dcpDateofpublichearing');
-    const locationAndDate = !!location && !!date;
-    return locationAndDate;
-  }
-
-  // if the first object dcpPublichearinglocation is "waived",
-  // then hearings have been waived
-  @computed('model.dispositions.firstObject.dcpPublichearinglocation')
-  get hearingsWaived() {
-    const firstObjectLocation = this.get('model.dispositions.firstObject.dcpPublichearinglocation');
-    const hearingsWaived = firstObjectLocation === 'waived';
-
-    return hearingsWaived;
-  }
-
   @computed('dispositionForAllActions', 'participantType')
   get dispositionForAllActionsChangeset() {
     const { participantType } = this;

--- a/app/controllers/show-project.js
+++ b/app/controllers/show-project.js
@@ -54,46 +54,6 @@ export default class ShowProjectController extends Controller {
     } return false;
   }
 
-  // if the each dcpPublichearinglocation and dcpDateofpublichearing properties are filled in dispositions array,
-  // then hearings have been submitted for that project
-  @computed('model.dispositions.@each.{dcpPublichearinglocation,dcpDateofpublichearing}')
-  get hearingsSubmitted() {
-    const dispositions = this.get('model.dispositions');
-    // array of hearing locations
-    const dispositionHearingLocations = dispositions.map(disp => `${disp.dcpPublichearinglocation}`);
-    // array of hearing dates
-    const dispositionHearingDates = dispositions.map(disp => disp.dcpDateofpublichearing);
-    // hearingsSubmittedForProject checks whether each item in array is truthy
-    const hearingsSubmittedForProject = dispositionHearingLocations.every(location => !!location) && dispositionHearingDates.every(date => !!date);
-    return hearingsSubmittedForProject;
-  }
-
-  // if all dcpPublichearinglocation in dispositions array equal "waived",
-  // then hearings have been waived
-  @computed('model.dispositions.@each.dcpPublichearinglocation')
-  get hearingsWaived() {
-    const dispositions = this.get('model.dispositions');
-    // array of hearing locations
-    const dispositionHearingLocations = dispositions.map(disp => `${disp.dcpPublichearinglocation}`);
-    // each location field equal to 'waived'
-    const hearingsWaived = dispositionHearingLocations.every(location => location === 'waived');
-    return hearingsWaived;
-  }
-
-  @computed('hearingsSubmitted', 'hearingsWaived')
-  get hearingsSubmittedOrWaived() {
-    const hearingsSubmitted = this.get('hearingsSubmitted');
-    const hearingsWaived = this.get('hearingsWaived');
-    return !!hearingsSubmitted || !!hearingsWaived;
-  }
-
-  @computed('hearingsSubmitted', 'hearingsWaived')
-  get hearingsNotSubmittedNotWaived() {
-    const hearingsSubmitted = this.get('hearingsSubmitted');
-    const hearingsWaived = this.get('hearingsWaived');
-    return !hearingsSubmitted && !hearingsWaived;
-  }
-
   @action
   openOptOutHearingPopup() {
     this.set('showPopup', true);

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -204,6 +204,46 @@ export default class ProjectModel extends Model {
     };
   }
 
+  // if the each dcpPublichearinglocation and dcpDateofpublichearing properties are filled in dispositions array,
+  // then hearings have been submitted for that project
+  @computed('dispositions.@each.{dcpPublichearinglocation,dcpDateofpublichearing}')
+  get hearingsSubmitted() {
+    const dispositions = this.get('dispositions');
+    // array of hearing locations
+    const dispositionHearingLocations = dispositions.map(disp => `${disp.dcpPublichearinglocation}`);
+    // array of hearing dates
+    const dispositionHearingDates = dispositions.map(disp => disp.dcpDateofpublichearing);
+    // hearingsSubmittedForProject checks whether each item in array is truthy
+    const hearingsSubmittedForProject = dispositionHearingLocations.every(location => !!location) && dispositionHearingDates.every(date => !!date);
+    return hearingsSubmittedForProject;
+  }
+
+  // if all dcpPublichearinglocation in dispositions array equal "waived",
+  // then hearings have been waived
+  @computed('dispositions.@each.dcpPublichearinglocation')
+  get hearingsWaived() {
+    const dispositions = this.get('dispositions');
+    // array of hearing locations
+    const dispositionHearingLocations = dispositions.map(disp => `${disp.dcpPublichearinglocation}`);
+    // each location field equal to 'waived'
+    const hearingsWaived = dispositionHearingLocations.every(location => location === 'waived');
+    return hearingsWaived;
+  }
+
+  @computed('hearingsSubmitted', 'hearingsWaived')
+  get hearingsSubmittedOrWaived() {
+    const hearingsSubmitted = this.get('hearingsSubmitted');
+    const hearingsWaived = this.get('hearingsWaived');
+    return !!hearingsSubmitted || !!hearingsWaived;
+  }
+
+  @computed('hearingsSubmitted', 'hearingsWaived')
+  get hearingsNotSubmittedNotWaived() {
+    const hearingsSubmitted = this.get('hearingsSubmitted');
+    const hearingsWaived = this.get('hearingsWaived');
+    return !hearingsSubmitted && !hearingsWaived;
+  }
+
   unknownProperty(key) {
     console.log(`Unexpected access of ${key} on ${this}`);
   }

--- a/app/templates/components/to-review-project-card.hbs
+++ b/app/templates/components/to-review-project-card.hbs
@@ -20,7 +20,7 @@
       </div>
     </div>
     <div class="cell medium-8 large-auto">
-      {{#if hearingsSubmittedOrWaived}}
+      {{#if project.hearingsSubmittedOrWaived}}
         <LinkTo @route="my-projects.project.recommendations.add"
           @model={{project.id}}
           @query={{hash participantType="CB"}}
@@ -31,10 +31,10 @@
           Submit Community Board Recommendation
         </LinkTo>
       {{/if}}
-      {{#if hearingsWaived}}
+      {{#if project.hearingsWaived}}
         <span data-test-hearings-waived-message="{{project.id}}">You have opted out of submitting hearings</span>
       {{/if}}
-      {{#if hearingsSubmitted}}
+      {{#if project.hearingsSubmitted}}
         {{#deduped-hearings-list project=project as |dedupedHearings|}}
           <h6>Community Board Hearings:</h6>
               <ul class="no-bullet">
@@ -69,7 +69,7 @@
               </ul>
         {{/deduped-hearings-list}}
       {{/if}}
-      {{#if hearingsNotSubmittedNotWaived}}
+      {{#if project.hearingsNotSubmittedNotWaived}}
         <LinkTo
           @route="my-projects.project.hearing.add"
           @model={{project.id}}

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -10,10 +10,10 @@
       </h3>
       <h5 class="applicant">{{project.applicants}}</h5>
       <p>{{project.dcpProjectbrief}}</p>
-      {{#if hearingsWaived}}
+      {{#if project.hearingsWaived}}
         <span data-test-hearings-waived-message="{{project.id}}">You have opted out of submitting hearings</span>
       {{/if}}
-      {{#if hearingsSubmitted}}
+      {{#if project.hearingsSubmitted}}
         {{#deduped-hearings-list project=project as |dedupedHearings|}}
           <h6>Community Board Hearings:</h6>
               <ul class="no-bullet">
@@ -48,7 +48,7 @@
               </ul>
         {{/deduped-hearings-list}}
       {{/if}}
-      {{#if hearingsNotSubmittedNotWaived}}
+      {{#if project.hearingsNotSubmittedNotWaived}}
         <LinkTo
           @route="my-projects.project.hearing.add"
           @model={{project.id}}

--- a/app/templates/my-projects/project/recommendations/add.hbs
+++ b/app/templates/my-projects/project/recommendations/add.hbs
@@ -40,7 +40,7 @@
           </div>
         </div>
         <div class="cell large-7">
-          {{#if (and hearingsSubmitted (not hearingsWaived))}}
+          {{#if project.hearingsSubmitted}}
             <strong
               data-test-quorum-question
             >
@@ -100,7 +100,7 @@
               {{/each}}
             {{/deduped-hearings-list}}
           {{/if}}
-          {{#if (and hearingsWaived (not hearingsSubmitted))}}
+          {{#if project.hearingsWaived}}
             <div data-test-hearings-waived-message>
               <h5>Note: You have opted out of submitting hearings for this project.</h5>
               <p class="text-small">Without proper notice of a public hearing, the [Participant Type]'s recommendation does not comply with City Charter requirements. NYC Planning will still accept a recommendation, but a disapproval will not trigger an automatic City Council call up.</p>

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -171,7 +171,7 @@
                   <p class="text-small dark-gray"><strong>Ends 09/02/19</strong></p>
                 </div>
               </div>
-                {{#if hearingsSubmittedOrWaived}}
+                {{#if model.hearingsSubmittedOrWaived}}
                   {{#link-to "my-projects.project.recommendations.add" model.id class="button expanded"}}
                   <span data-test-button-to-rec-form>
                     {{fa-icon 'thumbs-up' prefix='far' fixedWidth=true size="lg"}}
@@ -180,7 +180,7 @@
                   {{/link-to}}
                 {{/if}}
             {{/if}}
-              {{#if hearingsSubmitted}}
+              {{#if model.hearingsSubmitted}}
                 {{#deduped-hearings-list project=model as |dedupedHearings|}}
                   <h5 class="column-header">Hearing Information</h5>
                       <ul class="no-bullet">
@@ -215,10 +215,10 @@
                       </ul>
                 {{/deduped-hearings-list}}
               {{/if}}
-              {{#if hearingsWaived}}
+              {{#if model.hearingsWaived}}
                 <span data-test-hearings-waived-message>You have opted out of submitting hearings</span>
               {{/if}}
-              {{#if hearingsNotSubmittedNotWaived}}
+              {{#if model.hearingsNotSubmittedNotWaived}}
                 {{#link-to "my-projects.project.hearing.add" model.id class="button expanded"}}
                   <span data-test-button-hearing-form>
                     {{fa-icon 'calendar-alt' prefix='far' fixedWidth=true size="lg"}}

--- a/tests/integration/components/deduped-hearings-list-test.js
+++ b/tests/integration/components/deduped-hearings-list-test.js
@@ -17,89 +17,87 @@ module('Integration | Component | deduped-hearings-list', function(hooks) {
     const date_B = new Date('2020-11-12T17:45:00');
     const date_C = new Date('2020-10-21T09:25:00');
 
-    const projObject = EmberObject.extend({});
-
-    const ourDisps = EmberObject.extend({});
+    const store = this.owner.lookup('service:store');
 
     // Disposition 22 ############## DUPLICATE WITH 23 & 26
-    const disp22 = ourDisps.create({
+    const disp22 = store.createRecord('disposition', {
       id: 22,
       dcpPublichearinglocation: '121 Bananas Ave, Queens, NY',
       dcpDateofpublichearing: date_A,
-      action: {
+      action: store.createRecord('action', {
         dcpName: 'Zoning Special Permit',
         dcpUlurpnumber: 'C780076TLK',
-      },
+      }),
     });
 
     // Disposition 23 ############## DUPLICATE WITH 22 & 26
-    const disp23 = ourDisps.create({
+    const disp23 = store.createRecord('disposition', {
       id: 23,
       dcpPublichearinglocation: '121 Bananas Ave, Queens, NY',
       dcpDateofpublichearing: date_A,
-      action: {
+      action: store.createRecord('action', {
         dcpName: 'Zoning Text Amendment',
         dcpUlurpnumber: 'N860877TCM',
-      },
+      }),
     });
 
     // Disposition 24 ##########################################################
-    const disp24 = ourDisps.create({
+    const disp24 = store.createRecord('disposition', {
       id: 24,
       dcpPublichearinglocation: '186 Alligators Ave, Staten Island, NY',
       dcpDateofpublichearing: date_B,
-      action: {
+      action: store.createRecord('action', {
         dcpName: 'Business Improvement District',
         dcpUlurpnumber: 'I030148MMQ',
-      },
+      }),
     });
 
     // Disposition 25 ##########################################################
-    const disp25 = ourDisps.create({
+    const disp25 = store.createRecord('disposition', {
       id: 25,
       dcpPublichearinglocation: '144 Piranha Ave, Manhattan, NY',
       dcpDateofpublichearing: date_B,
-      action: {
+      action: store.createRecord('action', {
         dcpName: 'Change in City Map',
         dcpUlurpnumber: '200088ZMX',
-      },
+      }),
     });
 
     // Disposition 26 ############## DUPLICATE WITH 22 & 23
-    const disp26 = ourDisps.create({
+    const disp26 = store.createRecord('disposition', {
       id: 26,
       dcpPublichearinglocation: '121 Bananas Ave, Queens, NY',
       dcpDateofpublichearing: date_A,
-      action: {
+      action: store.createRecord('action', {
         dcpName: 'Enclosed Sidewalk Cafe',
         dcpUlurpnumber: '190172ZMK',
-      },
+      }),
     });
 
     // Disposition 27 ##########################################################
-    const disp27 = ourDisps.create({
+    const disp27 = store.createRecord('disposition', {
       id: 27,
       dcpPublichearinglocation: '456 Crocodiles Ave, Bronx, NY',
       dcpDateofpublichearing: date_B,
-      action: {
+      action: store.createRecord('action', {
         dcpName: 'Large Scale Special Permit',
         dcpUlurpnumber: 'N190257ZRK',
-      },
+      }),
     });
 
 
     // Disposition 28 ##########################################################
-    const disp28 = ourDisps.create({
+    const disp28 = store.createRecord('disposition', {
       id: 28,
       dcpPublichearinglocation: '121 Bananas Ave, Queens, NY',
       dcpDateofpublichearing: date_C,
-      action: {
+      action: store.createRecord('action', {
         dcpName: 'Zoning Certification',
         dcpUlurpnumber: '190256ZMK',
-      },
+      }),
     });
 
-    const project = projObject.create({
+    const project = store.createRecord('project', {
       id: 1,
       dispositions: [disp22, disp23, disp24, disp25, disp26, disp27, disp28],
     });

--- a/tests/integration/components/to-review-project-card-test.js
+++ b/tests/integration/components/to-review-project-card-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import EmberObject from '@ember/object';
 
 module('Integration | Component | to-review-project-card', function(hooks) {
   setupRenderingTest(hooks);
@@ -11,31 +10,29 @@ module('Integration | Component | to-review-project-card', function(hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
+    const store = this.owner.lookup('service:store');
+
     const hearingDate = new Date('2020-10-21T18:30:00');
 
-    const projObject = EmberObject.extend({});
-
-    const dispObject = EmberObject.extend({});
-
-    const disp1 = dispObject.create({
+    const disp1 = store.createRecord('disposition', {
       id: 1,
       dcpPublichearinglocation: '341 Yellow Avenue',
       dcpDateofpublichearing: hearingDate,
     });
 
-    const disp2 = dispObject.create({
+    const disp2 = store.createRecord('disposition', {
       id: 2,
       dcpPublichearinglocation: '890 Purple Street',
       dcpDateofpublichearing: hearingDate,
     });
 
-    const disp3 = dispObject.create({
+    const disp3 = store.createRecord('disposition', {
       id: 3,
       dcpPublichearinglocation: '124 Green Boulevard',
       dcpDateofpublichearing: hearingDate,
     });
 
-    const project = projObject.create({
+    const project = store.createRecord('project', {
       id: 1,
       dispositions: [disp1, disp2, disp3],
     });
@@ -59,30 +56,28 @@ module('Integration | Component | to-review-project-card', function(hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    const projObject = EmberObject.extend({});
+    const store = this.owner.lookup('service:store');
 
-    const dispObject = EmberObject.extend({});
-
-    const disp1 = dispObject.create({
+    const disp1 = store.createRecord('disposition', {
       id: 1,
       dcpPublichearinglocation: '',
       dcpDateofpublichearing: null,
     });
 
-    const disp2 = dispObject.create({
+    const disp2 = store.createRecord('disposition', {
       id: 2,
       dcpPublichearinglocation: '',
       dcpDateofpublichearing: null,
     });
 
-    const disp3 = dispObject.create({
+    const disp3 = store.createRecord('disposition', {
       id: 3,
       dcpPublichearinglocation: '',
       dcpDateofpublichearing: null,
     });
 
 
-    const project = projObject.create({
+    const project = store.createRecord('project', {
       id: 1,
       dispositions: [disp1, disp2, disp3],
     });
@@ -106,29 +101,27 @@ module('Integration | Component | to-review-project-card', function(hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    const projObject = EmberObject.extend({});
+    const store = this.owner.lookup('service:store');
 
-    const dispObject = EmberObject.extend({});
-
-    const disp1 = dispObject.create({
+    const disp1 = store.createRecord('disposition', {
       id: 1,
       dcpPublichearinglocation: 'waived',
       dcpDateofpublichearing: null,
     });
 
-    const disp2 = dispObject.create({
+    const disp2 = store.createRecord('disposition', {
       id: 2,
       dcpPublichearinglocation: 'waived',
       dcpDateofpublichearing: null,
     });
 
-    const disp3 = dispObject.create({
+    const disp3 = store.createRecord('disposition', {
       id: 3,
       dcpPublichearinglocation: 'waived',
       dcpDateofpublichearing: null,
     });
 
-    const project = projObject.create({
+    const project = store.createRecord('project', {
       id: 1,
       dispositions: [disp1, disp2, disp3],
     });

--- a/tests/integration/components/upcoming-project-card-test.js
+++ b/tests/integration/components/upcoming-project-card-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import EmberObject from '@ember/object';
 
 module('Integration | Component | upcoming-project-card', function(hooks) {
   setupRenderingTest(hooks);
@@ -11,31 +10,29 @@ module('Integration | Component | upcoming-project-card', function(hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
+    const store = this.owner.lookup('service:store');
+
     const hearingDate = new Date('2020-10-21T18:30:00');
 
-    const projObject = EmberObject.extend({});
-
-    const dispObject = EmberObject.extend({});
-
-    const disp1 = dispObject.create({
+    const disp1 = store.createRecord('disposition', {
       id: 1,
       dcpPublichearinglocation: '341 Yellow Avenue',
       dcpDateofpublichearing: hearingDate,
     });
 
-    const disp2 = dispObject.create({
+    const disp2 = store.createRecord('disposition', {
       id: 2,
       dcpPublichearinglocation: '890 Purple Street',
       dcpDateofpublichearing: hearingDate,
     });
 
-    const disp3 = dispObject.create({
+    const disp3 = store.createRecord('disposition', {
       id: 3,
       dcpPublichearinglocation: '124 Green Boulevard',
       dcpDateofpublichearing: hearingDate,
     });
 
-    const project = projObject.create({
+    const project = store.createRecord('project', {
       id: 1,
       dispositions: [disp1, disp2, disp3],
     });
@@ -59,30 +56,28 @@ module('Integration | Component | upcoming-project-card', function(hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    const projObject = EmberObject.extend({});
+    const store = this.owner.lookup('service:store');
 
-    const dispObject = EmberObject.extend({});
-
-    const disp1 = dispObject.create({
+    const disp1 = store.createRecord('disposition', {
       id: 1,
       dcpPublichearinglocation: '',
       dcpDateofpublichearing: null,
     });
 
-    const disp2 = dispObject.create({
+    const disp2 = store.createRecord('disposition', {
       id: 2,
       dcpPublichearinglocation: '',
       dcpDateofpublichearing: null,
     });
 
-    const disp3 = dispObject.create({
+    const disp3 = store.createRecord('disposition', {
       id: 3,
       dcpPublichearinglocation: '',
       dcpDateofpublichearing: null,
     });
 
 
-    const project = projObject.create({
+    const project = store.createRecord('project', {
       id: 1,
       dispositions: [disp1, disp2, disp3],
     });
@@ -105,29 +100,27 @@ module('Integration | Component | upcoming-project-card', function(hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    const projObject = EmberObject.extend({});
+    const store = this.owner.lookup('service:store');
 
-    const dispObject = EmberObject.extend({});
-
-    const disp1 = dispObject.create({
+    const disp1 = store.createRecord('disposition', {
       id: 1,
       dcpPublichearinglocation: 'waived',
       dcpDateofpublichearing: null,
     });
 
-    const disp2 = dispObject.create({
+    const disp2 = store.createRecord('disposition', {
       id: 2,
       dcpPublichearinglocation: 'waived',
       dcpDateofpublichearing: null,
     });
 
-    const disp3 = dispObject.create({
+    const disp3 = store.createRecord('disposition', {
       id: 3,
       dcpPublichearinglocation: 'waived',
       dcpDateofpublichearing: null,
     });
 
-    const project = projObject.create({
+    const project = store.createRecord('project', {
       id: 1,
       dispositions: [disp1, disp2, disp3],
     });

--- a/tests/unit/models/project-test.js
+++ b/tests/unit/models/project-test.js
@@ -11,4 +11,101 @@ module('Unit | Model | project', function(hooks) {
     const model = run(() => store.createRecord('project', {}));
     assert.ok(model);
   });
+
+  test('hearingsSubmitted calculated correctly', function(assert) {
+    const store = this.owner.lookup('service:store');
+
+    const hearingDate = new Date('2020-10-21T18:30:00');
+
+    const disp1 = store.createRecord('disposition', {
+      id: 1,
+      dcpPublichearinglocation: '121 Bananas Ave, Queens, NY',
+      dcpDateofpublichearing: hearingDate,
+    });
+
+    const disp2 = store.createRecord('disposition', {
+      id: 2,
+      dcpPublichearinglocation: '144 Piranha Ave, Manhattan, NY',
+      dcpDateofpublichearing: hearingDate,
+    });
+
+    const disp3 = store.createRecord('disposition', {
+      id: 3,
+      dcpPublichearinglocation: '186 Alligators Ave, Staten Island, NY',
+      dcpDateofpublichearing: hearingDate,
+    });
+
+    const model = run(() => store.createRecord('project', {
+      dispositions: [disp1, disp2, disp3],
+    }));
+
+    assert.equal(model.hearingsSubmitted, true);
+    assert.equal(model.hearingsWaived, false);
+    assert.equal(model.hearingsSubmittedOrWaived, true);
+    assert.equal(model.hearingsNotSubmittedNotWaived, false);
+  });
+
+  // Replace this with your real tests.
+  test('hearingsWaived calculated correctly', function(assert) {
+    const store = this.owner.lookup('service:store');
+
+    const disp1 = store.createRecord('disposition', {
+      id: 1,
+      dcpPublichearinglocation: 'waived',
+      dcpDateofpublichearing: null,
+    });
+
+    const disp2 = store.createRecord('disposition', {
+      id: 2,
+      dcpPublichearinglocation: 'waived',
+      dcpDateofpublichearing: null,
+    });
+
+    const disp3 = store.createRecord('disposition', {
+      id: 3,
+      dcpPublichearinglocation: 'waived',
+      dcpDateofpublichearing: null,
+    });
+
+    const model = run(() => store.createRecord('project', {
+      dispositions: [disp1, disp2, disp3],
+    }));
+
+    assert.equal(model.hearingsSubmitted, false);
+    assert.equal(model.hearingsWaived, true);
+    assert.equal(model.hearingsSubmittedOrWaived, true);
+    assert.equal(model.hearingsNotSubmittedNotWaived, false);
+  });
+
+  // Replace this with your real tests.
+  test('hearingsNotSubmittedNotWaived calculated correctly', function(assert) {
+    const store = this.owner.lookup('service:store');
+
+    const disp1 = store.createRecord('disposition', {
+      id: 1,
+      dcpPublichearinglocation: '',
+      dcpDateofpublichearing: null,
+    });
+
+    const disp2 = store.createRecord('disposition', {
+      id: 2,
+      dcpPublichearinglocation: '',
+      dcpDateofpublichearing: null,
+    });
+
+    const disp3 = store.createRecord('disposition', {
+      id: 3,
+      dcpPublichearinglocation: '',
+      dcpDateofpublichearing: null,
+    });
+
+    const model = run(() => store.createRecord('project', {
+      dispositions: [disp1, disp2, disp3],
+    }));
+
+    assert.equal(model.hearingsSubmitted, false);
+    assert.equal(model.hearingsWaived, false);
+    assert.equal(model.hearingsSubmittedOrWaived, false);
+    assert.equal(model.hearingsNotSubmittedNotWaived, true);
+  });
 });


### PR DESCRIPTION
### Changes:
Move `hearingsSubmitted`, `hearingsWaived`, and other associated computed properties to the `project` model. This way we can use these booleans anywhere in the app to check for whether a hearing has been submitted/waived for a particular project -- e.g. `project.hearingsSubmitted`

### Tests:
- new tests were written for the `project` model unit test
- Because we now have these computed properties on the project model, certain component integration tests were in need of updates: `deduped-hearings-list-test`, `to-review-project-card-test`, and `upcoming-project-card-test`

Closes #762 