### PR TITLE
793: dont show invalid dates, show planned where appropriate

### DIFF
--- a/app/components/reviewed-project-card.js
+++ b/app/components/reviewed-project-card.js
@@ -8,13 +8,13 @@ export default class ReviewedProjectCardComponent extends Component {
   currentUser;
 
   assignment = {
-    reviewedMilestoneActualStartEndDates: [],
+    reviewedMilestoneDates: [],
   };
 
   // Assumes at most two milestones are 'In Progress'
-  @computed('assignment.reviewedMilestoneActualStartEndDates')
+  @computed('assignment.reviewedMilestoneDates')
   get timeDisplayLabel() {
-    const inProgressMilestonesDates = this.assignment.reviewedMilestoneActualStartEndDates;
+    const inProgressMilestonesDates = this.assignment.reviewedMilestoneDates;
     if (inProgressMilestonesDates.length > 1 && inProgressMilestonesDates[0] && inProgressMilestonesDates[1]) {
       return `${inProgressMilestonesDates[0].displayName.replace(' Review', '').trim()} and ${inProgressMilestonesDates[1].displayName}`;
     }
@@ -24,9 +24,10 @@ export default class ReviewedProjectCardComponent extends Component {
     return '';
   }
 
-  @computed('assignment.reviewedMilestoneActualStartEndDates')
-  get timeDisplay() {
-    const firstInProgressMilestoneDates = this.assignment.reviewedMilestoneActualStartEndDates[0] || {};
+  @computed('assignment.reviewedMilestoneDates')
+  // used when dcpActualenddate exists
+  get actualTimeDisplay() {
+    const firstInProgressMilestoneDates = this.assignment.reviewedMilestoneDates[0] || {};
     if (firstInProgressMilestoneDates.displayName && firstInProgressMilestoneDates.dcpActualstartdate && firstInProgressMilestoneDates.dcpActualenddate) {
       return {
         displayName: firstInProgressMilestoneDates.displayName,
@@ -40,6 +41,26 @@ export default class ReviewedProjectCardComponent extends Component {
       timeRemaining: null,
       timeDuration: null,
       dcpActualenddate: null,
+    };
+  }
+
+  @computed('assignment.reviewedMilestoneDates')
+  // used when dcpActualenddate doesn't exist but dcpPlannedcompletiondate does
+  get plannedTimeDisplay() {
+    const firstInProgressMilestoneDates = this.assignment.reviewedMilestoneDates[0] || {};
+    if (firstInProgressMilestoneDates.displayName && firstInProgressMilestoneDates.dcpActualstartdate && firstInProgressMilestoneDates.dcpPlannedcompletiondate) {
+      return {
+        displayName: firstInProgressMilestoneDates.displayName,
+        estTimeRemaining: moment(firstInProgressMilestoneDates.dcpPlannedcompletiondate).diff(moment(), 'days'),
+        estTimeDuration: moment(firstInProgressMilestoneDates.dcpPlannedcompletiondate).diff(moment(firstInProgressMilestoneDates.dcpActualstartdate), 'days'),
+        dcpPlannedcompletiondate: firstInProgressMilestoneDates.dcpPlannedcompletiondate,
+      };
+    }
+    return {
+      displayName: null,
+      estTimeRemaining: null,
+      estTimeDuration: null,
+      dcpPlannedcompletiondate: null,
     };
   }
 }

--- a/app/models/assignment.js
+++ b/app/models/assignment.js
@@ -90,7 +90,7 @@ export default class AssignmentModel extends Model {
   //   - these start/end dates come from the current In Progress milestone
   //   - an array of milestone dates is returned
   @computed('tab', 'dcpLupteammemberrole', 'project.milestones')
-  get reviewedMilestoneActualStartEndDates() {
+  get reviewedMilestoneDates() {
     if (this.tab !== 'reviewed') {
       return null;
     }
@@ -100,6 +100,7 @@ export default class AssignmentModel extends Model {
       displayName: milestone.displayName,
       dcpActualstartdate: milestone.dcpActualstartdate,
       dcpActualenddate: milestone.dcpActualenddate,
+      dcpPlannedcompletiondate: milestone.dcpPlannedcompletiondate,
     }));
   }
 }

--- a/app/routes/my-projects/reviewed.js
+++ b/app/routes/my-projects/reviewed.js
@@ -11,7 +11,7 @@ export default class MyProjectsReviewedRoute extends Route {
   async model() {
     return this.store.query('assignment', {
       tab: 'reviewed',
-      include: 'project.milestones,project.dispositions,project.actions',
+      include: 'project.milestones,project.dispositions,project.actions,dispositions.action',
     }, {
       reload: true,
     });

--- a/app/templates/components/archive-project-milestone-list-item.hbs
+++ b/app/templates/components/archive-project-milestone-list-item.hbs
@@ -7,14 +7,14 @@
     {{else if (eq this.milestone.statuscode "Overridden")}}
       {{fa-icon 'stop' class='red-dark' fixedWidth=true}}
     {{else if (eq this.milestone.statuscode "Not Started")}}
-      <span data-test={{if (string-includes this.milestone.milestonename "Referral") "upcoming-indicator"}}>
+      <span data-test={{if (string-includes this.milestone.displayName "Review") "upcoming-indicator"}}>
         {{fa-icon 'calendar' class='light-gray' fixedWidth=true}}
       </span>
     {{/if}}
   </div>
   <div class="cell auto {{if (eq this.milestone.statuscode "Not Started") 'gray'}}">
     <strong>
-      {{this.milestone.milestonename}}
+      {{this.milestone.displayName}}
     </strong>
     {{#if (eq this.milestone.dcpMilestone this.milestoneConstants.COMMUNITY_BOARD_REFERRAL)}}
       {{#each this.communityBoardDispositions as |disposition|}}

--- a/app/templates/components/reviewed-project-card.hbs
+++ b/app/templates/components/reviewed-project-card.hbs
@@ -5,27 +5,41 @@
     <div class="grid-x grid-x-small-gutters">
       <div class="cell large-4 xlarge-5">
         <h3 class="tiny-margin-bottom">
-          {{#link-to 'show-project' this.project.id}}{{this.project.dcpProjectname}}{{/link-to}}
-          <small class="dark-gray">{{this.project.dcpUlurpNonulurp}}</small>
+          {{#link-to 'show-project' this.assignment.project.id}}{{this.assignment.project.dcpProjectname}}{{/link-to}}
+          <small class="dark-gray">{{this.assignment.project.dcpUlurpNonulurp}}</small>
         </h3>
-        <h5 class="applicant">{{this.project.applicants}}</h5>
-        <p>{{this.project.dcpProjectbrief}}</p>
+        <h5 class="applicant">{{this.assignment.project.applicants}}</h5>
+        <p>{{this.assignment.project.dcpProjectbrief}}</p>
       </div>
       <div class="cell medium-4 large-3 xlarge-2">
         <div class="text-center medium-margin-right medium-margin-left">
           <p class="tiny-margin-bottom">{{timeDisplayLabel}}</p>
-          <p>
-            <strong class="stat">{{timeDisplay.timeRemaining}}</strong>
-            <strong class="display-block">of {{timeDisplay.timeDuration}} days remain</strong>
-          </p>
-          <p class="text-tiny">Ends {{moment-format timeDisplay.dcpActualenddate "M/D/YYYY"}}</p>
+          {{#if actualTimeDisplay.dcpActualenddate}}
+            <p>
+              <strong
+                class="stat"
+                data-test-time-remaining
+              >{{actualTimeDisplay.timeRemaining}}</strong>
+              <strong class="display-block">of {{actualTimeDisplay.timeDuration}} days remain</strong>
+            </p>
+            <p class="text-tiny">Ends {{moment-format actualTimeDisplay.dcpActualenddate "M/D/YYYY"}}</p>
+          {{else}}
+            <p>
+              <strong
+                class="stat"
+                data-test-estimated-time-remaining
+              >{{plannedTimeDisplay.estTimeRemaining}}</strong>
+              <strong class="display-block">of {{plannedTimeDisplay.estTimeDuration}} estimated days remain</strong>
+            </p>
+            <p class="text-tiny">Estimated End {{moment-format plannedTimeDisplay.dcpPlannedcompletiondate "M/D/YYYY"}}</p>
+          {{/if}}
         </div>
       </div>
       <div class="cell medium-auto">
         <ul class="no-bullet no-margin">
           {{#each assignment.tabSpecificMilestones as |milestone|}}
             <ReviewedProjectMilestoneListItem
-              @project={{project}}
+              @project={{assignment.project}}
               @milestone={{milestone}}
             />
           {{/each}}

--- a/app/templates/components/reviewed-project-milestone-list-item.hbs
+++ b/app/templates/components/reviewed-project-milestone-list-item.hbs
@@ -3,7 +3,7 @@
 >
   <div class="cell shrink small-margin-right">
     {{#if (eq this.milestone.statuscode "Completed")}}
-      <span data-test={{if (string-includes this.milestone.milestonename "Referral") "reviewed-indicator"}}>
+      <span data-test={{if (string-includes this.milestone.displayName "Review") "reviewed-indicator"}}>
         {{fa-icon 'check' class='blue' fixedWidth=true}}
       </span>
     {{else if (eq this.milestone.statuscode "In Progress")}}
@@ -17,7 +17,7 @@
   <div class="cell auto {{if (eq this.milestone.statuscode "Not Started") 'gray'}}">
     <p class="small-margin-bottom">
       <strong>
-        {{this.milestone.milestonename}}
+        {{this.milestone.displayName}}
       </strong>
       {{#if (eq this.milestone.dcpMilestone this.milestoneConstants.COMMUNITY_BOARD_REFERRAL)}}
         {{#each this.communityBoardDispositions as |disposition|}}
@@ -54,12 +54,14 @@
         </small>
       {{else}}
         <br>
-        <small class="display-block">
-          {{#if (eq this.milestone.statuscode "Not Started")}}
-            Estimated
-          {{/if}}
-          {{~moment-format this.milestone.displayDate "MM/D/YYYY"~}}
-        </small>
+        {{#if this.milestone.displayDate}}
+          <small class="display-block">
+            {{#if (eq this.milestone.statuscode "Not Started")}}
+              Estimated
+            {{/if}}
+            {{~moment-format this.milestone.displayDate "MM/D/YYYY"~}}
+          </small>
+        {{/if}}
       {{/if}}
     </p>
   </div>

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -76,19 +76,21 @@
               {{else if (eq milestone.statuscode "Overridden")}}
                 {{fa-icon 'times' class='red-muted' fixedWidth=true}}
               {{else if (eq milestone.statuscode "Not Started")}}
-                <span data-test={{if (string-includes milestone.milestonename "Referral") "upcoming-indicator"}}>
+                <span data-test={{if (string-includes milestone.displayName "Review") "upcoming-indicator"}}>
                   {{fa-icon 'calendar' class='light-gray' fixedWidth=true}}
                 </span>
               {{/if}}
             </div>
             <div class="cell auto {{if (eq milestone.statuscode "Not Started") 'gray'}}">
-              <strong>{{milestone.milestonename}}</strong>
-              <small class="display-inline-block">
-                {{#if (eq milestone.statuscode "Not Started")}}
-                  Estimated
-                {{/if}}
-                {{~moment-format milestone.displayDate "MM/D/YYYY"~}}
-              </small>
+              <strong>{{milestone.displayName}}</strong>
+              {{#if milestone.displayDate}}
+                <small class="display-inline-block">
+                  {{#if (eq milestone.statuscode "Not Started")}}
+                    Estimated
+                  {{/if}}
+                  {{~moment-format milestone.displayDate "MM/D/YYYY"~}}
+                </small>
+              {{/if}}
             </div>
           </li>
         {{/each}}

--- a/tests/acceptance/reviewed-project-cards-renders-test.js
+++ b/tests/acceptance/reviewed-project-cards-renders-test.js
@@ -8,7 +8,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { invalidateSession, authenticateSession } from 'ember-simple-auth/test-support';
 import moment from 'moment';
 
-module('Acceptance | to review project cards renders', function(hooks) {
+module('Acceptance | reviewed project cards renders', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -24,16 +24,16 @@ module('Acceptance | to review project cards renders', function(hooks) {
     await invalidateSession();
   });
 
-  test('to-review project card renders due date if milestone dates are valid', async function(assert) {
+  test('reviewed project card renders due date if milestone dates are valid', async function(assert) {
     this.server.create('user', {
       id: 1,
       email: 'qncb5@planning.nyc.gov',
-      landUseParticipant: 'QNBP',
+      landUseParticipant: 'QNCB',
       assignments: [
         this.server.create('assignment', {
           id: 1,
-          tab: 'to-review',
-          dcpLupteammemberrole: 'BP',
+          tab: 'reviewed',
+          dcpLupteammemberrole: 'CB',
           dispositions: [],
           project: this.server.create('project', {
             milestones: [this.server.create('milestone', 'boroughPresidentReview', {
@@ -52,22 +52,23 @@ module('Acceptance | to review project cards renders', function(hooks) {
       id: 1,
     });
 
-    await visit('/my-projects/to-review');
+    await visit('/my-projects/reviewed');
 
     const timeRemainingValue = find('[data-test-time-remaining]').textContent.trim();
     assert.equal(timeRemainingValue, '20', 'Time remaining displays 20');
+    assert.notOk(find('[data-test-estimated-time-remaining]'));
   });
 
-  test('to-review project card renders a "contact DCP" message if milestone dates are invalid', async function(assert) {
+  test('reviewed project card renders an estimated time remaining is actual end date is invalid', async function(assert) {
     this.server.create('user', {
       id: 1,
       email: 'qncb5@planning.nyc.gov',
-      landUseParticipant: 'QNBP',
+      landUseParticipant: 'QNCB',
       assignments: [
         this.server.create('assignment', {
           id: 1,
-          tab: 'to-review',
-          dcpLupteammemberrole: 'BP',
+          tab: 'reviewed',
+          dcpLupteammemberrole: 'CB',
           dispositions: [],
           project: this.server.create('project', {
             milestones: [this.server.create('milestone', 'boroughPresidentReview', {
@@ -76,7 +77,7 @@ module('Acceptance | to review project cards renders', function(hooks) {
               displayDate: moment().subtract(9, 'days'),
               dcpActualenddate: null,
               displayDate2: null,
-              dcpPlannedcompletiondate: moment().subtract(21, 'days'),
+              dcpPlannedcompletiondate: moment().add(15, 'days'),
             })],
           }),
         }),
@@ -87,10 +88,11 @@ module('Acceptance | to review project cards renders', function(hooks) {
       id: 1,
     });
 
-    await visit('/my-projects/to-review');
+    await visit('/my-projects/reviewed');
 
     assert.notOk(find('[data-test-time-remaining]'));
 
-    assert.ok(find('[data-test-invalid-milestone-end-date]'));
+    const timeRemainingValue = find('[data-test-estimated-time-remaining]').textContent.trim();
+    assert.equal(timeRemainingValue, '14', 'Estimated time remaining displays 14');
   });
 });


### PR DESCRIPTION
This PR solves a few issues related to milestone displays:

- Incorrect milestone name labels. We should be using displayName instead of milestonename. displayName is a recoded attribute that provides more user friendly labels than CRM's.

- (Addresses #793) Milestone displayDate is calculated in the API using previously determined logic for which dates DCP feels comfortable showing the public (based on confidence/reliability). The front-end was assuming that displayDate will always be provided, but some milestones that haven't started yet purposefully don't have a displayDate. This was causing a bunch of "invalid date" dates being displayed. I've added logic to the "upcoming" and "reviewed" templates to not show dates if they're not provided.

- (Addresses #793) dcpActualenddate returned in the project model's computed `reviewedMilestoneActualStartEndDates()` property assumed that dcpActualenddate would always be available for an "In Progress" milestone. That's not true because some milestones don't have a known, mandated duration. The incorrect assumption was causing NaN countdowns for some "In Progress" milestones. I added logic in the project model to set dcpActualenddate = dcpPlannedcompletiondate when dcpActualenddate is NULL. This is potentially confusing because it's being called "actual" when it's planned. Curious to get @NYCPlanning/engineering 's thoughts on that.

I uncovered [several other data display concerns](https://github.com/NYCPlanning/labs-zap-search/issues/793#issuecomment-543321433) while sleuthing through this that I'll create separate issues for.