### PR TITLE
771 patch condition for displaying fuzzy public review start date on upcoming project card

### DIFF
--- a/app/models/assignment.js
+++ b/app/models/assignment.js
@@ -86,23 +86,13 @@ export default class AssignmentModel extends Model {
     return this.project.get('milestones').filter(milestone => this.milestoneConstants.milestoneListByTabLookup[this.tab].includes(milestone.dcpMilestone));
   }
 
-  // The following <tab>MilestoneActual<Start/End>
-  // date fields represent different dates from different milestones
-  // depending on `tab`:
-
-  // If `tab` is `upcoming`...
-  // if the project is in public review, this field is used to display the participant's review planned start date.
-  // else this field returns null
-  @computed('tab', 'dcpLupteammemberrole', 'project.{milestones,dcpPublicstatus}')
+  // This field is used to display the participant's review planned start date.
+  // If not found, returns null
+  @computed('tab', 'dcpLupteammemberrole', 'project.milestones')
   get upcomingMilestonePlannedStartDate() {
-    if (this.tab === 'upcoming') {
-      if (this.project.dcpPublicstatus !== 'Filed') {
-        const participantMilestoneId = MILESTONE_ID_LOOKUP[this.dcpLupteammemberrole];
-        const participantReviewMilestone = this.project.get('milestones').find(milestone => milestone.dcpMilestone === participantMilestoneId);
-        return participantReviewMilestone ? participantReviewMilestone.dcpPlannedstartdate : null;
-      }
-    }
-    return null;
+    const participantMilestoneId = MILESTONE_ID_LOOKUP[this.dcpLupteammemberrole];
+    const participantReviewMilestone = this.project.get('milestones').find(milestone => milestone.dcpMilestone === participantMilestoneId);
+    return participantReviewMilestone ? participantReviewMilestone.dcpPlannedstartdate : null;
   }
 
   // If `tab` is to-review', these start/end dates are derived from

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -5,23 +5,23 @@
   <div class="grid-x grid-x-small-gutters">
     <div class="cell large-4 xlarge-5">
       <h3 class="tiny-margin-bottom">
-        {{#link-to 'show-project' assignment.project.id}}<span data-test-project-profile-button="{{assignment.project.id}}">{{assignment.project.dcpProjectname}}</span>{{/link-to}}
-        <small class="dark-gray">{{assignment.project.dcpUlurpNonulurp}}</small>
+        {{#link-to 'show-project' this.assignment.project.id}}<span data-test-project-profile-button="{{this.assignment.project.id}}">{{this.assignment.project.dcpProjectname}}</span>{{/link-to}}
+        <small class="dark-gray">{{this.assignment.project.dcpUlurpNonulurp}}</small>
       </h3>
-      <h5 class="applicant">{{assignment.project.applicants}}</h5>
-      <p>{{assignment.project.dcpProjectbrief}}</p>
+      <h5 class="applicant">{{this.assignment.project.applicants}}</h5>
+      <p>{{this.assignment.project.dcpProjectbrief}}</p>
     </div>
     <div class="cell medium-4 large-3 xlarge-2">
       <div class="text-center medium-margin-right medium-margin-left">
-        {{#if assignment.upcomingMilestonePlannedStartDate}}
+        {{#if (eq this.assignment.project.dcpPublicstatusSimp 'In Public Review')}}
           <p class="tiny-margin-bottom">
-            {{participant-type-label assignment.dcpLupteammemberrole}} Review Begins
+            {{participant-type-label this.assignment.dcpLupteammemberrole}} Review Begins
           </p>
           <p class="lead">
             <strong
               data-test-time-remaining
             >
-              {{moment-format assignment.upcomingMilestonePlannedStartDate "M/D/YYYY"}}
+              {{moment-format this.assignment.upcomingMilestonePlannedStartDate "M/D/YYYY"}}
             </strong>
           </p>
         {{else}}
@@ -33,7 +33,7 @@
               data-test-fuzzy-time-remaining
             >
               {{#if (not (eq isMoreThanThirtyDaysBeforePublicReview null))}}
-                {{if isMoreThanThirtyDaysBeforePublicReview 'over 30 days' '< 30 days'}}
+                {{if isMoreThanThirtyDaysBeforePublicReview 'over 30 days' 'under 30 days'}}
               {{/if}}
             </strong>
           </p>
@@ -44,17 +44,17 @@
       </div>
     </div>
     <div class="cell medium-auto">
-      {{#if assignment.hearingsNotSubmittedNotWaived}}
+      {{#if this.assignment.hearingsNotSubmittedNotWaived}}
         <div class="grid-x">
           <div class="cell medium-auto">
             <LinkTo
               @route="my-projects.assignment.hearing.add"
-              @model={{assignment}}
+              @model={{this.assignment}}
               class="button expanded"
               data-test-button="submitHearing"
             >
               {{fa-icon 'calendar' fixedWidth=true size="lg" transform="left-2"}}
-              Post {{participant-type-label assignment.dcpLupteammemberrole}} Hearing Notice
+              Post {{participant-type-label this.assignment.dcpLupteammemberrole}} Hearing Notice
             </LinkTo>
           </div>
           <div class="cell medium-shrink">
@@ -67,12 +67,12 @@
               <small>Opt Out</small>
             </button>
 
-            {{waive-hearings-popup assignment=assignment showPopup=showPopup}}
+            {{waive-hearings-popup assignment=this.assignment showPopup=showPopup}}
           </div>
         </div>
       {{/if}}
       <ul class="no-bullet no-margin">
-        {{#each assignment.tabSpecificMilestones as |milestone|}}
+        {{#each this.assignment.tabSpecificMilestones as |milestone|}}
           <li class="grid-x small-margin-bottom">
             <div class="cell shrink small-margin-right">
               {{#if (eq milestone.statuscode "Completed")}}

--- a/mirage/factories/project.js
+++ b/mirage/factories/project.js
@@ -10,6 +10,17 @@ export default Factory.extend({
   //   return faker.random.uuid();
   // },
 
+  // dcpPublicStatus and dcpPublicstatusSimp should not receive random mock data
+  // because their values are critical to expressing project state.
+
+  // Domain is ['Filed', 'Certified', 'Approved', 'Withdrawn']
+  dcpPublicstatus: 'Filed',
+
+  // Domain is ['Filed', 'In Public Review', 'Completed', 'Unknown']
+  // This field is derived from dcpPublicstatus.
+  // See https://github.com/NYCPlanning/zap-api/blob/develop/queries/projects/show.sql#L28
+  dcpPublicstatusSimp: 'Filed',
+
   dcpName() {
     return faker.random.number();
   },
@@ -99,14 +110,6 @@ export default Factory.extend({
       ${faker.random.arrayElement([faker.address.streetName(), faker.company.companyName()])}
       ${faker.random.arrayElement(['Rezoning', faker.address.streetSuffix()])}
     `;
-  },
-
-  publicStatus() {
-    return faker.random.arrayElement(['Active', 'Approved', 'Withdrawn']);
-  },
-
-  dcpPublicstatusSimp() {
-    return faker.random.arrayElement(['Filed', 'In Public Review', 'Completed']);
   },
 
   projectCompleted() {

--- a/tests/acceptance/upcoming-project-cards-renders-test.js
+++ b/tests/acceptance/upcoming-project-cards-renders-test.js
@@ -33,13 +33,15 @@ module('Acceptance | upcoming project cards renders', function(hooks) {
         this.server.create('assignment', {
           id: 1,
           tab: 'upcoming',
-          dcpPublicstatus: 'Filed',
           dcpLupteammemberrole: 'BP',
           dispositions: [],
           project: this.server.create('project', {
-            milestones: [this.server.create('milestone', 'communityBoardReview', {
-              dcpPlannedstartdate: moment().add(32, 'days'),
-            })],
+            dcpPublicstatusSimp: 'Filed',
+            milestones: [
+              this.server.create('milestone', 'communityBoardReview', {
+                dcpPlannedstartdate: moment().add(32, 'days'),
+              }),
+            ],
           }),
         }),
       ],
@@ -56,7 +58,7 @@ module('Acceptance | upcoming project cards renders', function(hooks) {
     assert.notOk(find('[data-test-time-remaining]'));
   });
 
-  test('upcoming project card renders fuzzy date if public review is less than 30 days away', async function(assert) {
+  test('upcoming project card renders fuzzy date if public review is under 30 days away', async function(assert) {
     this.server.create('user', {
       id: 1,
       email: 'qncb5@planning.nyc.gov',
@@ -65,10 +67,10 @@ module('Acceptance | upcoming project cards renders', function(hooks) {
         this.server.create('assignment', {
           id: 1,
           tab: 'upcoming',
-          dcpPublicstatus: 'Filed',
           dcpLupteammemberrole: 'BP',
           dispositions: [],
           project: this.server.create('project', {
+            dcpPublicstatusSimp: 'Filed',
             milestones: [this.server.create('milestone', 'communityBoardReview', {
               dcpPlannedstartdate: moment().add(15, 'days'),
             })],
@@ -84,7 +86,7 @@ module('Acceptance | upcoming project cards renders', function(hooks) {
     await visit('/my-projects/upcoming');
 
     const timeRemainingValue = find('[data-test-fuzzy-time-remaining]').textContent.trim();
-    assert.equal(timeRemainingValue, '< 30 days', 'Time remaining displays less than 30 days');
+    assert.equal(timeRemainingValue, 'under 30 days', 'Time remaining displays under 30 days');
     assert.notOk(find('[data-test-time-remaining]'));
   });
 
@@ -97,10 +99,10 @@ module('Acceptance | upcoming project cards renders', function(hooks) {
         this.server.create('assignment', {
           id: 1,
           tab: 'upcoming',
-          dcpPublicstatus: 'Certified',
           dcpLupteammemberrole: 'BP',
           dispositions: [],
           project: this.server.create('project', {
+            dcpPublicstatusSimp: 'In Public Review',
             milestones: [
               this.server.create('milestone', 'communityBoardReview', {
               }),
@@ -122,5 +124,39 @@ module('Acceptance | upcoming project cards renders', function(hooks) {
     const timeRemainingValue = find('[data-test-time-remaining]').textContent.trim();
     assert.equal(timeRemainingValue, '11/30/2019', 'Estimated start is 11/30/2019');
     assert.notOk(find('[data-test-fuzzy-time-remaining]'));
+  });
+
+  test('upcoming project card defaults to fuzzy date if project.dcpPublicstatusSimp is undefined', async function(assert) {
+    this.server.create('user', {
+      id: 1,
+      email: 'qncb5@planning.nyc.gov',
+      landUseParticipant: 'QNBP',
+      assignments: [
+        this.server.create('assignment', {
+          id: 1,
+          tab: 'upcoming',
+          dcpLupteammemberrole: 'BP',
+          dispositions: [],
+          project: this.server.create('project', {
+            dcpPublicstatusSimp: '',
+            milestones: [this.server.create('milestone', 'communityBoardReview', {
+              // note how Community Board Review has already started, but we still display
+              // the fuzzy public review start date ('under 30 days')
+              dcpPlannedstartdate: moment().subtract(15, 'days'),
+            })],
+          }),
+        }),
+      ],
+    });
+
+    await authenticateSession({
+      id: 1,
+    });
+
+    await visit('/my-projects/upcoming');
+
+    const timeRemainingValue = find('[data-test-fuzzy-time-remaining]').textContent.trim();
+    assert.equal(timeRemainingValue, 'under 30 days', 'Time remaining displays under 30 days');
+    assert.notOk(find('[data-test-time-remaining]'));
   });
 });


### PR DESCRIPTION
- refactor assignment 'upcoming' date CPs to have less dependencies, and to handle undefined `dcpPublicStatusSimp`
- fix upcoming project card test