### PR TITLE
770: combine active bp & bb review on reviewed tab

### DIFF
--- a/app/components/reviewed-project-card.js
+++ b/app/components/reviewed-project-card.js
@@ -7,15 +7,39 @@ export default class ReviewedProjectCardComponent extends Component {
   @service
   currentUser;
 
-  project = {};
+  project = {
+    reviewedMilestoneActualStartEndDates: [],
+  };
+
+  // Assumes at most two milestones are 'In Progress'
+  @computed('project.reviewedMilestoneActualStartEndDates')
+  get timeDisplayLabel() {
+    const inProgressMilestonesDates = this.project.reviewedMilestoneActualStartEndDates;
+    if (inProgressMilestonesDates.length > 1 && inProgressMilestonesDates[0] && inProgressMilestonesDates[1]) {
+      return `${inProgressMilestonesDates[0].displayName.replace(' Review', '').trim()} and ${inProgressMilestonesDates[1].displayName}`;
+    }
+    if (inProgressMilestonesDates[0]) {
+      return inProgressMilestonesDates[0].displayName;
+    }
+    return '';
+  }
 
   @computed('project.reviewedMilestoneActualStartEndDates')
-  get timeDisplays() {
-    return this.project.reviewedMilestoneActualStartEndDates.map(startEndDate => ({
-      displayName: startEndDate.displayName,
-      timeRemaining: moment(startEndDate.dcpActualenddate).diff(moment().endOf('day'), 'days'),
-      timeDuration: moment(startEndDate.dcpActualenddate).diff(moment(startEndDate.dcpActualstartdate), 'days'),
-      dcpActualenddate: startEndDate.dcpActualenddate,
-    }));
+  get timeDisplay() {
+    const firstInProgressMilestoneDates = this.project.reviewedMilestoneActualStartEndDates[0] || {};
+    if (firstInProgressMilestoneDates.displayName && firstInProgressMilestoneDates.dcpActualstartdate && firstInProgressMilestoneDates.dcpActualenddate) {
+      return {
+        displayName: firstInProgressMilestoneDates.displayName,
+        timeRemaining: moment(firstInProgressMilestoneDates.dcpActualenddate).diff(moment(), 'days'),
+        timeDuration: moment(firstInProgressMilestoneDates.dcpActualenddate).diff(moment(firstInProgressMilestoneDates.dcpActualstartdate), 'days'),
+        dcpActualenddate: firstInProgressMilestoneDates.dcpActualenddate,
+      };
+    }
+    return {
+      displayName: null,
+      timeRemaining: null,
+      timeDuration: null,
+      dcpActualenddate: null,
+    };
   }
 }

--- a/app/components/to-review-project-card.js
+++ b/app/components/to-review-project-card.js
@@ -13,7 +13,7 @@ export default class ToReviewProjectCardComponent extends Component {
 
   @computed('project.toReviewMilestoneActualEndDate')
   get timeRemaining() {
-    return moment(this.project.toReviewMilestoneActualEndDate).diff(moment().endOf('day'), 'days');
+    return moment(this.project.toReviewMilestoneActualEndDate).diff(moment(), 'days');
   }
 
   @computed('project.{toReviewMilestoneActualStartDate,toReviewMilestoneActualEndDate}')

--- a/app/templates/components/reviewed-project-card.hbs
+++ b/app/templates/components/reviewed-project-card.hbs
@@ -12,14 +12,12 @@
         <p>{{this.project.dcpProjectbrief}}</p>
       </div>
       <div class="cell medium-4 large-3 xlarge-2">
-        {{#each this.timeDisplays as |timeDisplay|}}
-          <div class="lup-countdown medium-margin-right medium-margin-left">
-            <p class="cert-date">{{timeDisplay.displayName}}</p>
-            <p class="days">{{timeDisplay.timeRemaining}}</p>
-            <p class="total">of {{timeDisplay.timeDuration}} days remain</p>
-            <p class="end-date">Ends {{moment-format timeDisplay.dcpActualenddate "M/D/YYYY"}}</p>
-          </div>
-        {{/each}}
+        <div class="lup-countdown medium-margin-right medium-margin-left">
+          <p class="cert-date">{{timeDisplayLabel}}</p>
+          <p class="days">{{timeDisplay.timeRemaining}}</p>
+          <p class="total">of {{timeDisplay.timeDuration}} days remain</p>
+          <p class="end-date">Ends {{moment-format timeDisplay.dcpActualenddate "M/D/YYYY"}}</p>
+        </div>
       </div>
       <div class="cell medium-auto">
         <ul class="no-bullet no-margin">


### PR DESCRIPTION
Addresses #770 

This PR adds a check on the `reviewed-project-card` component. It checks if the project has multiple in-progress milestones and if those are BP and BB review. If so, it combines the countdown displays to show both reviews together instead of duplicating the same date info for each.

![image](https://user-images.githubusercontent.com/13967925/66860498-4dedc000-ef5b-11e9-9875-c14d371afe99.png)
