### PR TITLE
update hearing opt-out design

### DIFF
--- a/app/templates/components/to-review-project-card.hbs
+++ b/app/templates/components/to-review-project-card.hbs
@@ -26,12 +26,13 @@
           class="button expanded"
           data-test-button="submitRecommendation"
         >
-          {{fa-icon 'thumbs-up' prefix='far' fixedWidth=true size="lg"}}
+          {{fa-icon 'thumbs-up' fixedWidth=true size="lg"}}
+          {{fa-icon 'thumbs-down' fixedWidth=true size="lg" transform="flip-h left-2"}}
           Submit {{participant-type-label project.dcpLupteammemberrole}} Recommendation
         </LinkTo>
       {{/if}}
       {{#if project.hearingsWaived}}
-        <span data-test-hearings-waived-message="{{project.id}}">You have opted out of submitting hearings</span>
+        <span data-test-hearings-waived-message="{{project.id}}">You've opted out of noticing a public hearing.</span>
       {{/if}}
       {{#if project.hearingsSubmitted}}
         {{#deduped-hearings-list project=project as |dedupedHearings|}}
@@ -76,27 +77,30 @@
         {{/deduped-hearings-list}}
       {{/if}}
       {{#if project.hearingsNotSubmittedNotWaived}}
-        <LinkTo
-          @route="my-projects.project.hearing.add"
-          @model={{project.id}}
-          class="button expanded tiny-margin-bottom"
-          data-test-button="submitHearing"
-        >
-          {{fa-icon 'calendar-alt' prefix='far' fixedWidth=true size="lg"}}
-          Submit {{participant-type-label project.dcpLupteammemberrole}} Hearing Info
-        </LinkTo>
-        <p class="text-small text-right">
-          <span class="display-inline-block">
+        <div class="grid-x">
+          <div class="cell medium-auto">
+            <LinkTo
+              @route="my-projects.project.hearing.add"
+              @model={{project.id}}
+              class="button expanded"
+              data-test-button="submitHearing"
+            >
+              {{fa-icon 'calendar' fixedWidth=true size="lg" transform="left-2"}}
+              Notice {{participant-type-label project.dcpLupteammemberrole}} Hearing
+            </LinkTo>
+          </div>
+          <div class="cell medium-shrink">
             <button
-              class="button tiny clear no-margin"
+              class="button expanded gray"
               onClick={{action "openOptOutHearingPopup"}}
               data-test-button="optOutHearingOpenPopup"
             >
-              Opt out of hearings
+              {{fa-icon 'calendar-times' size="lg" transform="shrink-5 down-1"}}
+              <small>Opt Out</small>
             </button>
             {{waive-hearings-popup project=project showPopup=showPopup}}
-          </span>
-        </p>
+          </div>
+        </div>
       {{/if}}
     </div>
   </div>

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -38,27 +38,30 @@
     </div>
     <div class="cell medium-auto">
       {{#if project.hearingsNotSubmittedNotWaived}}
-        <LinkTo
-          @route="my-projects.project.hearing.add"
-          @model={{project.id}}
-          class="button expanded tiny-margin-bottom"
-          data-test-button="submitHearing"
-        >
-          {{fa-icon 'calendar-alt' prefix='far' fixedWidth=true size="lg"}}
-          Submit {{participant-type-label project.dcpLupteammemberrole}} Hearing Info
-        </LinkTo>
-        <p class="text-small text-right">
-          <span class="display-inline-block">
+        <div class="grid-x">
+          <div class="cell medium-auto">
+            <LinkTo
+              @route="my-projects.project.hearing.add"
+              @model={{project.id}}
+              class="button expanded"
+              data-test-button="submitHearing"
+            >
+              {{fa-icon 'calendar' fixedWidth=true size="lg" transform="left-2"}}
+              Notice {{participant-type-label project.dcpLupteammemberrole}} Hearing
+            </LinkTo>
+          </div>
+          <div class="cell medium-shrink">
             <button
-              class="button tiny clear no-margin"
+              class="button expanded gray"
               onClick={{action "openOptOutHearingPopup"}}
               data-test-button="optOutHearingOpenPopup"
             >
-              Opt out of hearings
+              {{fa-icon 'calendar-times' size="lg" transform="shrink-5 down-1"}}
+              <small>Opt Out</small>
             </button>
             {{waive-hearings-popup project=project showPopup=showPopup}}
-          </span>
-        </p>
+          </div>
+        </div>
       {{/if}}
       <ul class="no-bullet no-margin">
         {{#each project.tabSpecificMilestones as |milestone|}}
@@ -89,7 +92,7 @@
         {{/each}}
       </ul>
       {{#if project.hearingsWaived}}
-        <span data-test-hearings-waived-message="{{project.id}}">You have opted out of submitting hearings</span>
+        <span data-test-hearings-waived-message="{{project.id}}">You've opted out of noticing a public hearing.</span>
       {{/if}}
       {{#if project.hearingsSubmitted}}
         {{#deduped-hearings-list project=project as |dedupedHearings|}}

--- a/app/templates/components/waive-hearings-popup.hbs
+++ b/app/templates/components/waive-hearings-popup.hbs
@@ -1,10 +1,13 @@
 {{#ember-wormhole to="reveal-modal-container"}}
   {{#confirmation-modal open=showPopup}}
 
-    <h3>Opt out of hearings for: <br>{{project.dcpProjectname}}</h3>
+    <h3>
+      <small class="display-inline-block">Opt out of noticing a public hearing for:</small>
+      <span class="display-inline-block">{{project.dcpProjectname}}</span>
+    </h3>
     <p>Without proper notice of a public hearing, the {{participant-type-label project.dcpLupteammemberrole}}'s recommendation does not comply with City Charter requirements.
     NYC Planning will still accept a recommendation, but a disapproval will not trigger an automatic City Council call up.</p>
-    <p><strong>Are you sure you want to opt out of submitting hearings?</strong></p>
+    <p><strong>Are you sure you want to opt out of noticing a public hearing?</strong></p>
     <button
       class="button small"
       data-test-button="onConfirmOptOutHearing"

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -225,27 +225,30 @@
               {{/deduped-hearings-list}}
             {{/if}}
             {{#if model.hearingsWaived}}
-              <span data-test-hearings-waived-message>You have opted out of submitting hearings</span>
+              <span data-test-hearings-waived-message>You've opted out of noticing a public hearing.</span>
             {{/if}}
             {{#if model.hearingsNotSubmittedNotWaived}}
-              {{#link-to "my-projects.project.hearing.add" model.id class="button expanded"}}
-                <span data-test-button-hearing-form>
-                  {{fa-icon 'calendar-alt' prefix='far' fixedWidth=true size="lg"}}
-                  Submit {{participant-type-label model.dcpLupteammemberrole}} Hearing Info
-                </span>
-              {{/link-to}}
-              <p class="text-small text-right">
-                <span class="display-inline-block">
+              <div class="grid-x">
+                <div class="cell medium-auto">
+                  {{#link-to "my-projects.project.hearing.add" model.id class="button expanded"}}
+                    <span data-test-button-hearing-form>
+                      {{fa-icon 'calendar' fixedWidth=true size="lg" transform="left-2"}}
+                      Notice {{participant-type-label project.dcpLupteammemberrole}} Hearing
+                    </span>
+                  {{/link-to}}
+                </div>
+                <div class="cell medium-shrink">
                   <button
-                    class="button tiny clear no-margin"
+                    class="button expanded gray"
                     onClick={{action "openOptOutHearingPopup"}}
                     data-test-button="optOutHearingOpenPopup"
                   >
-                    Opt out of hearings
+                    {{fa-icon 'calendar-times' size="lg" transform="shrink-5 down-1"}}
+                    <small>Opt Out</small>
                   </button>
                   {{waive-hearings-popup project=model showPopup=showPopup}}
-                </span>
-              </p>
+                </div>
+              </div>
             {{/if}}
           </div>
         {{/if}}

--- a/tests/integration/components/to-review-project-card-test.js
+++ b/tests/integration/components/to-review-project-card-test.js
@@ -95,8 +95,8 @@ module('Integration | Component | to-review-project-card', function(hooks) {
 
     const card = this.element.textContent.trim();
 
-    assert.ok(card.includes('Submit Community Board Hearing Info'));
-    assert.ok(card.includes('Opt out of hearings'));
+    assert.ok(card.includes('Notice Community Board Hearing'));
+    assert.ok(card.includes('Opt Out'));
   });
 
   test('check that opt out of hearings MESSAGE appears when hearing locations are waived', async function(assert) {
@@ -139,8 +139,8 @@ module('Integration | Component | to-review-project-card', function(hooks) {
 
     const card = this.element.textContent.trim();
 
-    assert.ok(card.includes('You have opted out of submitting hearings'));
-    assert.notOk(card.includes('Opt out of hearings'));
-    assert.notOk(card.includes('Submit Community Board Hearing Info'));
+    assert.ok(card.includes("You've opted out of noticing a public hearing."));
+    assert.notOk(card.includes('Opt out'));
+    assert.notOk(card.includes('Notice Community Board Hearing'));
   });
 });

--- a/tests/integration/components/upcoming-project-card-test.js
+++ b/tests/integration/components/upcoming-project-card-test.js
@@ -93,7 +93,7 @@ module('Integration | Component | upcoming-project-card', function(hooks) {
     const card = this.element.textContent.trim();
 
     assert.ok(card.includes('Review Begins'));
-    assert.ok(card.includes('Opt out of hearings'));
+    assert.ok(card.includes('Opt Out'));
   });
 
   test('check that card renders and opt out of hearing MESSAGE appears when hearing locations are waived', async function(assert) {
@@ -136,7 +136,7 @@ module('Integration | Component | upcoming-project-card', function(hooks) {
     const card = this.element.textContent.trim();
 
     assert.ok(card.includes('Review Begins'));
-    assert.ok(card.includes('You have opted out of submitting hearings'));
-    assert.notOk(card.includes('Opt out of hearings'));
+    assert.ok(card.includes("You've opted out of noticing a public hearing."));
+    assert.notOk(card.includes('Opt Out'));
   });
 });

--- a/tests/integration/components/waive-hearings-popup-test.js
+++ b/tests/integration/components/waive-hearings-popup-test.js
@@ -22,7 +22,7 @@ module('Integration | Component | waive-hearings-popup', function(hooks) {
 
     const waiveHearingsMessageOnPopup = this.element.textContent.trim();
 
-    const messageVisible = waiveHearingsMessageOnPopup.includes('Are you sure you want to opt out of submitting hearings?');
+    const messageVisible = waiveHearingsMessageOnPopup.includes('Are you sure you want to opt out of noticing a public hearing?');
 
     assert.ok(messageVisible);
   });


### PR DESCRIPTION
This PR updates the design of the hearing opt-out workflow. 
- Makes the opt-out button more noticeable
- Updates the language as to not confuse opting out of noticing the hearing, with opting out of holding one (closes #753)
- Updates the modal text

![image](https://user-images.githubusercontent.com/409279/67114130-33a92180-f1a9-11e9-93df-8fd1029d467e.png)

![image](https://user-images.githubusercontent.com/409279/67114225-7539cc80-f1a9-11e9-89a9-e794bd97aaa1.png)

![image](https://user-images.githubusercontent.com/409279/67114116-2b50e680-f1a9-11e9-8745-717c09320825.png)

![image](https://user-images.githubusercontent.com/409279/67114207-6a7f3780-f1a9-11e9-895c-a12f66ecc355.png)
