### PR TITLE
824: use assignment to get lup role for upcoming buttons

### DIFF
--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -54,7 +54,7 @@
               data-test-button="submitHearing"
             >
               {{fa-icon 'calendar' fixedWidth=true size="lg" transform="left-2"}}
-              Post {{participant-type-label project.dcpLupteammemberrole}} Hearing Notice
+              Post {{participant-type-label assignment.dcpLupteammemberrole}} Hearing Notice
             </LinkTo>
           </div>
           <div class="cell medium-shrink">


### PR DESCRIPTION
This should solve the issue of the LUP role not being included on the hearing buttons on the "upcoming" tab #824.