### PR TITLE
816 fixup done pages, other small patches

### DIFF
--- a/app/components/to-review-project-card.js
+++ b/app/components/to-review-project-card.js
@@ -18,7 +18,7 @@ export default class ToReviewProjectCardComponent extends Component {
 
   @computed('assignment.{toReviewMilestoneActualStartDate,toReviewMilestoneActualEndDate}')
   get timeDuration() {
-    return moment(this.assignment.get('toReviewMilestoneActualEndDate')).diff(moment(this.assignment.get('toReviewMilestoneActualStartDate')), 'days');
+    return moment(this.assignment.toReviewMilestoneActualEndDate).diff(moment(this.assignment.toReviewMilestoneActualStartDate), 'days');
   }
 
   @action

--- a/app/controllers/show-project.js
+++ b/app/controllers/show-project.js
@@ -41,7 +41,7 @@ export default class ShowProjectController extends Controller {
   get isUserAssignedToProject() {
     // user is from currentUser Service
     // currentUser Service injected in show-project route on setUpController
-    if (this.session.isAuthenticated) {
+    if (this.user && this.session.isAuthenticated) {
       const userProjectIds = this.user.assignments.map(({ project }) => project.id);
 
       return userProjectIds.includes(this.model.id);

--- a/app/routes/my-projects/assignment/hearing/done.js
+++ b/app/routes/my-projects/assignment/hearing/done.js
@@ -1,13 +1,10 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 
-export default class MyProjectsProjectHearingDoneRoute extends Route {
-  async model() {
-    return this.modelFor('my-projects.project');
-  }
-
+export default class MyProjectsAssignmentHearingDoneRoute extends Route {
   @action
-  error() {
+  error(e) {
+    console.log(e); // eslint-disable-line
     this.transitionTo('not-found', 'not-found');
   }
 }

--- a/app/routes/my-projects/assignment/recommendations/done.js
+++ b/app/routes/my-projects/assignment/recommendations/done.js
@@ -1,13 +1,10 @@
 import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 
-export default class MyProjectsProjectRecommendationsDoneRoute extends Route {
-  async model() {
-    return this.modelFor('my-projects.project');
-  }
-
+export default class MyProjectsAssignmentRecommendationsDoneRoute extends Route {
   @action
-  error() {
+  error(e) {
+    console.log(e); // eslint-disable-line
     this.transitionTo('not-found', 'not-found');
   }
 }

--- a/app/templates/my-projects/assignment/hearing/done.hbs
+++ b/app/templates/my-projects/assignment/hearing/done.hbs
@@ -6,15 +6,15 @@
       <h3 class="tiny-margin-bottom">
         <LinkTo
           @route="show-project"
-          @model={{project}}
+          @model={{model.project}}
           data-test-button="back-to-project-profile"
         >
-          {{model.dcpProjectname}}
+          {{model.project.dcpProjectname}}
         </LinkTo>
-        <small class="dark-gray">{{model.dcpUlurpNonulurp}}</small>
+        <small class="dark-gray">{{model.project.dcpUlurpNonulurp}}</small>
       </h3>
-      <h5 class="applicant">{{model.applicants}}</h5>
-      <p>{{model.dcpProjectbrief}}</p>
+      <h5 class="applicant">{{model.project.applicants}}</h5>
+      <p>{{model.project.dcpProjectbrief}}</p>
     </div>
   </div>
   <div class="large-7 cell">
@@ -28,6 +28,7 @@
       @route="my-projects.to-review"
       data-test-button="back-to-review"
       class="button gray"
+      data-test-button="back-to-review"
     >
       Go to My Projects
     </LinkTo>

--- a/app/templates/my-projects/assignment/recommendations/done.hbs
+++ b/app/templates/my-projects/assignment/recommendations/done.hbs
@@ -7,15 +7,15 @@
       <h3 class="tiny-margin-bottom">
         <LinkTo
           @route="show-project"
-          @model={{project}}
+          @model={{model.project}}
           data-test-button="back-to-project-profile"
         >
-          {{model.dcpProjectname}}
+          {{model.project.dcpProjectname}}
         </LinkTo>
-        <small class="dark-gray">{{model.dcpUlurpNonulurp}}</small>
+        <small class="dark-gray">{{model.project.dcpUlurpNonulurp}}</small>
       </h3>
-      <h5 class="applicant">{{model.applicants}}</h5>
-      <p>{{model.dcpProjectbrief}}</p>
+      <h5 class="applicant">{{model.project.applicants}}</h5>
+      <p>{{model.project.dcpProjectbrief}}</p>
     </div>
   </div>
   <div class="large-7 cell">
@@ -26,6 +26,7 @@
       @route="my-projects.to-review"
       data-test-button="back-to-review"
       class="button gray"
+      data-test-button="back-to-review"
     >
       Go to My Projects
     </LinkTo>

--- a/tests/acceptance/user-can-fill-out-hearing-form-test.js
+++ b/tests/acceptance/user-can-fill-out-hearing-form-test.js
@@ -13,7 +13,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { selectChoose } from 'ember-power-select/test-support';
 import { invalidateSession, authenticateSession } from 'ember-simple-auth/test-support';
 
-module('Acceptance | user can save hearing form', function(hooks) {
+module('Acceptance | user can fill out hearing form', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 

--- a/tests/acceptance/user-can-navigate-away-from-done-pages-test.js
+++ b/tests/acceptance/user-can-navigate-away-from-done-pages-test.js
@@ -1,0 +1,177 @@
+import { module, test } from 'qunit';
+import {
+  click,
+  visit,
+  currentURL,
+} from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { invalidateSession, authenticateSession } from 'ember-simple-auth/test-support';
+
+module('Acceptance | user can navigate away from done pages', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  hooks.beforeEach(async function() {
+    window.location.hash = '';
+
+    await invalidateSession();
+  });
+
+  hooks.afterEach(async function() {
+    window.location.hash = '';
+
+    await invalidateSession();
+  });
+
+  test('user can navigate from the recommendation/done page to project profile', async function(assert) {
+    this.server.create('user', {
+      id: 1,
+      emailaddress1: 'testuser@planning.nyc.gov',
+      assignments: [
+        this.server.create('assignment', {
+          id: 1,
+          tab: 'to-review',
+          dcpLupteammemberrole: 'CB',
+          dispositions: [
+            this.server.create('disposition', {
+              dcpPublichearinglocation: 'Canal street',
+              dcpDateofpublichearing: '11/12/2019',
+              action: this.server.create('action'),
+            }),
+          ],
+          project: this.server.create('project', {
+            id: 2,
+            actions: this.server.schema.actions.all(),
+            assignments: this.server.schema.assignments.all(),
+            dispositions: this.server.schema.dispositions.all(),
+            users: this.server.schema.users.all(),
+          }),
+        }),
+      ],
+    });
+
+    await authenticateSession({
+      id: 1,
+    });
+
+    await visit('/my-projects/1/recommendations/done');
+    assert.equal(currentURL(), '/my-projects/1/recommendations/done');
+
+    await click('[data-test-button="back-to-project-profile"]');
+    assert.equal(currentURL(), '/projects/2');
+  });
+
+  test('user can navigate from the recommendation/done page to to-review page', async function(assert) {
+    this.server.create('user', {
+      id: 1,
+      emailaddress1: 'testuser@planning.nyc.gov',
+      assignments: [
+        this.server.create('assignment', {
+          id: 1,
+          tab: 'to-review',
+          dcpLupteammemberrole: 'CB',
+          dispositions: [
+            this.server.create('disposition', {
+              dcpPublichearinglocation: 'Canal street',
+              dcpDateofpublichearing: '11/12/2019',
+              action: this.server.create('action'),
+            }),
+          ],
+          project: this.server.create('project', {
+            id: 2,
+            actions: server.schema.actions.all(),
+            assignments: server.schema.assignments.all(),
+            dispositions: server.schema.dispositions.all(),
+          }),
+        }),
+      ],
+    });
+
+    await authenticateSession({
+      id: 1,
+    });
+
+    await visit('/my-projects/1/recommendations/done');
+    assert.equal(currentURL(), '/my-projects/1/recommendations/done');
+
+    await click('[data-test-button="back-to-review"]');
+
+    assert.equal(currentURL(), '/my-projects/to-review');
+  });
+
+  test('user can navigate from the hearing/done page to project profile', async function(assert) {
+    this.server.create('user', {
+      id: 1,
+      emailaddress1: 'testuser@planning.nyc.gov',
+      assignments: [
+        this.server.create('assignment', {
+          id: 1,
+          tab: 'to-review',
+          dcpLupteammemberrole: 'CB',
+          dispositions: [
+            this.server.create('disposition', {
+              dcpPublichearinglocation: 'Canal street',
+              dcpDateofpublichearing: '11/12/2019',
+              action: this.server.create('action'),
+            }),
+          ],
+          project: this.server.create('project', {
+            id: 2,
+            actions: this.server.schema.actions.all(),
+            assignments: this.server.schema.assignments.all(),
+            dispositions: this.server.schema.dispositions.all(),
+            users: this.server.schema.users.all(),
+          }),
+        }),
+      ],
+    });
+
+    await authenticateSession({
+      id: 1,
+    });
+
+    await visit('/my-projects/1/hearing/done');
+    assert.equal(currentURL(), '/my-projects/1/hearing/done');
+
+    await click('[data-test-button="back-to-project-profile"]');
+    assert.equal(currentURL(), '/projects/2');
+  });
+
+  test('user can navigate from the hearing/done page to to-review page', async function(assert) {
+    this.server.create('user', {
+      id: 1,
+      emailaddress1: 'testuser@planning.nyc.gov',
+      assignments: [
+        this.server.create('assignment', {
+          id: 1,
+          tab: 'to-review',
+          dcpLupteammemberrole: 'CB',
+          dispositions: [
+            this.server.create('disposition', {
+              dcpPublichearinglocation: 'Canal street',
+              dcpDateofpublichearing: '11/12/2019',
+              action: this.server.create('action'),
+            }),
+          ],
+          project: this.server.create('project', {
+            id: 2,
+            actions: server.schema.actions.all(),
+            assignments: server.schema.assignments.all(),
+            dispositions: server.schema.dispositions.all(),
+          }),
+        }),
+      ],
+    });
+
+    await authenticateSession({
+      id: 1,
+    });
+
+    await visit('/my-projects/1/hearing/done');
+    assert.equal(currentURL(), '/my-projects/1/hearing/done');
+
+    await click('[data-test-button="back-to-review"]');
+
+    assert.equal(currentURL(), '/my-projects/to-review');
+  });
+});


### PR DESCRIPTION
- update recommmendation/done and hearing/done to access project through assignment
- add tests to make sure navigation away from done pages work
- bugfix: in show-project controller, ensure currentUser.user is instantiated before computing `isUserAssignedToProject` 
- get rid of unnecessary `.get()`