### PR TITLE
switch Search's default filters to be stage:filed,review

### DIFF
--- a/app/controllers/query-parameters/show-geography.js
+++ b/app/controllers/query-parameters/show-geography.js
@@ -16,7 +16,7 @@ export const projectParams = new QueryParams({
  * filters it should send to the API.
  */
   'applied-filters': {
-    defaultValue: ['dcp_certifiedreferred'].sort(),
+    defaultValue: ['dcp_publicstatus'].sort(),
     refresh: true,
     serialize(value) {
       return value.toString();
@@ -85,7 +85,7 @@ export const projectParams = new QueryParams({
     },
   },
   dcp_publicstatus: {
-    defaultValue: [].sort(),
+    defaultValue: ['Filed', 'In Public Review'].sort(),
     refresh: true,
     serialize(value) {
       value = value.filter(d => d !== '');

--- a/app/templates/show-geography.hbs
+++ b/app/templates/show-geography.hbs
@@ -94,6 +94,31 @@
         </div>
       </div>
 
+      {{!-- FILTER: PROJECT STAGE --}}
+      {{#filters.section
+        filterNames='dcp_publicstatus'
+        as |section|}}
+        {{#section.filter-wrapper
+          filterTitle=(get-label-for 'filters.dcp_publicstatus')
+          tooltip='These checkboxes filter projects by their stage in the application process. “Filed” refers to applications that have been submitted but have not yet started the public review process. “In Public Review” refers to applications that have graduated to the public review process. “Completed” refers to applications that have been Approved, Disapproved, Withdrawn or Terminated.'}}
+          <ul class="menu vertical medium-horizontal stage-checkboxes">
+            {{#each (array 'Filed' 'In Public Review' 'Completed' 'Unknown') as |type|}}
+              <li {{action section.delegate-mutation (action 'mutateArray' 'dcp_publicstatus' type)}}
+                data-test-status-checkbox={{type}}
+              >
+                <a>
+                  {{filter-checkbox
+                    value=type
+                    currentValues=dcp_publicstatus
+                    classPrefix="publicstatus"
+                  }}
+                </a>
+              </li>
+            {{/each}}
+          </ul>
+        {{/section.filter-wrapper}}
+      {{/filters.section}}
+
       {{!-- FILTER: PROJECT / DESCRIPTION / APPLICANT --}}
       {{#filters.section
         filterNames='project_applicant_text'
@@ -216,31 +241,6 @@
           }}
             {{district.boro}} {{district.num}}
           {{/power-select-multiple}}
-        {{/section.filter-wrapper}}
-      {{/filters.section}}
-
-      {{!-- FILTER: PROJECT STAGE --}}
-      {{#filters.section
-        filterNames='dcp_publicstatus'
-        as |section|}}
-        {{#section.filter-wrapper
-          filterTitle=(get-label-for 'filters.dcp_publicstatus')
-          tooltip='These checkboxes filter projects by their stage in the application process. “Filed” refers to applications that have been submitted but have not yet started the public review process. “In Public Review” refers to applications that have graduated to the public review process. “Completed” refers to applications that have been Approved, Disapproved, Withdrawn or Terminated.'}}
-          <ul class="menu vertical medium-horizontal stage-checkboxes">
-            {{#each (array 'Filed' 'In Public Review' 'Completed' 'Unknown') as |type|}}
-              <li {{action section.delegate-mutation (action 'mutateArray' 'dcp_publicstatus' type)}}
-                data-test-status-checkbox={{type}}
-              >
-                <a>
-                  {{filter-checkbox
-                    value=type
-                    currentValues=dcp_publicstatus
-                    classPrefix="publicstatus"
-                  }}
-                </a>
-              </li>
-            {{/each}}
-          </ul>
         {{/section.filter-wrapper}}
       {{/filters.section}}
 

--- a/tests/acceptance/filter-checkbox-test.js
+++ b/tests/acceptance/filter-checkbox-test.js
@@ -14,12 +14,12 @@ module('Acceptance | filter checkbox', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('User clicks Filed project status and it filters', async function(assert) {
+  test('User clicks Completed project status and it filters', async function(assert) {
     server.createList('project', 20);
     await visit('/');
-    await click('[data-test-status-checkbox="Filed"]');
+    await click('[data-test-status-checkbox="Completed"]');
 
-    assert.equal(currentURL().includes('Filed'), true);
+    assert.equal(currentURL().includes('Completed'), true);
   });
 
   test('User clicks first FEMA Flood Zone status and it filters', async function(assert) {
@@ -37,7 +37,7 @@ module('Acceptance | filter checkbox', function(hooks) {
     await fillIn('[data-test-filter-control="filter-section-community-district"] .ember-power-select-multiple-options input', 'Brooklyn');
     await selectChoose('.community-district-dropdown-selection', 'Brooklyn 2');
 
-    assert.equal(currentURL(), '/projects?applied-filters=community-districts%2Cdcp_certifiedreferred&community-districts=BK02');
+    assert.equal(currentURL(), '/projects?applied-filters=community-districts%2Cdcp_publicstatus&community-districts=BK02');
   });
 
   test('User clicks ULURP checkbox and it filters', async function(assert) {
@@ -77,7 +77,7 @@ module('Acceptance | filter checkbox', function(hooks) {
     await click('[data-test-status-checkbox="In Public Review"]');
     await click('[data-test-status-checkbox="Filed"]');
 
-    assert.equal(currentURL(), '/projects?applied-filters=dcp_certifiedreferred%2Cdcp_publicstatus');
+    assert.equal(currentURL(), '/projects');
   });
 
   test('User can click on filter switches with updated state', async function(assert) {
@@ -85,7 +85,7 @@ module('Acceptance | filter checkbox', function(hooks) {
     await visit('/projects');
     await click('[data-test-filter-section="filter-section-fema-flood-zone"] .switch-paddle');
 
-    assert.equal(currentURL(), '/projects?applied-filters=dcp_certifiedreferred%2Cdcp_femafloodzonea%2Cdcp_femafloodzonecoastala%2Cdcp_femafloodzoneshadedx%2Cdcp_femafloodzonev');
+    assert.equal(currentURL(), '/projects?applied-filters=dcp_femafloodzonea%2Cdcp_femafloodzonecoastala%2Cdcp_femafloodzoneshadedx%2Cdcp_femafloodzonev%2Cdcp_publicstatus');
     await click('[data-test-filter-section="filter-section-fema-flood-zone"] .switch-paddle');
 
     assert.equal(currentURL(), '/projects');


### PR DESCRIPTION
This PR updates the default filters on the Search view to be the "PROJECT STAGE" instead of "DATE CERTIFIED / REFERRED". Also moves that default filter to the top of the list of filters. 

This is intended to prevent the confusion of users who don't know there's a default filter applied being unable to find projects because they're out of the default date range. 

Closes #679 