### PR TITLE
847: hearings-list-for-milestones-list displays hearing by participant

### DIFF
--- a/app/components/deduped-hearings-list.js
+++ b/app/components/deduped-hearings-list.js
@@ -32,27 +32,19 @@ export default class DedupedHearingsListComponent extends Component {
 
   @computed('dispositions')
   get dedupedHearings() {
-    const newDispositionsArray = [];
-
-    // setting a new property on each disposition called hearingActions which is an array of objects
-    // property hearingActions is initally set to an array of the current disposition's action model.
+    // ** Setting a new property on each object called hearingActions which is an array of objects.
+    // The new property hearingActions is initally set to an array of the current disposition's action model.
     // During the reduce, if there is a duplicate in the array of dispositions,
-    // the actions model for that duplicate disposition is pushed into this array
-
-    // setting a new property--each disposition in the deduped list will have an array of its duplicate dispositions
-    // property duplicateDisps is initally set to an array of the current disposition model (itself)
+    // the actions model for that duplicate disposition is pushed into this array.
+    // ** Setting a new property--each object in the deduped list will have an array of that disposition's duplicate dispositions.
+    // The new property duplicateDisps is initally set to an array of the current disposition model (itself).
     // During the reduce, if there is a duplicate in the array of dispositions,
-    // that duplicate disposition is pushed into this array
-
-    this.dispositions.forEach(function(currentDisp) {
-      newDispositionsArray.push(
-        {
-          disposition: currentDisp,
-          hearingActions: [currentDisp.action],
-          duplicateDisps: [currentDisp],
-        },
-      );
-    });
+    // that duplicate disposition is pushed into this array.
+    const newDispositionsArray = this.dispositions.map(disp => ({
+      disposition: disp,
+      hearingActions: [disp.action],
+      duplicateDisps: [disp],
+    }));
 
     // function to deduplicate dispositions based on dcpPublichearinglocation & dcpDateofpublichearing
     // each disposition object in the new deduped array will have a property hearingActions and duplicateDisps, both arrays of objects

--- a/app/components/hearings-list-for-milestones-list.js
+++ b/app/components/hearings-list-for-milestones-list.js
@@ -1,7 +1,40 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 
-export default class ProjectMilestoneComponent extends Component {
+// Deduplicate an array of objects based on one field --> landUseParticipantFullName.
+// While reducing, if there's a match, concatenate each disposition onto userDispositions property.
+// userDispositions property is a concatenation of all dispositions associated with one landUseParticipantFullName
+export function dedupeByParticipant(records = []) {
+  return records.reduce((accumulator, current) => {
+    // object that represents a match between accumulator and current based on one similar field
+    const matchingFieldObject = accumulator.find(item => item.landUseParticipantFullName === current.landUseParticipantFullName);
+
+    if (matchingFieldObject) {
+      // push the current's disposition into the userDispositions property
+      matchingFieldObject.userDispositions.push(current.disposition);
+      // if there is a match, return just the accumulator.
+      // only change is that the current's disposition is pushed into userDispositions array
+      return accumulator;
+    }
+    // if there is no match, concatenate the current onto the accumulator array
+    return accumulator.concat([current]);
+  }, []);
+}
+
+export function checkHearingsSubmitted(records = []) {
+  const dispositionHearingsLocations = records.map(disp => `${disp.dcpPublichearinglocation}`);
+  const dispositionHearingsDates = records.map(disp => disp.dcpDateofpublichearing);
+  // checks whether each item in array is truthy
+  return dispositionHearingsLocations.every(item => !!item) && dispositionHearingsDates.every(item => !!item);
+}
+
+export function checkHearingsWaived(records = []) {
+  const dispositionHearingsLocations = records.map(disp => `${disp.dcpPublichearinglocation}`);
+  // checks whether each item in array === 'waived'
+  return dispositionHearingsLocations.every(item => item === 'waived');
+}
+
+export default class HearingsListForMilestonesListComponent extends Component {
   // @argument
   milestone;
 
@@ -11,56 +44,54 @@ export default class ProjectMilestoneComponent extends Component {
     CB: 'Community Board Review',
   }
 
-  // An array of disposition models that match the current milestone
+  // An array of disposition models that match the current milestone that is passed in
   @computed('milestone', 'milestone.project.dispositions')
   get currentMilestoneDispositions() {
-    const currentMilestoneDispositions = [];
-
     const milestone = this.get('milestone');
     // ALL dispositions associated with a milestone's project
     const dispositions = milestone.get('project.dispositions');
     const milestoneParticipantReviewLookup = this.get('milestoneParticipantReviewLookup');
 
-    // iterate through ALL of the current project's dispositions
-    // IF a single disposition's assignment's dcpLupteammemberrole matches the
-    // current milestone's displayName, push that disposition into the new
-    // currentMilestoneDispositions array
-    dispositions.forEach(function(disposition) {
-      const participantType = disposition.get('assignment.dcpLupteammemberrole');
 
-      // milestoneParticipantReviewLookup[participantType] = e.g. `Community Board Review`
-      if (milestone.displayName === milestoneParticipantReviewLookup[participantType]) {
-        currentMilestoneDispositions.push(disposition);
-      }
+    // Iterate through ALL of the current project's dispositions.
+    // Filter by IF a single disposition's dcpRecommendationsubmittedbyname matches the
+    // current milestone's displayName based on the milestoneParticipantReviewLookup.
+    // disposition.dcpRecommendationsubmittedbyname = e.g. 'QNBP'
+    // disposition.dcpRecommendationsubmittedbyname.substring(2,4) = e.g. 'BP'
+    // matching e.g. 'BP' with the milestoneParticipantReviewLookup provides 'Borough President Review'
+    return dispositions.filter(disposition => milestone.displayName === milestoneParticipantReviewLookup[disposition.dcpRecommendationsubmittedbyname.substring(2, 4)]);
+  }
+
+  // An array of objects that contain the `landUseParticipantFullName` value and an array of dispositions that match that landUseParticipantFullName
+  @computed('currentMilestoneDispositions')
+  get milestoneParticipants() {
+    const currentMilestoneDispositions = this.get('currentMilestoneDispositions');
+    // Map new object where recommendationSubmittedByFullName property on disposition
+    // is easily accessible as landUseParticipantFullName.
+    // When deduplicated, userDispositions will be an array of ALL dispositions
+    // associated with ONE landUseParticipantFullName
+    const milestoneParticipants = currentMilestoneDispositions.map(disp => ({
+      landUseParticipantFullName: disp.recommendationSubmittedByFullName,
+      disposition: disp,
+      userDispositions: [disp],
+      hearingsSubmitted: false,
+      hearingsWaived: false,
+    }));
+
+    // deduplicate based on landUseParticipantFullName property
+    // concatenate all dispositions associated with that participant in userDispositions
+    const milestoneParticipantsDeduped = dedupeByParticipant(milestoneParticipants);
+
+    // In order to check whether dispositions for each participant has hearingsSubmitted or hearingsWaived
+    // iterate through a single participant's userDispositions and check that
+    // dcpPublichearinglocation and dcpDateofpublichearing are truthy (for hearingsSubmitted) OR
+    // dcpPublichearinglocation === 'waived' (for hearingsWaived)
+    // checking hearingsSubmitted/hearingsWavied is necessary for when we pass userDispositions into deduped-hearings-list
+    milestoneParticipantsDeduped.forEach(function(participant) {
+      participant.hearingsSubmitted = checkHearingsSubmitted(participant.userDispositions);
+      participant.hearingsWaived = checkHearingsWaived(participant.userDispositions);
     });
 
-    // if dispositions have been pushed to the array (its length is greater than 1)
-    // return arrray -- otherwise return null
-    if (currentMilestoneDispositions.length < 1) {
-      return null;
-    } return currentMilestoneDispositions;
-  }
-
-  // An array of disposition models that match the current milestone
-  @computed('milestone.milestonename')
-  get currentMilestoneUserType() {
-    const milestoneName = this.get('milestone.milestonename');
-    return milestoneName.replace(' Review', '');
-  }
-
-
-  // if each dcpPublichearinglocation and dcpDateofpublichearing properties are filled in currentMilestoneDispositions array,
-  // then hearings have been submitted for that project
-  @computed('currentMilestoneDispositions.@each.{dcpPublichearinglocation,dcpDateofpublichearing}')
-  get hearingsSubmitted() {
-    const dispositions = this.get('currentMilestoneDispositions');
-    // array of hearing locations
-    const dispositionHearingLocations = dispositions.map(disp => `${disp.dcpPublichearinglocation}`);
-    // array of hearing dates
-    const dispositionHearingDates = dispositions.map(disp => disp.dcpDateofpublichearing);
-    // hearingsSubmittedForProject checks whether each item in array is truthy
-    const arraysFilled = dispositionHearingLocations.length > 0 && dispositionHearingDates.length > 0;
-    const hearingsSubmittedForProject = arraysFilled && dispositionHearingLocations.every(location => !!location) && dispositionHearingDates.every(date => !!date);
-    return hearingsSubmittedForProject;
+    return milestoneParticipantsDeduped;
   }
 }

--- a/app/models/assignment.js
+++ b/app/models/assignment.js
@@ -63,9 +63,7 @@ export default class AssignmentModel extends Model {
 
   @computed('hearingsSubmitted', 'hearingsWaived')
   get hearingsSubmittedOrWaived() {
-    const hearingsSubmitted = this.get('hearingsSubmitted');
-    const hearingsWaived = this.get('hearingsWaived');
-    return !!hearingsSubmitted || !!hearingsWaived;
+    return this.get('hearingsSubmitted') || this.get('hearingsWaived');
   }
 
   @computed('hearingsSubmitted', 'hearingsWaived')

--- a/app/models/disposition.js
+++ b/app/models/disposition.js
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import { computed } from '@ember/object';
 
 const {
   Model, attr, belongsTo,
@@ -23,6 +24,10 @@ export default class DispositionModel extends Model {
 
   // sourced from dcp_dcpDateofpublichearing
   @attr('date', { defaultValue: null }) dcpDateofpublichearing;
+
+  // sourced from dcp_recommendationsubmittedbyname
+  // e.g. 'QNCB6', 'BXBP', 'MNBB'
+  @attr('string', { defaultValue: '' }) dcpRecommendationsubmittedbyname;
 
   // Not needed
   // @attr('string', { defaultValue: '' }) formCompleterName;
@@ -92,4 +97,40 @@ export default class DispositionModel extends Model {
   // NOTE: when this is defined as boolean, it automatically changes to false from null
   // we want this to be null until a user selects yes or no
   @attr({ defaultValue: null }) dcpWasaquorumpresent;
+
+  // dcpRecommendationsubmittedbyname = e.g. 'QNCB5'
+  // recommendationSubmittedByFullName = e.g. `Queens Community Board 5`
+  @computed('dcpRecommendationsubmittedbyname')
+  get recommendationSubmittedByFullName() {
+    const boroughLookup = {
+      MN: 'Manhattan',
+      BX: 'Bronx',
+      QN: 'Queens',
+      BK: 'Brooklyn',
+      SI: 'Staten Island',
+    };
+
+    const participantLookup = {
+      BP: 'Borough President',
+      BB: 'Borough Board',
+      CB: 'Community Board',
+    };
+
+    // shortName = e.g. 'QNCB5'
+    const shortName = this.get('dcpRecommendationsubmittedbyname');
+    // borough = e.g. 'Queens'
+    const borough = boroughLookup[shortName.substring(0, 2)];
+    // participantTypeAbbr = e.g. 'CB'
+    const participantTypeAbbr = shortName.substring(2, 4);
+    // participantType = e.g. "Community Board"
+    const participantType = participantLookup[participantTypeAbbr];
+    // cbNumber = e.g. QNCB5 --> 5
+    const cbNumber = shortName.substring(4);
+    // concat together
+    // CBs have numbers whereas BPs and BBs do not
+    if (participantTypeAbbr === 'CB') {
+      return borough.concat(' ', participantType, ' ', cbNumber);
+    }
+    return borough.concat(' ', participantType);
+  }
 }

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -14,6 +14,8 @@ export default class UserModel extends Model {
 
   @hasMany('assignment', { async: false }) assignments;
 
+  @hasMany('user', { async: false }) dispositions;
+
   // ONE User has Many User Project Participant Types
   @hasMany('userProjectParticipantType', { async: false }) userProjectParticipantTypes;
 

--- a/app/routes/my-projects/archive.js
+++ b/app/routes/my-projects/archive.js
@@ -12,7 +12,7 @@ export default class MyProjectsArchiveRoute extends Route {
     // Use this endpoint for now. This will need to be updated when the backend is finalized.
     return this.store.query('assignment', {
       tab: 'archive',
-      include: 'project.milestones,project.dispositions,project.actions,dispositions,dispositions.action',
+      include: 'project.milestones,project.dispositions,project.actions,project.dispositions.action,dispositions,dispositions.action',
     }, {
       reload: true,
     });

--- a/app/routes/my-projects/reviewed.js
+++ b/app/routes/my-projects/reviewed.js
@@ -11,7 +11,7 @@ export default class MyProjectsReviewedRoute extends Route {
   async model() {
     return this.store.query('assignment', {
       tab: 'reviewed',
-      include: 'project.milestones,project.dispositions,project.actions,dispositions,dispositions.action',
+      include: 'project.milestones,project.dispositions,project.actions,project.dispositions.action,dispositions,dispositions.action',
     }, {
       reload: true,
     });

--- a/app/routes/my-projects/upcoming.js
+++ b/app/routes/my-projects/upcoming.js
@@ -11,7 +11,7 @@ export default class MyProjectsUpcomingRoute extends Route {
   async model() {
     return this.store.query('assignment', {
       tab: 'upcoming',
-      include: 'project.milestones,project.dispositions,project.actions,dispositions,dispositions.action',
+      include: 'project.milestones,project.dispositions,project.actions,project.dispositions.action,dispositions,dispositions.action',
     }, {
       reload: true,
     });

--- a/app/templates/components/archive-project-card.hbs
+++ b/app/templates/components/archive-project-card.hbs
@@ -31,11 +31,9 @@
             @project={{this.assignment.project}}
             @milestone={{milestone}}
           />
-          {{#if (or (not milestone.dcpActualenddate) (is-before milestone.dcpActualenddate))}}
-            <HearingsListForMilestonesList
-              @milestone={{milestone}}
-            />
-          {{/if}}
+          <HearingsListForMilestonesList
+            @milestone={{milestone}}
+          />
         {{/each}}
       </ul>
     </div>

--- a/app/templates/components/hearings-list-for-milestones-list.hbs
+++ b/app/templates/components/hearings-list-for-milestones-list.hbs
@@ -1,6 +1,9 @@
-{{#if currentMilestoneDispositions}}
-  {{#if hearingsSubmitted}}
-    {{#deduped-hearings-list dispositions=currentMilestoneDispositions as |dedupedHearings|}}
+{{#each milestoneParticipants as |milestoneParticipant|}}
+  {{#if milestoneParticipant.hearingsSubmitted}}
+    <strong data-test-hearing-title="{{milestoneParticipant.landUseParticipantFullName}}">
+      {{milestoneParticipant.landUseParticipantFullName}} Public Hearing
+    </strong>
+    {{#deduped-hearings-list dispositions=milestoneParticipant.userDispositions as |dedupedHearings|}}
       {{#each dedupedHearings as |hearing|}}
           <ul class="sub-milestones no-bullet">
             <li class="grid-x">
@@ -12,17 +15,16 @@
                 {{/if}}
               </div>
               <div class="cell auto">
-                <strong data-test-hearing-title>{{currentMilestoneUserType}} Public Hearing</strong>
                 <span data-test-hearing-location="{{hearing.disposition.id}}">{{hearing.disposition.dcpPublichearinglocation}}</span>
                 <small class="display-inline-block" data-test-hearing-date="{{hearing.disposition.id}}">
                   <DateDisplay
-                    @date={{hearing.disposition.dcpDateofpublichearing}} 
+                    @date={{hearing.disposition.dcpDateofpublichearing}}
                     @outputFormat="LLL"
                   />
                 </small>
                 <span class="display-inline-block text-tiny">
                   {{#each hearing.hearingActions as |action index|}}
-                    <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-hearing-actions-list="{{index}}">
+                    <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-hearing-actions-list="{{hearing.disposition.id}}{{index}}">
                       {{action.dcpName}}
                       <small>{{action.dcpUlurpnumber}}</small>
                     </span>
@@ -34,4 +36,10 @@
         {{/each}}
       {{/deduped-hearings-list}}
     {{/if}}
-  {{/if}}
+    {{#if milestoneParticipant.hearingsWaived}}
+      {{fa-icon 'calendar-times' fixedWidth=true class='light-gray'}}
+      <strong data-test-hearing-title="{{milestoneParticipant.landUseParticipantFullName}}">
+        No {{milestoneParticipant.landUseParticipantFullName}} Hearings Posted
+      </strong>
+    {{/if}}
+  {{/each}}

--- a/app/templates/components/reviewed-project-card.hbs
+++ b/app/templates/components/reviewed-project-card.hbs
@@ -33,11 +33,9 @@
               @project={{this.assignment.project}}
               @milestone={{milestone}}
             />
-            {{#if (or (not milestone.dcpActualenddate) (is-before milestone.dcpActualenddate))}}
-              <HearingsListForMilestonesList
-                @milestone={{milestone}}
-              />
-            {{/if}}
+            <HearingsListForMilestonesList
+              @milestone={{milestone}}
+            />
           {{/each}}
         </ul>
       </div>

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -98,10 +98,10 @@
                     @date={{milestone.dcpActualenddate}}
                   />
                 </small>
-              {{#if (or (not milestone.dcpActualenddate) (is-before milestone.dcpActualenddate))}}
-                  {{hearings-list-for-milestones-list milestone=milestone}}
               {{/if}}
-              {{/if}}
+              <HearingsListForMilestonesList
+                @milestone={{milestone}}
+              />
             </div>
           </li>
         {{/each}}

--- a/mirage/factories/disposition.js
+++ b/mirage/factories/disposition.js
@@ -32,6 +32,10 @@ export default Factory.extend({
     return faker.list.random('Active', 'Inactive')(i);
   },
 
+  dcpRecommendationsubmittedbyname(i) {
+    return faker.list.random('QNBB', 'MNBP', 'QNCB5')(i);
+  },
+
   statuscode(i) {
     return faker.list.random('Draft', 'Saved', 'Submitted', 'Deactivated', 'Not Submitted')(i);
   },

--- a/tests/acceptance/hearings-list-for-milestones-list-shows-up-correctly-test.js
+++ b/tests/acceptance/hearings-list-for-milestones-list-shows-up-correctly-test.js
@@ -27,38 +27,76 @@ module('Acceptance | hearings list for milestones list shows up correctly', func
     await authenticateSession();
   });
 
-  test('hearings-list-for-milestones-list shows up on upcoming tab', async function(assert) {
+  test('hearings-list-for-milestones-list shows up on upcoming tab in complicated scenario', async function(assert) {
     // ########## UPCOMING #################################################################
     this.server.create('assignment', {
       id: 5,
       tab: 'upcoming',
-      dispositions: [
-        server.create('disposition', {
-          id: 17,
-          dcpPublichearinglocation: 'Purple',
-          dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
-          action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
-        }),
-        server.create('disposition', {
-          id: 18,
-          dcpPublichearinglocation: 'Purple',
-          dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
-          action: server.create('action', { dcpName: 'Zoning Text Amendment', dcpUlurpnumber: 'N860877TCM' }),
-        }),
-      ],
+      user: server.create('user', {
+        name: 'Peter Pan',
+        landUseParticipant: 'QNBB',
+      }),
       project: this.server.create('project', {
         dispositions: [
           server.create('disposition', {
             id: 17,
-            dcpPublichearinglocation: 'Purple',
+            dcpPublichearinglocation: '121 Bananas Avenue, Queens',
             dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
-            action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+            dcpRecommendationsubmittedbyname: 'QNBB',
+            action: server.create('action', { id: 1, dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
           }),
           server.create('disposition', {
             id: 18,
-            dcpPublichearinglocation: 'Purple',
+            dcpPublichearinglocation: '345 Purple Street, Manhattan',
             dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
-            action: server.create('action', { dcpName: 'Zoning Text Amendment', dcpUlurpnumber: 'N860877TCM' }),
+            dcpRecommendationsubmittedbyname: 'MNBB',
+            action: server.create('action', { id: 1, dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+          }),
+          server.create('disposition', {
+            id: 19,
+            dcpPublichearinglocation: '567 Grapefruit Boulevard, Manhattan',
+            dcpDateofpublichearing: new Date('2021-04-14T20:30:00'),
+            dcpRecommendationsubmittedbyname: 'MNBB',
+            action: server.create('action', { id: 3, dcpName: 'Change to City Map', dcpUlurpnumber: 'N19983dLUP' }),
+          }),
+          server.create('disposition', {
+            id: 20,
+            dcpPublichearinglocation: '908 Cherries Road, Queens',
+            dcpDateofpublichearing: new Date('2019-04-14T20:30:00'),
+            dcpRecommendationsubmittedbyname: 'QNCB4',
+            action: server.create('action', { id: 1, dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+          }),
+          // #### duplicate of 22 ############################################################
+          server.create('disposition', {
+            id: 21,
+            dcpPublichearinglocation: '239 Spaghetti Street, Queens',
+            dcpDateofpublichearing: new Date('2021-06-21T14:30:00'),
+            dcpRecommendationsubmittedbyname: 'QNCB5',
+            action: server.create('action', { id: 3, dcpName: 'Change to City Map', dcpUlurpnumber: 'N19983dLUP' }),
+          }),
+          // #### duplicate of 21 ############################################################
+          server.create('disposition', {
+            id: 22,
+            dcpPublichearinglocation: '239 Spaghetti Street, Queens',
+            dcpDateofpublichearing: new Date('2021-06-21T14:30:00'),
+            dcpRecommendationsubmittedbyname: 'QNCB5',
+            action: server.create('action', { id: 4, dcpName: 'Business Improvement District', dcpUlurpnumber: 'C780076TLK' }),
+          }),
+          // #### shouldn't show up ############################################################
+          server.create('disposition', {
+            id: 23,
+            dcpPublichearinglocation: '',
+            dcpDateofpublichearing: null,
+            dcpRecommendationsubmittedbyname: 'BXCB2',
+            action: server.create('action', { id: 4, dcpName: 'Business Improvement District', dcpUlurpnumber: 'C780076TLK' }),
+          }),
+          // #### hearings waived ############################################################
+          server.create('disposition', {
+            id: 24,
+            dcpPublichearinglocation: 'waived',
+            dcpDateofpublichearing: null,
+            dcpRecommendationsubmittedbyname: 'BKCB3',
+            action: server.create('action', { id: 4, dcpName: 'Business Improvement District', dcpUlurpnumber: 'C780076TLK' }),
           }),
         ],
         milestones: [
@@ -86,7 +124,7 @@ module('Acceptance | hearings list for milestones list shows up correctly', func
             dcpMilestoneoutcome: null,
             displayDate2: null,
             displayDate: '2019-10-18T19:31:57.916Z',
-            statuscode: 'Not Started',
+            statuscode: 'Completed',
             dcpActualenddate: null,
             dcpActualstartdate: '2019-10-18T19:31:57.916Z',
             dcpPlannedcompletiondate: null,
@@ -101,12 +139,12 @@ module('Acceptance | hearings list for milestones list shows up correctly', func
             milestoneLinks: [],
             dcpMilestoneoutcome: null,
             displayDate2: null,
-            displayDate: '2019-11-17T20:31:57.956Z',
-            statuscode: 'Not Started',
+            displayDate: '2019-10-05T20:31:57.956Z',
+            statuscode: 'Completed',
             dcpActualenddate: null,
             dcpActualstartdate: null,
             dcpPlannedcompletiondate: null,
-            dcpPlannedstartdate: '2019-11-17T20:31:57.956Z',
+            dcpPlannedstartdate: '2019-10-05T20:31:57.956Z',
             id: '12',
           }),
           server.create('milestone', {
@@ -131,11 +169,54 @@ module('Acceptance | hearings list for milestones list shows up correctly', func
 
     await visit('/my-projects/upcoming');
 
-    assert.ok(this.element.querySelector('[data-test-hearing-title]').textContent.includes('Borough Board Public Hearing'));
-    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="0"]').textContent.includes('Zoning Special Permit'));
-    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="1"]').textContent.includes('Zoning Text Amendment'));
-    assert.ok(this.element.querySelector('[data-test-hearing-location="17"]').textContent.includes('Purple'));
-    assert.ok(this.element.querySelector('[data-test-hearing-date="17"]').textContent.includes('October 21'));
+    // #### HEARING TITLE ############################################################
+    assert.ok(this.element.querySelector('[data-test-hearing-title="Queens Borough Board"]').textContent.includes('Queens Borough Board Public Hearing'), 'QNBB');
+    assert.ok(this.element.querySelector('[data-test-hearing-title="Manhattan Borough Board"]').textContent.includes('Manhattan Borough Board Public Hearing'), 'MNBB');
+    assert.ok(this.element.querySelector('[data-test-hearing-title="Queens Community Board 5"]').textContent.includes('Queens Community Board 5 Public Hearing'), 'QNCB5');
+    assert.ok(this.element.querySelector('[data-test-hearing-title="Queens Community Board 4"]').textContent.includes('Queens Community Board 4 Public Hearing'), 'QNCB4');
+    assert.ok(this.element.querySelector('[data-test-hearing-title="Brooklyn Community Board 3"]').textContent.includes('No Brooklyn Community Board 3 Hearings Posted'), 'BKCB3');
+    assert.notOk(find('[data-test-hearing-title="Bronx Community Board 2"]'), 'BXCB2');
+
+    // #### HEARING LOCATION ############################################################
+    assert.ok(this.element.querySelector('[data-test-hearing-location="17"]').textContent.includes('121 Bananas Avenue, Queens'), 'location 17');
+    assert.ok(this.element.querySelector('[data-test-hearing-location="18"]').textContent.includes('345 Purple Street, Manhattan'), 'location 18');
+    assert.ok(this.element.querySelector('[data-test-hearing-location="19"]').textContent.includes('567 Grapefruit Boulevard, Manhattan'), 'location 19');
+    assert.ok(this.element.querySelector('[data-test-hearing-location="20"]').textContent.includes('908 Cherries Road, Queens'), 'location 20');
+    assert.ok(this.element.querySelector('[data-test-hearing-location="21"]').textContent.includes('239 Spaghetti Street, Queens'), 'location 21');
+    // duplicate
+    assert.notOk(find('[data-test-hearing-location="22"]'), 'location 22');
+    // not submitted yet
+    assert.notOk(find('[data-test-hearing-location="23"]'), 'location 23');
+    // waived
+    assert.notOk(find('[data-test-hearing-location="24"]'), 'location 24');
+
+    // #### HEARING DATE ############################################################
+    assert.ok(this.element.querySelector('[data-test-hearing-date="17"]').textContent.includes('October 21'), 'date 17');
+    assert.ok(this.element.querySelector('[data-test-hearing-date="18"]').textContent.includes('October 21'), 'date 18');
+    assert.ok(this.element.querySelector('[data-test-hearing-date="19"]').textContent.includes('April 14'), 'date 19');
+    assert.ok(this.element.querySelector('[data-test-hearing-date="20"]').textContent.includes('April 14'), 'date 20');
+    assert.ok(this.element.querySelector('[data-test-hearing-date="21"]').textContent.includes('June 21'), 'date 21');
+    // duplicate
+    assert.notOk(find('[data-test-hearing-date="22"]'), 'date 22');
+    // not submitted yet
+    assert.notOk(find('[data-test-hearing-date="23"]'), 'date 23');
+    // waived
+    assert.notOk(find('[data-test-hearing-date="24"]'), 'date 24');
+
+
+    // #### HEARING ACTIONS ############################################################
+    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="170"]').textContent.includes('Zoning Special Permit'), 'action 170');
+    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="180"]').textContent.includes('Zoning Special Permit'), 'action 180');
+    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="190"]').textContent.includes('Change to City Map'), 'action 190');
+    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="200"]').textContent.includes('Zoning Special Permit'), 'action 200');
+    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="210"]').textContent.includes('Change to City Map'), 'action 210');
+    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="211"]').textContent.includes('Business Improvement District'), 'action 211 duplicate');
+    // duplicate
+    assert.notOk(find('[data-test-hearing-actions-list="220"]'), 'action 220');
+    // not submitted yet
+    assert.notOk(find('[data-test-hearing-actions-list="230"]'), 'action 230');
+    // waived
+    assert.notOk(find('[data-test-hearing-actions-list="240"]'), 'action 240');
   });
 
   test('hearings-list-for-milestones-list shows up on reviewed tab', async function(assert) {
@@ -143,32 +224,20 @@ module('Acceptance | hearings list for milestones list shows up correctly', func
     this.server.create('assignment', {
       id: 5,
       tab: 'reviewed',
-      dispositions: [
-        server.create('disposition', {
-          id: 17,
-          dcpPublichearinglocation: 'Purple',
-          dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
-          action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
-        }),
-        server.create('disposition', {
-          id: 18,
-          dcpPublichearinglocation: 'Purple',
-          dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
-          action: server.create('action', { dcpName: 'Zoning Text Amendment', dcpUlurpnumber: 'N860877TCM' }),
-        }),
-      ],
       project: this.server.create('project', {
         dispositions: [
           server.create('disposition', {
             id: 17,
-            dcpPublichearinglocation: 'Purple',
+            dcpPublichearinglocation: 'Purple Street',
             dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
+            dcpRecommendationsubmittedbyname: 'QNBB',
             action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
           }),
           server.create('disposition', {
             id: 18,
-            dcpPublichearinglocation: 'Purple',
-            dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
+            dcpPublichearinglocation: 'Green Street',
+            dcpDateofpublichearing: new Date('2020-04-21T01:30:00'),
+            dcpRecommendationsubmittedbyname: 'MNBB',
             action: server.create('action', { dcpName: 'Zoning Text Amendment', dcpUlurpnumber: 'N860877TCM' }),
           }),
         ],
@@ -242,11 +311,14 @@ module('Acceptance | hearings list for milestones list shows up correctly', func
 
     await visit('/my-projects/reviewed');
 
-    assert.ok(this.element.querySelector('[data-test-hearing-title]').textContent.includes('Borough Board Public Hearing'));
-    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="0"]').textContent.includes('Zoning Special Permit'));
-    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="1"]').textContent.includes('Zoning Text Amendment'));
-    assert.ok(this.element.querySelector('[data-test-hearing-location="17"]').textContent.includes('Purple'));
+    assert.ok(this.element.querySelector('[data-test-hearing-title="Queens Borough Board"]').textContent.includes('Queens Borough Board Public Hearing'));
+    assert.ok(this.element.querySelector('[data-test-hearing-title="Manhattan Borough Board"]').textContent.includes('Manhattan Borough Board Public Hearing'));
+    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="170"]').textContent.includes('Zoning Special Permit'), 'action 170');
+    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="180"]').textContent.includes('Zoning Text Amendment'), 'action 180');
+    assert.ok(this.element.querySelector('[data-test-hearing-location="17"]').textContent.includes('Purple Street'));
     assert.ok(this.element.querySelector('[data-test-hearing-date="17"]').textContent.includes('October 21'));
+    assert.ok(this.element.querySelector('[data-test-hearing-location="18"]').textContent.includes('Green Street'));
+    assert.ok(this.element.querySelector('[data-test-hearing-date="18"]').textContent.includes('April 21'));
   });
 
   test('hearings-list-for-milestones-list shows up on archive tab', async function(assert) {
@@ -254,32 +326,20 @@ module('Acceptance | hearings list for milestones list shows up correctly', func
     this.server.create('assignment', {
       id: 5,
       tab: 'archive',
-      dispositions: [
-        server.create('disposition', {
-          id: 17,
-          dcpPublichearinglocation: 'Purple',
-          dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
-          action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
-        }),
-        server.create('disposition', {
-          id: 18,
-          dcpPublichearinglocation: 'Purple',
-          dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
-          action: server.create('action', { dcpName: 'Zoning Text Amendment', dcpUlurpnumber: 'N860877TCM' }),
-        }),
-      ],
       project: this.server.create('project', {
         dispositions: [
           server.create('disposition', {
             id: 17,
-            dcpPublichearinglocation: 'Purple',
+            dcpPublichearinglocation: 'Purple Street',
             dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
+            dcpRecommendationsubmittedbyname: 'QNBB',
             action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
           }),
           server.create('disposition', {
             id: 18,
-            dcpPublichearinglocation: 'Purple',
-            dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
+            dcpPublichearinglocation: 'Green Street',
+            dcpDateofpublichearing: new Date('2020-04-21T01:30:00'),
+            dcpRecommendationsubmittedbyname: 'MNBB',
             action: server.create('action', { dcpName: 'Zoning Text Amendment', dcpUlurpnumber: 'N860877TCM' }),
           }),
         ],
@@ -353,121 +413,13 @@ module('Acceptance | hearings list for milestones list shows up correctly', func
 
     await visit('/my-projects/archive');
 
-    assert.ok(this.element.querySelector('[data-test-hearing-title]').textContent.includes('Borough Board Public Hearing'));
-    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="0"]').textContent.includes('Zoning Special Permit'));
-    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="1"]').textContent.includes('Zoning Text Amendment'));
-    assert.ok(this.element.querySelector('[data-test-hearing-location="17"]').textContent.includes('Purple'));
+    assert.ok(this.element.querySelector('[data-test-hearing-title="Queens Borough Board"]').textContent.includes('Queens Borough Board Public Hearing'));
+    assert.ok(this.element.querySelector('[data-test-hearing-title="Manhattan Borough Board"]').textContent.includes('Manhattan Borough Board Public Hearing'));
+    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="170"]').textContent.includes('Zoning Special Permit'), 'action 170');
+    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="180"]').textContent.includes('Zoning Text Amendment'), 'action 180');
+    assert.ok(this.element.querySelector('[data-test-hearing-location="17"]').textContent.includes('Purple Street'));
     assert.ok(this.element.querySelector('[data-test-hearing-date="17"]').textContent.includes('October 21'));
-  });
-
-  test('hearings-list-for-milestones-list does not show up if dcpActualenddate is in past', async function(assert) {
-    // ########## Archive #################################################################
-    this.server.create('assignment', {
-      id: 5,
-      tab: 'reviewed',
-      dispositions: [
-        server.create('disposition', {
-          id: 17,
-          dcpPublichearinglocation: 'Purple',
-          dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
-          action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
-        }),
-        server.create('disposition', {
-          id: 18,
-          dcpPublichearinglocation: 'Purple',
-          dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
-          action: server.create('action', { dcpName: 'Zoning Text Amendment', dcpUlurpnumber: 'N860877TCM' }),
-        }),
-      ],
-      project: this.server.create('project', {
-        dispositions: [
-          server.create('disposition', {
-            id: 17,
-            dcpPublichearinglocation: 'Purple',
-            dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
-            action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
-          }),
-          server.create('disposition', {
-            id: 18,
-            dcpPublichearinglocation: 'Purple',
-            dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
-            action: server.create('action', { dcpName: 'Zoning Text Amendment', dcpUlurpnumber: 'N860877TCM' }),
-          }),
-        ],
-        milestones: [
-          server.create('milestone', {
-            displayName: 'Land Use Application Filed',
-            dcpMilestonesequence: 26,
-            milestonename: 'Land Use Application Filed',
-            dcpMilestone: '663beec4-dad0-e711-8116-1458d04e2fb8',
-            dcpMilestoneoutcome: null,
-            displayDate2: null,
-            displayDate: '2019-07-13T19:31:57.763Z',
-            statuscode: 'Completed',
-            dcpActualenddate: null,
-            dcpActualstartdate: '2019-07-13T19:31:57.763Z',
-            dcpPlannedcompletiondate: null,
-            dcpPlannedstartdate: null,
-            id: '1',
-          }),
-          server.create('milestone', {
-            displayName: 'Application Reviewed at City Planning Commission Review Session',
-            dcpMilestonesequence: 46,
-            milestonename: 'Application Reviewed at City Planning Commission Review Session',
-            dcpMilestone: '8e3beec4-dad0-e711-8116-1458d04e2fb8',
-            milestoneLinks: [],
-            dcpMilestoneoutcome: null,
-            displayDate2: null,
-            displayDate: '2019-10-18T19:31:57.916Z',
-            statuscode: 'Not Started',
-            dcpActualenddate: null,
-            dcpActualstartdate: '2019-10-18T19:31:57.916Z',
-            dcpPlannedcompletiondate: null,
-            dcpPlannedstartdate: null,
-            id: '11',
-          }),
-          server.create('milestone', {
-            displayName: 'Community Board Review',
-            dcpMilestonesequence: 48,
-            milestonename: 'Community Board Review',
-            dcpMilestone: '923beec4-dad0-e711-8116-1458d04e2fb8',
-            milestoneLinks: [],
-            dcpMilestoneoutcome: null,
-            displayDate2: null,
-            displayDate: '2019-11-17T20:31:57.956Z',
-            statuscode: 'Not Started',
-            dcpActualenddate: null,
-            dcpActualstartdate: null,
-            dcpPlannedcompletiondate: null,
-            dcpPlannedstartdate: '2019-11-17T20:31:57.956Z',
-            id: '12',
-          }),
-          server.create('milestone', {
-            displayName: 'Borough Board Review',
-            dcpMilestonesequence: 50,
-            milestonename: 'Borough Board Review',
-            dcpMilestone: '963beec4-dad0-e711-8116-1458d04e2fb8',
-            milestoneLinks: [],
-            dcpMilestoneoutcome: null,
-            displayDate2: '2019-11-06T20:31:58.519Z',
-            displayDate: '2019-10-07T19:31:58.519Z',
-            statuscode: 'Approved',
-            dcpActualenddate: '2018-11-06T20:31:58.519Z',
-            dcpActualstartdate: '2019-10-07T19:31:58.519Z',
-            dcpPlannedcompletiondate: null,
-            dcpPlannedstartdate: null,
-            id: '38',
-          }),
-        ],
-      }),
-    });
-
-    await visit('/my-projects/reviewed');
-
-    assert.notOk(find('[data-test-hearing-title]'));
-    assert.notOk(find('[data-test-hearing-actions-list="0"]'));
-    assert.notOk(find('[data-test-hearing-actions-list="1"]'));
-    assert.notOk(find('[data-test-hearing-location="17"]'));
-    assert.notOk(find('[data-test-hearing-date="17"]'));
+    assert.ok(this.element.querySelector('[data-test-hearing-location="18"]').textContent.includes('Green Street'));
+    assert.ok(this.element.querySelector('[data-test-hearing-date="18"]').textContent.includes('April 21'));
   });
 });

--- a/tests/integration/components/hearings-list-for-milestones-list-test.js
+++ b/tests/integration/components/hearings-list-for-milestones-list-test.js
@@ -1,22 +1,318 @@
-import { module, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+import { dedupeByParticipant } from 'labs-zap-search/components/hearings-list-for-milestones-list';
+import EmberObject from '@ember/object';
 
 module('Integration | Component | hearings-list-for-milestones-list', function(hooks) {
   setupRenderingTest(hooks);
 
-  skip('it renders', async function(assert) {
+  test('check that hearings list renders when user has submitted hearings on upcoming tab', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    // Template block usage:
+    const store = this.owner.lookup('service:store');
+
+    const assignment = store.createRecord('assignment', {
+      id: 5,
+      tab: 'upcoming',
+      publicReviewPlannedStartDate: new Date('2020-10-21T01:30:00'),
+      user: store.createRecord('user', {
+        name: 'Peter Pan',
+        landUseParticipant: 'QNBB',
+      }),
+      project: store.createRecord('project', {
+        dispositions: [
+          store.createRecord('disposition', {
+            id: 17,
+            dcpPublichearinglocation: '121 Bananas Avenue, Queens',
+            dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
+            dcpRecommendationsubmittedbyname: 'QNBB',
+            action: store.createRecord('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+          }),
+          store.createRecord('disposition', {
+            id: 18,
+            dcpPublichearinglocation: '345 Purple Street, Manhattan',
+            dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
+            dcpRecommendationsubmittedbyname: 'MNBB',
+            action: store.createRecord('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+          }),
+          store.createRecord('disposition', {
+            id: 19,
+            dcpPublichearinglocation: '567 Grapefruit Boulevard, Manhattan',
+            dcpDateofpublichearing: new Date('2021-04-14T20:30:00'),
+            dcpRecommendationsubmittedbyname: 'MNBB',
+            action: store.createRecord('action', { dcpName: 'Change to City Map', dcpUlurpnumber: 'N19983dLUP' }),
+          }),
+          store.createRecord('disposition', {
+            id: 20,
+            dcpPublichearinglocation: '908 Cherries Road, Queens',
+            dcpDateofpublichearing: new Date('2021-04-14T20:30:00'),
+            dcpRecommendationsubmittedbyname: 'QNCB4',
+            action: store.createRecord('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+          }),
+          store.createRecord('disposition', {
+            id: 21,
+            dcpPublichearinglocation: '239 Spaghetti Street, Queens',
+            dcpDateofpublichearing: new Date('2021-06-21T14:30:00'),
+            dcpRecommendationsubmittedbyname: 'QNCB5',
+            action: store.createRecord('action', { dcpName: 'Change to City Map', dcpUlurpnumber: 'N19983dLUP' }),
+          }),
+          store.createRecord('disposition', {
+            id: 22,
+            dcpPublichearinglocation: '239 Spaghetti Street, Queens',
+            dcpDateofpublichearing: new Date('2021-06-21T14:30:00'),
+            dcpRecommendationsubmittedbyname: 'QNCB5',
+            action: store.createRecord('action', { dcpName: 'Business Improvement District', dcpUlurpnumber: 'C780076TLK' }),
+          }),
+          store.createRecord('disposition', {
+            id: 23,
+            dcpPublichearinglocation: '',
+            dcpDateofpublichearing: null,
+            dcpRecommendationsubmittedbyname: 'BXCB2',
+            action: store.createRecord('action', { dcpName: 'Business Improvement District', dcpUlurpnumber: 'C780076TLK' }),
+          }),
+          store.createRecord('disposition', {
+            id: 24,
+            dcpPublichearinglocation: 'waived',
+            dcpDateofpublichearing: null,
+            dcpRecommendationsubmittedbyname: 'BKCB3',
+            action: store.createRecord('action', { dcpName: 'Business Improvement District', dcpUlurpnumber: 'C780076TLK' }),
+          }),
+        ],
+        milestones: [
+          store.createRecord('milestone', {
+            displayName: 'Land Use Application Filed',
+            dcpMilestonesequence: 26,
+            milestonename: 'Land Use Application Filed',
+            dcpMilestone: '663beec4-dad0-e711-8116-1458d04e2fb8',
+            dcpMilestoneoutcome: null,
+            displayDate2: null,
+            displayDate: '2019-07-13T19:31:57.763Z',
+            statuscode: 'Completed',
+            dcpActualenddate: null,
+            dcpActualstartdate: '2019-07-13T19:31:57.763Z',
+            dcpPlannedcompletiondate: null,
+            dcpPlannedstartdate: null,
+            id: '1',
+          }),
+          store.createRecord('milestone', {
+            displayName: 'Application Reviewed at City Planning Commission Review Session',
+            dcpMilestonesequence: 46,
+            milestonename: 'Application Reviewed at City Planning Commission Review Session',
+            dcpMilestone: '8e3beec4-dad0-e711-8116-1458d04e2fb8',
+            milestoneLinks: [],
+            dcpMilestoneoutcome: null,
+            displayDate2: null,
+            displayDate: '2019-10-18T19:31:57.916Z',
+            statuscode: 'Not Started',
+            dcpActualenddate: null,
+            dcpActualstartdate: '2019-10-18T19:31:57.916Z',
+            dcpPlannedcompletiondate: null,
+            dcpPlannedstartdate: null,
+            id: '11',
+          }),
+          store.createRecord('milestone', {
+            displayName: 'Community Board Review',
+            dcpMilestonesequence: 48,
+            milestonename: 'Community Board Review',
+            dcpMilestone: '923beec4-dad0-e711-8116-1458d04e2fb8',
+            milestoneLinks: [],
+            dcpMilestoneoutcome: null,
+            displayDate2: null,
+            displayDate: '2019-10-05T20:31:57.956Z',
+            statuscode: 'Not Started',
+            dcpActualenddate: null,
+            dcpActualstartdate: null,
+            dcpPlannedcompletiondate: null,
+            dcpPlannedstartdate: '2019-10-05T20:31:57.956Z',
+            id: '12',
+          }),
+          store.createRecord('milestone', {
+            displayName: 'Borough Board Review',
+            dcpMilestonesequence: 50,
+            milestonename: 'Borough Board Review',
+            dcpMilestone: '963beec4-dad0-e711-8116-1458d04e2fb8',
+            milestoneLinks: [],
+            dcpMilestoneoutcome: null,
+            displayDate2: '2019-11-06T20:31:58.519Z',
+            displayDate: '2019-10-07T19:31:58.519Z',
+            statuscode: 'In Progress',
+            dcpActualenddate: '2019-11-06T20:31:58.519Z',
+            dcpActualstartdate: '2019-10-07T19:31:58.519Z',
+            dcpPlannedcompletiondate: null,
+            dcpPlannedstartdate: null,
+            id: '38',
+          }),
+        ],
+      }),
+    });
+
+
+    this.set('assignment', assignment);
+
     await render(hbs`
-      <HearingsListForMilestonesList>
-        template block text
-      </HearingsListForMilestonesList>
+      {{#upcoming-project-card assignment=assignment}}
+      {{/upcoming-project-card}}
     `);
 
-    assert.equal(this.element.textContent.trim(), 'template block text');
+    const list = this.element.textContent.trim();
+
+    // hearings submitted
+    assert.ok(list.includes('Queens Borough Board Public Hearing'));
+    assert.ok(list.includes('Manhattan Borough Board Public Hearing'));
+    assert.ok(list.includes('Queens Community Board 4 Public Hearing'));
+    assert.ok(list.includes('Queens Community Board 5 Public Hearing'));
+    // hearings waived
+    assert.ok(list.includes('No Brooklyn Community Board 3 Hearings Posted'));
+    // hearings not submitted yet
+    assert.notOk(list.includes('Bronx Community Board 2 Public Hearing'));
+  });
+
+  test('dedupeByParticipant function works', async function(assert) {
+    // dates for dcpDateofpublichearing
+    const date_A = new Date('2020-01-21T18:30:00');
+    const date_B = new Date('2020-02-25T17:45:00');
+    const date_C = new Date('2020-03-14T09:25:00');
+    const date_D = new Date('2021-04-01T14:15:00');
+    const date_E = new Date('2021-05-07T15:05:00');
+
+    const ourDisps = EmberObject.extend({});
+
+    const milestoneParticipant1 = {
+      landUseParticipantFullName: 'Queens Community Board 1',
+      disposition: ourDisps.create({
+        id: 1,
+        dcpPublichearinglocation: '121 Bananas Ave, Queens, NY',
+        dcpDateofpublichearing: date_A,
+        action: {
+          dcpName: 'Zoning Special Permit',
+          dcpUlurpnumber: 'C780076TLK',
+        },
+      }),
+      userDispositions: [
+        ourDisps.create({
+          id: 1,
+          dcpPublichearinglocation: '121 Bananas Ave, Queens, NY',
+          dcpDateofpublichearing: date_A,
+          action: {
+            dcpName: 'Zoning Special Permit',
+            dcpUlurpnumber: 'C780076TLK',
+          },
+        }),
+      ],
+    };
+
+    const milestoneParticipant2 = {
+      landUseParticipantFullName: 'Queens Community Board 1',
+      disposition: ourDisps.create({
+        id: 2,
+        dcpPublichearinglocation: '121 Bananas Ave, Queens, NY',
+        dcpDateofpublichearing: date_B,
+        action: {
+          dcpName: 'Zoning Text Amendment',
+          dcpUlurpnumber: 'N860877TCM',
+        },
+      }),
+      userDispositions: [
+        ourDisps.create({
+          id: 2,
+          dcpPublichearinglocation: '121 Bananas Ave, Queens, NY',
+          dcpDateofpublichearing: date_B,
+          action: {
+            dcpName: 'Zoning Text Amendment',
+            dcpUlurpnumber: 'N860877TCM',
+          },
+        }),
+      ],
+    };
+
+    const milestoneParticipant3 = {
+      landUseParticipantFullName: 'Queens Community Board 2',
+      disposition: ourDisps.create({
+        id: 3,
+        dcpPublichearinglocation: '186 Alligators Ave, Staten Island, NY',
+        dcpDateofpublichearing: date_C,
+        action: {
+          dcpName: 'Zoning Special Permit',
+          dcpUlurpnumber: 'C780076TLK',
+        },
+      }),
+      userDispositions: [
+        ourDisps.create({
+          id: 3,
+          dcpPublichearinglocation: '186 Alligators Ave, Staten Island, NY',
+          dcpDateofpublichearing: date_C,
+          action: {
+            dcpName: 'Zoning Special Permit',
+            dcpUlurpnumber: 'C780076TLK',
+          },
+        }),
+      ],
+    };
+
+    const milestoneParticipant4 = {
+      landUseParticipantFullName: 'Queens Community Board 2',
+      disposition: ourDisps.create({
+        id: 4,
+        dcpPublichearinglocation: '456 Crocodiles Ave, Bronx, NY',
+        dcpDateofpublichearing: date_D,
+        action: {
+          dcpName: 'Zoning Text Amendment',
+          dcpUlurpnumber: 'N860877TCM',
+        },
+      }),
+      userDispositions: [
+        ourDisps.create({
+          id: 4,
+          dcpPublichearinglocation: '456 Crocodiles Ave, Bronx, NY',
+          dcpDateofpublichearing: date_D,
+          action: {
+            dcpName: 'Zoning Text Amendment',
+            dcpUlurpnumber: 'N860877TCM',
+          },
+        }),
+      ],
+    };
+
+    const milestoneParticipant5 = {
+      landUseParticipantFullName: 'Queens Community Board 3',
+      disposition: ourDisps.create({
+        id: 5,
+        dcpPublichearinglocation: '456 Crocodiles Ave, Bronx, NY',
+        dcpDateofpublichearing: date_E,
+        action: {
+          dcpName: 'Zoning Special Permit',
+          dcpUlurpnumber: 'C780076TLK',
+        },
+      }),
+      userDispositions: [
+        ourDisps.create({
+          id: 5,
+          dcpPublichearinglocation: '456 Crocodiles Ave, Bronx, NY',
+          dcpDateofpublichearing: date_E,
+          action: {
+            dcpName: 'Zoning Special Permit',
+            dcpUlurpnumber: 'C780076TLK',
+          },
+        }),
+      ],
+    };
+
+    const communityBoardMilestoneParticipants = [milestoneParticipant1, milestoneParticipant2, milestoneParticipant3, milestoneParticipant4, milestoneParticipant5];
+
+    // run the dedupeByParticipant function, which...
+    // (1) deduplicates array based on objects having the same `landUseParticipantFullName`
+    // and (2) concatenates disposition objects in userDispositions property
+    const deduped = dedupeByParticipant(communityBoardMilestoneParticipants);
+
+    assert.equal(deduped[0].landUseParticipantFullName, 'Queens Community Board 1');
+    assert.equal(deduped[1].landUseParticipantFullName, 'Queens Community Board 2');
+    assert.equal(deduped[2].landUseParticipantFullName, 'Queens Community Board 3');
+
+    assert.equal(deduped[0].userDispositions.map(d => d.id).join(','), '1,2');
+    assert.equal(deduped[1].userDispositions.map(d => d.id).join(','), '3,4');
+    assert.equal(deduped[2].userDispositions.map(d => d.id).join(','), '5');
   });
 });


### PR DESCRIPTION
### Changes:
- refactor `deduped-hearings-list` implementation further
- update `hearings-list-for-milestones-list` component to display hearings by participant

### Tests:
- Acceptance test that checks for text displays within hearings list in milestones list in `upcoming`, `reviewed`, and `archive` tab
- Integration test for `hearings-list-for-milestones-list` component that tests exported `reduce` function and rendering of component on `upcoming-project-card.hbs`

Addresses #847 