### PR TITLE
771: fuzzy public review start date

### DIFF
--- a/app/components/upcoming-project-card.js
+++ b/app/components/upcoming-project-card.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
-import { action } from '@ember/object';
+import { computed, action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import moment from 'moment';
 
 export default class UpcomingProjectCardComponent extends Component {
   @service
@@ -9,6 +10,14 @@ export default class UpcomingProjectCardComponent extends Component {
   assignment = {};
 
   showPopup = false;
+
+  @computed('assignment.publicReviewPlannedStartDate')
+  get timeRemainingTillPublicReview() {
+    if (moment(this.assignment.publicReviewPlannedStartDate).diff(moment(), 'days') > 30) {
+      return 'over 30 days';
+    }
+    return '< 30 days';
+  }
 
   @action
   openOptOutHearingPopup() {

--- a/app/models/assignment.js
+++ b/app/models/assignment.js
@@ -52,10 +52,10 @@ export default class AssignmentModel extends Model {
   // If `tab` is `upcoming`...
   // if the project is in public review, this field is used to display the participant's review planned start date.
   // else this field returns null
-  @computed('tab', 'dcpLupteammemberrole', 'project.{milestones,dcpPublicstatusSimp}')
+  @computed('tab', 'dcpLupteammemberrole', 'project.{milestones,dcpPublicstatus}')
   get upcomingMilestonePlannedStartDate() {
     if (this.tab === 'upcoming') {
-      if (this.project.dcpPublicstatusSimp !== 'Filed') {
+      if (this.project.dcpPublicstatus !== 'Filed') {
         const participantMilestoneId = MILESTONE_ID_LOOKUP[this.dcpLupteammemberrole];
         const participantReviewMilestone = this.project.get('milestones').find(milestone => milestone.dcpMilestone === participantMilestoneId);
         return participantReviewMilestone ? participantReviewMilestone.dcpPlannedstartdate : null;

--- a/app/styles/modules/_m-project-summary-cards.scss
+++ b/app/styles/modules/_m-project-summary-cards.scss
@@ -17,30 +17,6 @@
   }
 }
 
-// LUP countdown
-.lup-countdown {
-  text-align: center;
-
-  .cert-date {
-    font-size: rem-calc(10);
-  }
-
-  .days {
-    font-size: rem-calc(40);
-    font-weight: $global-weight-bold;
-    line-height: 1;
-    margin: 0;
-  }
-
-  .total {
-    font-weight: $global-weight-bold;
-  }
-
-  .end-date {
-    font-size: rem-calc(10);
-  }
-}
-
 // Hearing Info
 .hearing-info {
   text-align: center;

--- a/app/templates/components/archive-project-card.hbs
+++ b/app/templates/components/archive-project-card.hbs
@@ -12,10 +12,14 @@
       <p>{{this.project.dcpProjectbrief}}</p>
     </div>
     <div class="cell medium-4 large-3 xlarge-2">
-      <p class="text-center medium-margin-right medium-margin-left">
-        <strong class="display-block lead small-margin-bottom">{{this.project.dcpPublicstatus}}</strong>
-        <span class="display-block">{{moment-format this.project.dcpProjectcompleted "M/D/YYYY"}}</span>
-      </p>
+      <div class="text-center medium-margin-right medium-margin-left">
+        <p class="lead small-margin-bottom">
+          <strong>
+            {{this.project.dcpPublicstatus}}
+            {{moment-format this.project.dcpProjectcompleted "M/D/YYYY"}}
+          </strong>
+        </p>
+      </div>
     </div>
     <div class="cell medium-auto">
       <ul class="no-bullet no-margin">

--- a/app/templates/components/reviewed-project-card.hbs
+++ b/app/templates/components/reviewed-project-card.hbs
@@ -12,11 +12,13 @@
         <p>{{this.project.dcpProjectbrief}}</p>
       </div>
       <div class="cell medium-4 large-3 xlarge-2">
-        <div class="lup-countdown medium-margin-right medium-margin-left">
-          <p class="cert-date">{{timeDisplayLabel}}</p>
-          <p class="days">{{timeDisplay.timeRemaining}}</p>
-          <p class="total">of {{timeDisplay.timeDuration}} days remain</p>
-          <p class="end-date">Ends {{moment-format timeDisplay.dcpActualenddate "M/D/YYYY"}}</p>
+        <div class="text-center medium-margin-right medium-margin-left">
+          <p class="tiny-margin-bottom">{{timeDisplayLabel}}</p>
+          <p>
+            <strong class="stat">{{timeDisplay.timeRemaining}}</strong>
+            <strong class="display-block">of {{timeDisplay.timeDuration}} days remain</strong>
+          </p>
+          <p class="text-tiny">Ends {{moment-format timeDisplay.dcpActualenddate "M/D/YYYY"}}</p>
         </div>
       </div>
       <div class="cell medium-auto">

--- a/app/templates/components/to-review-project-card.hbs
+++ b/app/templates/components/to-review-project-card.hbs
@@ -12,11 +12,13 @@
       <p>{{assignment.project.dcpProjectbrief}}</p>
     </div>
     <div class="cell medium-4 large-3 xlarge-2">
-      <div class="lup-countdown medium-margin-right medium-margin-left">
-        <p class="cert-date">{{participant-type-label assignment.dcpLupteammemberrole}} Review</p>
-        <p class="days">{{timeRemaining}}</p>
-        <p class="total">of {{timeDuration}} days remain</p>
-        <p class="end-date">Ends {{moment-format project.toReviewMilestoneActualEndDate "M/D/YYYY"}}</p>
+      <div class="text-center medium-margin-right medium-margin-left">
+        <p class="tiny-margin-bottom">{{participant-type-label assignment.dcpLupteammemberrole}} Review</p>
+        <p>
+          <strong class="stat">{{timeRemaining}}</strong>
+          <strong class="display-block">of {{timeDuration}} days remain</strong>
+        </p>
+        <p class="text-tiny">Ends {{moment-format assignment.toReviewMilestoneActualEndDate "M/D/YYYY"}}</p>
       </div>
     </div>
     <div class="cell medium-8 large-auto">

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -12,29 +12,30 @@
       <p>{{assignment.project.dcpProjectbrief}}</p>
     </div>
     <div class="cell medium-4 large-3 xlarge-2">
-      <p class="text-center medium-margin-right medium-margin-left">
+      <div class="text-center medium-margin-right medium-margin-left">
         {{#if assignment.upcomingMilestonePlannedStartDate}}
-          <span class="display-block tiny-margin-bottom">
-            {{participant-type-label project.dcpLupteammemberrole}}<br>
-            Review Begins
-          </span>
-          <span class="display-block lead small-margin-bottom">
+          <p class="tiny-margin-bottom">
+            {{participant-type-label assignment.dcpLupteammemberrole}} Review Begins
+          </p>
+          <p class="lead">
             <strong>
               {{moment-format assignment.upcomingMilestonePlannedStartDate "M/D/YYYY"}}
             </strong>
-          </span>
+          </p>
         {{else}}
-          <span class="display-block tiny-margin-bottom">
+          <p class="tiny-margin-bottom">
             Public Review Begins
-          </span>
-          <span class="display-block lead small-margin-bottom">
+          </p>
+          <p class="lead">
             <strong>
-              {{moment-format assignment.publicReviewPlannedStartDate "M/D/YYYY"}}
+              {{timeRemainingTillPublicReview}}
             </strong>
-          </span>
+          </p>
         {{/if}}
-        <span class="display-block text-tiny">(Estimated Start Date)</span>
-      </p>
+        <p class="text-center text-tiny">
+          (Estimated Start Date)
+        </p>
+      </div>
     </div>
     <div class="cell medium-auto">
       {{#if assignment.project.hearingsNotSubmittedNotWaived}}


### PR DESCRIPTION
Prior to certification, the exec office wants to show fuzzy count down dates for when public review is expected to begin. This PR implements that by 
- Fixing the computed `upcomingMilestonePlannedStartDate` property on the project model. The API isn't providing any attributes for `dcpPublicstatusSimp`, so filed projects were being treated like certified projects. We need to use `dcpPublicstatus` instead.
- Adding a relative date computed value to the `upcoming-project-card` component

@andycochran the font size hierarchy looks a little off now that we're displaying text instead of purely dates. I started with using real words instead of "<" but the font was too big. Can you take a look at the design/text and see if you think it should be tweaked?

Addresses #771 