### PR TITLE
add style for active site header menu item

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -100,6 +100,7 @@ $completed-color: #a6cee3;
 @import 'modules/_m-project-filters';
 @import 'modules/_m-reveal-modal';
 @import 'modules/_m-search';
+@import 'modules/_m-site-header';
 @import 'modules/_m-tabs';
 @import 'modules/_m-project-summary-cards';
 @import 'modules/_m-recommendations';

--- a/app/styles/modules/_m-site-header.scss
+++ b/app/styles/modules/_m-site-header.scss
@@ -1,0 +1,14 @@
+// --------------------------------------------------
+// Module: Site header
+// --------------------------------------------------
+
+.site-header {
+
+  .menu {
+
+    .active {
+      background-color: $off-white;
+      box-shadow: inset 0 -0.25rem 0 0 #ffc861;
+    }
+  }
+}


### PR DESCRIPTION
Add active menu class style to the site header, as per style guide. 

Closes #696. 

![image](https://user-images.githubusercontent.com/409279/66952913-8230b180-f02b-11e9-815d-1af03fb30e80.png)
