### PR TITLE
823 wrap moment-format helpers in custom guard

### DIFF
--- a/app/components/date-display.js
+++ b/app/components/date-display.js
@@ -1,0 +1,20 @@
+import Component from '@ember/component';
+
+// Unfortunately, moment-format's allow-empty flag is not yet stable.
+// So we manually handle undefined dates through this component.
+// https://github.com/stefanpenner/ember-moment#common-optional-named-arguments
+export default class DateDisplayComponent extends Component {
+  tagName = '';
+
+  // A date string in a common format
+  date = '';
+
+  // date output format
+  outputFormat = 'MM/D/YYYY';
+
+  // date input format
+  inputFormat = '';
+
+  // message to display if invalid date
+  errorMessage = 'Date Unknown';
+}

--- a/app/controllers/my-projects/assignment/recommendations/add.js
+++ b/app/controllers/my-projects/assignment/recommendations/add.js
@@ -209,7 +209,7 @@ export default class MyProjectsProjectRecommendationsAddController extends Contr
   }
 
   @action
-  async onContinue() {
+  onContinue() {
     this.dispositionForAllActionsChangeset.validate();
     this.dispositionsChangesets.forEach(changeset => changeset.validate());
     if (this.isFormValid) {

--- a/app/templates/components/archive-project-card.hbs
+++ b/app/templates/components/archive-project-card.hbs
@@ -16,7 +16,10 @@
         <p class="lead small-margin-bottom">
           <strong>
             {{this.assignment.project.dcpPublicstatusSimp}}
-            {{moment-format this.assignment.project.dcpProjectcompleted "M/D/YYYY"}}
+            <DateDisplay
+              @date={{this.assignment.project.dcpProjectcompleted}}
+              @outputFormat="M/D/YYYY"
+            />
           </strong>
         </p>
       </div>

--- a/app/templates/components/archive-project-milestone-list-item.hbs
+++ b/app/templates/components/archive-project-milestone-list-item.hbs
@@ -27,7 +27,7 @@
       {{/each}}
       <br>
       <small class="display-block">
-        Recommendation submitted&nbsp;{{~moment-format this.anyCommunityBoardDispositionDateReceived "MM/D/YYYY"~}}
+        Recommendation submitted&nbsp;<DateDisplay @date={{this.anyCommunityBoardDispositionDateReceived}} />
       </small>
     {{else if (eq this.milestone.dcpMilestone this.milestoneConstants.BOROUGH_BOARD_REFERRAL)}}
       {{#each this.boroughBoardDispositions as |disposition|}}
@@ -38,7 +38,7 @@
       {{/each}}
       <br>
       <small class="display-block">
-        Recommendation submitted&nbsp;{{~moment-format this.anyBoroughBoardDispositionDateReceived "MM/D/YYYY"~}}
+        Recommendation submitted&nbsp;<DateDisplay @date={{this.anyBoroughBoardDispositionDateReceived}} />
       </small>
     {{else if (eq this.milestone.dcpMilestone this.milestoneConstants.BOROUGH_PRESIDENT_REFERRAL)}}
       {{#each this.boroughPresidentDispositions as |disposition|}}
@@ -49,12 +49,14 @@
       {{/each}}
       <br>
       <small class="display-block">
-        Recommendation submitted&nbsp;{{~moment-format this.anyBoroughPresidentDispositionDateReceived "MM/D/YYYY"~}}
+        Recommendation submitted&nbsp;<DateDisplay @date={{this.anyBoroughPresidentDispositionDateReceived}} />
       </small>
     {{else}}
       <br>
       <small class="display-block">
-        {{~moment-format this.milestone.dcpActualenddate "MM/D/YYYY"~}}
+        <DateDisplay
+          @date={{this.milestone.dcpActualenddate}}
+        />
       </small>
     {{/if}}
   </div>

--- a/app/templates/components/date-display.hbs
+++ b/app/templates/components/date-display.hbs
@@ -1,0 +1,7 @@
+{{#if this.date}}
+  {{~moment-format this.date this.outputFormat this.inputFormat~}}
+{{else}}
+  <small class="light-gray">
+    {{this.errorMessage}}
+  </small>
+{{/if}}

--- a/app/templates/components/hearings-list-for-milestones-list.hbs
+++ b/app/templates/components/hearings-list-for-milestones-list.hbs
@@ -14,7 +14,12 @@
               <div class="cell auto">
                 <strong data-test-hearing-title>{{currentMilestoneUserType}} Public Hearing</strong>
                 <span data-test-hearing-location="{{hearing.disposition.id}}">{{hearing.disposition.dcpPublichearinglocation}}</span>
-                <small class="display-inline-block" data-test-hearing-date="{{hearing.disposition.id}}">{{~moment-format hearing.disposition.dcpDateofpublichearing "LLL"~}}</small>
+                <small class="display-inline-block" data-test-hearing-date="{{hearing.disposition.id}}">
+                  <DateDisplay
+                    @date={{hearing.disposition.dcpDateofpublichearing}} 
+                    @outputFormat="LLL"
+                  />
+                </small>
                 <span class="display-inline-block text-tiny">
                   {{#each hearing.hearingActions as |action index|}}
                     <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-hearing-actions-list="{{index}}">

--- a/app/templates/components/project-list-item.hbs
+++ b/app/templates/components/project-list-item.hbs
@@ -14,7 +14,10 @@
     {{#if project.lastmilestonedate}}
       <span class="date dark-gray projects-list-result--date">
         {{icon-tooltip icon='calendar' tip='Latest Milestone'}}
-        {{moment-format project.lastmilestonedate "MMMM D, YYYY"}}
+        <DateDisplay
+          @date={{project.lastmilestonedate}}
+          @outputFormat="MMMM D, YYYY"
+        />
       </span>
     {{/if}}
     <h3 class="projects-list-result--header header-medium">

--- a/app/templates/components/project-milestone.hbs
+++ b/app/templates/components/project-milestone.hbs
@@ -29,10 +29,22 @@
   {{#if milestone.displayDate}}
     <div class="milestone-dates">
       {{#if milestone.displayDate}}
-        <div>{{moment-format milestone.displayDate "MMMM D, YYYY" }} {{#if milestone.displayDate2}}<small>Start</small>{{/if}}</div>
+        <div>
+          <DateDisplay
+            @date={{milestone.displayDate}}
+            @outputFormat="MMMM D, YYYY"
+          />
+          {{#if milestone.displayDate2}}<small>Start</small>{{/if}}
+        </div>
       {{/if}}
       {{#if milestone.displayDate2}}
-        <div>{{moment-format milestone.displayDate2 "MMMM D, YYYY" }} <small>End</small></div>
+        <div>
+          <DateDisplay
+            @date={{milestone.displayDate2}}
+            @outputFormat="MMMM D, YYYY"
+          />
+          <small>End</small>
+        </div>
       {{/if}}
       {{#if timeRelativeToNow}}
         <div class="milestone-offset">{{timeRelativeToNow}}</div>

--- a/app/templates/components/projects-map-data.hbs
+++ b/app/templates/components/projects-map-data.hbs
@@ -12,7 +12,7 @@
 
   {{#if highlightedFeature}}
     <div class='map-tooltip' style="top:{{tooltipPoint.y}}px;left:{{tooltipPoint.x}}px;">
-      {{highlightedFeature.properties.dcp_projectname}} ({{moment-format highlightedFeature.properties.lastmilestonedate "MMMM, YYYY"}})
+      {{highlightedFeature.properties.dcp_projectname}} (<DateDisplay @date={{highlightedFeature.properties.lastmilestonedate}} @outputFormat="MMMM, YYYY" />)
     </div>
   {{/if}}
 

--- a/app/templates/components/reviewed-project-card.hbs
+++ b/app/templates/components/reviewed-project-card.hbs
@@ -21,7 +21,9 @@
             >{{plannedTimeDisplay.estTimeRemaining}}</strong>
             <strong class="display-block">of {{plannedTimeDisplay.estTimeDuration}} estimated days remain</strong>
           </p>
-          <p class="text-tiny">Estimated End {{moment-format plannedTimeDisplay.dcpPlannedcompletiondate "M/D/YYYY"}}</p>
+          <p class="text-tiny">
+            Estimated End <DateDisplay @date={{plannedTimeDisplay.dcpPlannedcompletiondate}} outputFormat="M/D/YYYY" />
+          </p>
         </div>
       </div>
       <div class="cell medium-auto">

--- a/app/templates/components/reviewed-project-milestone-list-item.hbs
+++ b/app/templates/components/reviewed-project-milestone-list-item.hbs
@@ -28,7 +28,7 @@
         {{/each}}
         <br>
         <small class="display-block">
-          Recommendation submitted&nbsp;{{~moment-format this.anyCommunityBoardDispositionDateReceived "MM/D/YYYY"~}}
+          Recommendation submitted&nbsp;<DateDisplay @date={{this.anyCommunityBoardDispositionDateReceived}} />
         </small>
       {{else if (eq this.milestone.dcpMilestone this.milestoneConstants.BOROUGH_BOARD_REFERRAL)}}
         {{#each this.boroughBoardDispositions as |disposition|}}
@@ -39,7 +39,7 @@
         {{/each}}
         <br>
         <small class="display-block">
-          Recommendation submitted&nbsp;{{~moment-format this.anyBoroughBoardDispositionDateReceived "MM/D/YYYY"~}}
+          Recommendation submitted&nbsp;<DateDisplay @date={{this.anyBoroughBoardDispositionDateReceived}} />
         </small>
       {{else if (eq this.milestone.dcpMilestone this.milestoneConstants.BOROUGH_PRESIDENT_REFERRAL)}}
         {{#each this.boroughPresidentDispositions as |disposition|}}
@@ -50,13 +50,13 @@
         {{/each}}
         <br>
         <small class="display-block">
-          Recommendation submitted&nbsp;{{~moment-format this.anyBoroughPresidentDispositionDateReceived "MM/D/YYYY"~}}
+          Recommendation submitted&nbsp;<DateDisplay @date={{this.anyBoroughPresidentDispositionDateReceived}} />
         </small>
       {{else}}
         <br>
         {{#if this.milestone.dcpActualenddate}}
           <small class="display-block">
-            {{~moment-format this.milestone.dcpActualenddate "MM/D/YYYY"~}}
+            <DateDisplay @date={{this.milestone.dcpActualenddate}} />
           </small>
         {{/if}}
       {{/if}}

--- a/app/templates/components/to-review-project-card.hbs
+++ b/app/templates/components/to-review-project-card.hbs
@@ -23,7 +23,9 @@
             </strong>
             <strong class="display-block">of {{timeDuration}} days remain</strong>
           </p>
-          <p class="text-tiny">Ends {{moment-format assignment.toReviewMilestonePlannedCompletionDate "M/D/YYYY"}}</p>
+          <p class="text-tiny">
+            Ends <DateDisplay @date={{assignment.toReviewMilestonePlannedCompletionDate}} @outputFormat="M/D/YYYY" />
+          </p>
         {{else}}
           <br>
           <p
@@ -70,11 +72,11 @@
 
                     <span class="display-inline-block">
                       <span data-test-hearing-date="{{hearing.disposition.id}}">
-                        {{~moment-format hearing.disposition.dcpDateofpublichearing "MM/D/YYYY"~}}
+                        <DateDisplay @date={{hearing.disposition.dcpDateofpublichearing}} />
                       </span>
                       <span class="light-gray">|</span>
                       <span data-test-hearing-time="{{hearing.disposition.id}}">
-                        {{~moment-format hearing.disposition.dcpDateofpublichearing "h:mm A"~}}
+                        <DateDisplay @date={{hearing.disposition.dcpDateofpublichearing}} @outputFormat="h:mm A" />
                       </span>
                     </span>
 

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -21,7 +21,10 @@
             <strong
               data-test-time-remaining
             >
-              {{moment-format this.assignment.upcomingMilestonePlannedStartDate "M/D/YYYY"}}
+              <DateDisplay
+                @date={{this.assignment.upcomingMilestonePlannedStartDate}}
+                @outputFormat="M/D/YYYY"
+              />
             </strong>
           </p>
         {{else}}
@@ -91,7 +94,9 @@
               <strong>{{milestone.displayName}}</strong>
               {{#if milestone.dcpActualenddate}}
                 <small class="display-inline-block">
-                  {{~moment-format milestone.dcpActualenddate "MM/D/YYYY"~}}
+                  <DateDisplay
+                    @date={{milestone.dcpActualenddate}}
+                  />
                 </small>
               {{#if (or (not milestone.dcpActualenddate) (is-before milestone.dcpActualenddate))}}
                   {{hearings-list-for-milestones-list milestone=milestone}}

--- a/app/templates/my-projects/assignment/hearing/add.hbs
+++ b/app/templates/my-projects/assignment/hearing/add.hbs
@@ -97,13 +97,18 @@
                   <strong class="display-block hearing-location">
                     {{~dispositionForAllActions.dcpPublichearinglocation~}}
                   </strong>
-                  <span class="hearing-date">
-                    {{~moment-format dispositionForAllActions.dcpDateofpublichearing "MM/D/YYYY"~}}
-                  </span>
+                  <span class="hearing-date">{{!--
+                --}}<DateDisplay
+                      @date={{dispositionForAllActions.dcpDateofpublichearing}}
+                    />{{!--
+              --}}</span>
                   <span class="light-gray">|</span>
-                  <span class="hearing-time">
-                    {{~moment-format dispositionForAllActions.dcpDateofpublichearing "h:mm A"~}}
-                  </span>
+                  <span class="hearing-time">{{!--
+                --}}<DateDisplay
+                      @date={{dispositionForAllActions.dcpDateofpublichearing}}
+                      @outputFormat="h:mm A"
+                    />{{!--
+              --}}</span>
                 </div>
               </li>
             {{else}}
@@ -125,13 +130,19 @@
                           </strong>
 
                           <span class="display-inline-block">
-                            <span data-test-hearing-date="{{hearing.disposition.id}}">
-                              {{~moment-format hearing.disposition.dcpDateofpublichearing "MM/D/YYYY"~}}
-                            </span>
+                            <span data-test-hearing-date="{{hearing.disposition.id}}"
+                            >{{!--
+                          --}}<DateDisplay
+                                @date={{hearing.disposition.dcpDateofpublichearing}}
+                              />{{!--
+                        --}}</span>
                             <span class="light-gray">|</span>
-                            <span data-test-hearing-time="{{hearing.disposition.id}}">
-                              {{~moment-format hearing.disposition.dcpDateofpublichearing "h:mm A"~}}
-                            </span>
+                            <span data-test-hearing-time="{{hearing.disposition.id}}">{{!--
+                            --}}<DateDisplay
+                                @date={{hearing.disposition.dcpDateofpublichearing}}
+                                @outputFormat="h:mm A"
+                              />{{!--
+                        --}}</span>
                           </span>
 
                           <small data-test-hearing-actions-list="{{hearing.disposition.id}}">

--- a/app/templates/my-projects/assignment/recommendations/add.hbs
+++ b/app/templates/my-projects/assignment/recommendations/add.hbs
@@ -50,7 +50,11 @@
                   <div class="grid-x">
                     <p class="cell auto small-order-2">
                       <span class="display-block">
-                        <strong>{{moment-format hearing.disposition.dcpDateofpublichearing "MM/D/YYYY"}}</strong>
+                        <strong>
+                          <DateDisplay
+                            @date={{hearing.disposition.dcpDateofpublichearing}}
+                          />
+                        </strong>
                         <span class="light-gray">|</span>
                         <strong>{{hearing.disposition.dcpPublichearinglocation}}</strong>
                       </span>
@@ -521,7 +525,11 @@
                     </strong>
                     <span class="cell auto">
                       <span class="display-block">
-                        <strong>{{moment-format hearing.disposition.dcpDateofpublichearing "MM/D/YYYY"}}</strong>
+                        <strong>
+                          <DateDisplay
+                            @date={{hearing.disposition.dcpDateofpublichearing}}
+                          />
+                        </strong>
                         <span class="light-gray">|</span>
                         <strong>{{hearing.disposition.dcpPublichearinglocation}}</strong>
                       </span>

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -69,7 +69,14 @@
                 <span style="color:#ff0000">{{fa-icon 'youtube' prefix='fab' size='2x' pull='left'}}</span>
                 <span class="text-small">
                   <strong>{{link.hearing_type}}</strong>
-                  <span class="display-block dark-gray"><small>{{moment-format link.date "MMMM D, YYYY" }}</small></span>
+                  <span class="display-block dark-gray">
+                    <small>
+                      <DateDisplay
+                        @date={{link.date}}
+                        @outputFormat="MMMM D, YYYY"
+                      />
+                    </small>
+                  </span>
                 </span>
               </a>
             {{/each}}

--- a/tests/integration/components/date-display-test.js
+++ b/tests/integration/components/date-display-test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | date-display', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders date in specified format', async function(assert) {
+    await render(hbs`<DateDisplay
+      @date='11/1/2013'
+      @outputFormat='MM/DD/YY'
+      @inputFormat='D/MM/YYYY'
+      @errorMessage='Date Unknown'
+    />`);
+
+    assert.equal(this.element.textContent.trim(), '01/11/13');
+  });
+
+  test('it displays specified error message if blank date passed', async function(assert) {
+    await render(hbs`<DateDisplay
+      @date=''
+      @outputFormat='MM/DD/YY'
+      @inputFormat='D/MM/YYYY'
+      @errorMessage='Date is strange.'
+    />`);
+
+    assert.equal(this.element.textContent.trim(), 'Date is strange.');
+  });
+
+  test('it displays default error message if blank date passed', async function(assert) {
+    await render(hbs`<DateDisplay
+      @date=''
+      @outputFormat='MM/DD/YY'
+      @inputFormat='D/MM/YYYY'
+    />`);
+
+    assert.equal(this.element.textContent.trim(), 'Date Unknown');
+  });
+});


### PR DESCRIPTION
Note that because it seems the `~` whitespace trim operator within a component doesn't work outside of  that component, it's up to the consuming template to trim out whitespace around the `<DisplayDate />` component.

Also takes care of #686 
