### PR TITLE
830: only show action bubble on rec form if actions are provided

### DIFF
--- a/app/templates/my-projects/assignment/recommendations/add.hbs
+++ b/app/templates/my-projects/assignment/recommendations/add.hbs
@@ -56,10 +56,12 @@
                       </span>
                       <small data-test-hearing-actions-list="{{hearing.id}}">
                         {{#each hearing.hearingActions as |action index| ~}}
-                          <span class="label light-gray tiny-margin-bottom tiny-margin-right">
-                            {{action.dcpName}}
-                            <small>{{action.dcpUlurpnumber}}</small>
-                          </span>
+                          {{#if action.dcpName}}
+                            <span class="label light-gray tiny-margin-bottom tiny-margin-right">
+                              {{action.dcpName}}
+                              <small>{{action.dcpUlurpnumber}}</small>
+                            </span>
+                          {{/if}}
                         {{~/each}}
                       </small>
                     </p>


### PR DESCRIPTION
Solves #830 by only rendering the light grey `<span>` if a valid action.dcpName is provided.