### PR TITLE
743 - update map dot colors

### DIFF
--- a/app/components/structural/project-list-map.js
+++ b/app/components/structural/project-list-map.js
@@ -6,9 +6,9 @@ const PROJECT_STATUS_COLOR_RAMP_CONFIG = {
   property: 'dcp_publicstatus_simp',
   type: 'categorical',
   stops: [
-    ['Filed', '#FF9400'],
-    ['In Public Review', '#78D271'],
-    ['Completed', '#44A3D5'],
+    ['Filed', '#78D271'],
+    ['In Public Review', '#0979C3'],
+    ['Completed', '#a6cee3'],
   ],
   default: '#6b717b',
 };

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -83,9 +83,9 @@ $fieldset-border: $callout-border;
 //
 // Custom app modules and styles
 // --------------------------------------------------
-$filed-color: #FF9400;
-$in-public-review-color: #78D271;
-$completed-color: #44A3D5;
+$filed-color: #78D271;
+$in-public-review-color: #0979C3;
+$completed-color: #a6cee3;
 
 @import 'base/_typography';
 @import 'layouts/_l-default';

--- a/app/styles/modules/_m-categorical-colors.scss
+++ b/app/styles/modules/_m-categorical-colors.scss
@@ -4,20 +4,20 @@
 
 .label {
   .publicstatus-filed & {
-    background: lighten($filed-color, 15%);
-    color: color-pick-contrast(lighten($filed-color, 15%), ($label-color, $label-color-alt));
+    background: $filed-color;
+    color: $black;
   }
   .publicstatus-in-public-review & {
-    background: lighten($in-public-review-color, 15%);
-    color: color-pick-contrast(lighten($in-public-review-color, 15%), ($label-color, $label-color-alt));
+    background: $in-public-review-color;
+    color: $white;
   }
   .publicstatus-completed & {
-   background: lighten($completed-color, 15%);
-   color: color-pick-contrast(lighten($completed-color, 15%), ($label-color, $label-color-alt));
+   background: $completed-color;
+   color: $black;
   }
   .publicstatus-unknown & {
-   background: lighten($dark-gray, 15%);
-   color: color-pick-contrast(lighten($dark-gray, 15%), ($label-color, $label-color-alt));
+   background: $light-gray;
+   color: $black;
   }
 }
 


### PR DESCRIPTION
This PR updates the colors used in the map dots and status labels throughout the app. 
Worked w/ @kchanba to find WCAG-AA-compliant colors (different than those specified in the issue. 

`#78D271` Filed
`#0979C3` In Public Review
`#a6cee3` Completed


Closes #743. 