### PR TITLE
798 prevent double set on hearingActions via multiple deduped-hearings-list renders

### DIFF
--- a/app/components/deduped-hearings-list.js
+++ b/app/components/deduped-hearings-list.js
@@ -37,7 +37,9 @@ export default class DedupedHearingsListComponent extends Component {
     // During the reduce, if there is a duplicate in the array of dispositions,
     // the actions model for that duplicate disposition is pushed into this array
     this.dispositions.forEach(function(disposition) {
-      disposition.set('hearingActions', [disposition.action]);
+      if (!Object.keys(disposition).includes('hearingActions')) {
+        disposition.set('hearingActions', [disposition.action]);
+      }
     });
 
     // setting a new property--each disposition in the deduped list will have an array of its duplicate dispositions


### PR DESCRIPTION
This was the Ember console error, reproduced after following steps in #798 
```
Assertion Failed: You modified "hearingActions" twice on <labs-zap-search@model:disposition::ember371:17> in a single render. It was rendered in "component:deduped-hearings-list" and modified in "component:deduped-hearings-list". This was unreliable and slow in Ember 1.x and is no longer supported. 
```
<img width="462" alt="Screen Shot 2019-10-18 at 1 10 11 PM" src="https://user-images.githubusercontent.com/3311663/67114023-f3e23a00-f1a8-11e9-94dd-2577a1c5ef4d.png">

This patch prevents the double set on hearingActions