### PR TITLE
new mirage scenarios for cb and bp users

### DIFF
--- a/app/components/sign-in.js
+++ b/app/components/sign-in.js
@@ -25,6 +25,11 @@ export default class SignInComponent extends Component {
 
   @action
   toggleAuthModal() {
-    this.set('showAuthModal', !this.get('showAuthModal'));
+    if (ENV.environment === 'development') {
+      window.location.hash = 'access_token=asdf';
+      this.router.transitionTo('/login');
+    } else {
+      this.set('showAuthModal', !this.get('showAuthModal'));
+    }
   }
 }

--- a/app/models/assignment.js
+++ b/app/models/assignment.js
@@ -45,12 +45,10 @@ export default class AssignmentModel extends Model {
   @computed('dispositions.@each.dcpPublichearinglocation')
   get hearingsWaived() {
     const dispositions = this.get('dispositions');
-
     // array of hearing locations
     const dispositionHearingLocations = dispositions.map(disp => disp.dcpPublichearinglocation);
     // each location field equal to 'waived'
-
-    return dispositionHearingLocations.every(location => location === 'waived');
+    return dispositionHearingLocations.every(location => location === 'waived') && dispositionHearingLocations.length > 0;
   }
 
   @computed('hearingsSubmitted', 'hearingsWaived')

--- a/app/templates/components/archive-project-card.hbs
+++ b/app/templates/components/archive-project-card.hbs
@@ -15,7 +15,11 @@
       <div class="text-center medium-margin-right medium-margin-left">
         <p class="lead small-margin-bottom">
           <strong>
-            {{this.assignment.project.dcpPublicstatusSimp}}
+            {{#if (eq this.assignment.project.dcpPublicstatus 'Withdrawn/Terminated/Disapproved')}}
+              Withdrawn, Terminated, or Disapproved
+            {{else}}
+              {{this.assignment.project.dcpPublicstatus}}
+            {{/if}}
             <DateDisplay
               @date={{this.assignment.project.dcpProjectcompleted}}
               @outputFormat="M/D/YYYY"

--- a/app/templates/components/archive-project-milestone-list-item.hbs
+++ b/app/templates/components/archive-project-milestone-list-item.hbs
@@ -53,11 +53,13 @@
       </small>
     {{else}}
       <br>
-      <small class="display-block">
-        <DateDisplay
-          @date={{this.milestone.dcpActualenddate}}
-        />
-      </small>
+      {{#if this.milestone.dcpActualenddate}}
+        <small class="display-block">
+          <DateDisplay
+            @date={{this.milestone.dcpActualenddate}}
+          />
+        </small>
+      {{/if}}
     {{/if}}
   </div>
 </li>

--- a/app/templates/components/reviewed-project-milestone-list-item.hbs
+++ b/app/templates/components/reviewed-project-milestone-list-item.hbs
@@ -20,6 +20,7 @@
         {{this.milestone.displayName}}
       </strong>
       {{#if (eq this.milestone.dcpMilestone this.milestoneConstants.COMMUNITY_BOARD_REFERRAL)}}
+
         {{#each this.communityBoardDispositions as |disposition|}}
           <RecommendationResultIcon
             @recommendation={{disposition.dcpCommunityboardrecommendation}}

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -6,7 +6,7 @@
     <div class="cell large-4 xlarge-5">
       <h3 class="tiny-margin-bottom">
         {{#link-to 'show-project' this.assignment.project.id}}<span data-test-project-profile-button="{{this.assignment.project.id}}">{{this.assignment.project.dcpProjectname}}</span>{{/link-to}}
-        <small class="dark-gray">{{this.assignment.project.dcpUlurpNonulurp}}</small>
+        <small class="dark-gray display-inline-block">{{this.assignment.project.dcpUlurpNonulurp}}</small>
       </h3>
       <h5 class="applicant">{{this.assignment.project.applicants}}</h5>
       <p>{{this.assignment.project.dcpProjectbrief}}</p>
@@ -36,7 +36,7 @@
               data-test-fuzzy-time-remaining
             >
               {{#if (not (eq isMoreThanThirtyDaysBeforePublicReview null))}}
-                {{if isMoreThanThirtyDaysBeforePublicReview 'over 30 days' 'under 30 days'}}
+                {{if isMoreThanThirtyDaysBeforePublicReview 'in more than 30 days' 'in fewer than 30 days'}}
               {{/if}}
             </strong>
           </p>

--- a/mirage/factories/disposition.js
+++ b/mirage/factories/disposition.js
@@ -103,9 +103,9 @@ export default Factory.extend({
     dcpCommunityboardrecommendation: null,
   }),
 
-  withActions: trait({
+  withAction: trait({
     afterCreate(disposition, server) {
-      server.createList('action', 7, { dispositions: [disposition] });
+      disposition.update({ action: server.create('action') });
     },
   }),
 });

--- a/mirage/scenarios/borough-president.js
+++ b/mirage/scenarios/borough-president.js
@@ -1,8 +1,45 @@
 import moment from 'moment';
 
 export default function(server) {
+  // Project attributes for Upcoming Project 1 which has both BP and BB assignments
+  const projectForUpcoming1 = server.create('project', {
+    dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+    dcpPublicstatusSimp: 'Filed',
+    dispositions: [
+      server.create('disposition', 'withAction', {
+        dcpRecommendationsubmittedbyname: 'QNBP',
+        dcpBoroughpresidentrecommendation: null,
+        dcpDatereceived: null,
+      }),
+    ],
+    milestones: [
+      server.create('milestone', 'prepareFiledLandUseApplication', {
+        statuscode: 'Completed',
+        dcpPlannedstartdate: moment().subtract(60, 'days'),
+        displayDate: moment().subtract(60, 'days'),
+        displayDate2: moment().subtract(60, 'days'),
+        dcpActualenddate: moment().subtract(60, 'days'),
+        dcpMilestoneoutcome: null,
+      }),
+      server.create('milestone', 'certifiedReferred', {
+        statuscode: 'Not Started',
+      }),
+      server.create('milestone', 'communityBoardReview', {
+        statuscode: 'Not Started',
+        dcpPlannedstartdate: moment().add(42, 'days'),
+        displayDate: moment().add(42, 'days'),
+      }),
+      server.create('milestone', 'boroughPresidentReview', {
+        statuscode: 'Not Started',
+      }),
+      server.create('milestone', 'boroughBoardReview', {
+        statuscode: 'Not Started',
+      }),
+    ],
+  });
+
   // Array of dispositions for To Review Project 1
-  const dispositionsArray = [
+  const dispositionsArrayForToReview = [
     server.create('disposition', 'withAction', {
       dcpRecommendationsubmittedbyname: 'QNCB4',
       dcpCommunityboardrecommendation: null,
@@ -30,7 +67,7 @@ export default function(server) {
   ];
 
   // Array of dispositions for To Review Project 2 BP role
-  const dispositionsArray2 = [
+  const dispositionsArrayForToReview2 = [
     server.create('disposition', 'withAction', {
       dcpRecommendationsubmittedbyname: 'QNCB4',
       dcpCommunityboardrecommendation: null,
@@ -58,7 +95,7 @@ export default function(server) {
   ];
 
   // Array of dispositions for To Review Project 2 BB role
-  const dispositionsArray3 = [
+  const dispositionsArrayForToReview3 = [
     server.create('disposition', 'withAction', {
       dcpRecommendationsubmittedbyname: 'QNCB4',
       dcpCommunityboardrecommendation: null,
@@ -91,15 +128,30 @@ export default function(server) {
       // UPCOMING
       //----------------------------------------
 
-      // Upcoming Project 1: pre-cert with BP & BB roles >30
+      // Upcoming Project 1A: BP role for pre-cert with BP & BB roles >30
       server.create('assignment', {
         tab: 'upcoming',
         dcpLupteammemberrole: 'BP',
-        dcpPublicstatusSimp: 'Filed',
         publicReviewPlannedStartDate: moment().add(42, 'days'),
+        project: projectForUpcoming1,
+      }),
+
+      // Upcoming Project 1B: BP role for pre-cert with BP & BB roles >30
+      server.create('assignment', {
+        tab: 'upcoming',
+        dcpLupteammemberrole: 'BB',
+        publicReviewPlannedStartDate: moment().add(42, 'days'),
+        project: projectForUpcoming1,
+      }),
+
+      // Upcoming Project 2: pre-cert with BP role <30
+      server.create('assignment', {
+        tab: 'upcoming',
+        dcpLupteammemberrole: 'BP',
+        publicReviewPlannedStartDate: moment().add(12, 'days'),
         project: server.create('project', {
           dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
-          dcpPublicstatus: 'Filed',
+          dcpPublicstatusSimp: 'Filed',
           dispositions: [
             server.create('disposition', 'withAction', {
               dcpRecommendationsubmittedbyname: 'QNBP',
@@ -110,10 +162,10 @@ export default function(server) {
           milestones: [
             server.create('milestone', 'prepareFiledLandUseApplication', {
               statuscode: 'Completed',
-              dcpPlannedstartdate: moment().subtract(60, 'days'),
-              displayDate: moment().subtract(60, 'days'),
-              displayDate2: moment().subtract(60, 'days'),
-              dcpActualenddate: moment().subtract(60, 'days'),
+              dcpPlannedstartdate: moment().subtract(80, 'days'),
+              displayDate: moment().subtract(80, 'days'),
+              displayDate2: moment().subtract(80, 'days'),
+              dcpActualenddate: moment().subtract(80, 'days'),
               dcpMilestoneoutcome: null,
             }),
             server.create('milestone', 'certifiedReferred', {
@@ -121,8 +173,7 @@ export default function(server) {
             }),
             server.create('milestone', 'communityBoardReview', {
               statuscode: 'Not Started',
-              dcpPlannedstartdate: moment().add(42, 'days'),
-              displayDate: moment().add(42, 'days'),
+              dcpPlannedstartdate: moment().add(10, 'days'),
             }),
             server.create('milestone', 'boroughPresidentReview', {
               statuscode: 'Not Started',
@@ -130,15 +181,15 @@ export default function(server) {
           ],
         }),
       }),
-      // Upcoming Project 2: pre-cert with BP & BB roles <30
+
+      // Upcoming Project 3: post-cert with BP role
       server.create('assignment', {
         tab: 'upcoming',
         dcpLupteammemberrole: 'BP',
-        dcpPublicstatusSimp: 'In Public Review',
         publicReviewPlannedStartDate: moment().add(12, 'days'),
         project: server.create('project', {
           dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
-          dcpPublicstatus: 'Filed',
+          dcpPublicstatusSimp: 'In Public Review',
           dispositions: [
             server.create('disposition', 'withAction', {
               dcpRecommendationsubmittedbyname: 'QNBP',
@@ -157,17 +208,16 @@ export default function(server) {
             }),
             server.create('milestone', 'certifiedReferred', {
               statuscode: 'Completed',
-              dcpActualenddate: moment().subtract(75, 'days'),
+              dcpActualenddate: moment().subtract(55, 'days'),
             }),
             server.create('milestone', 'communityBoardReview', {
               statuscode: 'In Progress',
-              dcpActualenddate: moment().subtract(75, 'days'),
-              dcpPlannedcompletiondate: moment().add(42, 'days'),
-              displayDate: moment().add(42, 'days'),
+              dcpPlannedcompletiondate: moment().add(38, 'days'),
+              displayDate: moment().add(38, 'days'),
             }),
             server.create('milestone', 'boroughPresidentReview', {
               statuscode: 'Not Started',
-              dcpPlannedstartdate: moment().add(42, 'days'),
+              dcpPlannedstartdate: moment().add(38, 'days'),
             }),
           ],
         }),
@@ -180,11 +230,11 @@ export default function(server) {
       server.create('assignment', {
         tab: 'to-review',
         dcpLupteammemberrole: 'BP',
-        dispositions: dispositionsArray,
+        dispositions: dispositionsArrayForToReview,
         project: server.create('project', {
           dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
           dcpPublicstatusSimp: 'In Public Review',
-          dispositions: dispositionsArray,
+          dispositions: dispositionsArrayForToReview,
           milestones: [
             server.create('milestone', 'boroughPresidentReview', {
               statuscode: 'In Progress',
@@ -201,11 +251,11 @@ export default function(server) {
       server.create('assignment', {
         tab: 'to-review',
         dcpLupteammemberrole: 'BP',
-        dispositions: dispositionsArray2,
+        dispositions: dispositionsArrayForToReview2,
         project: server.create('project', {
           dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
           dcpPublicstatusSimp: 'In Public Review',
-          dispositions: dispositionsArray2,
+          dispositions: dispositionsArrayForToReview2,
           milestones: [
             server.create('milestone', 'boroughPresidentReview', {
               statuscode: 'In Progress',
@@ -222,13 +272,21 @@ export default function(server) {
       server.create('assignment', {
         tab: 'to-review',
         dcpLupteammemberrole: 'BB',
-        dispositions: dispositionsArray3,
+        dispositions: dispositionsArrayForToReview3,
         project: server.create('project', {
           dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
           dcpPublicstatusSimp: 'In Public Review',
-          dispositions: dispositionsArray3,
+          dispositions: dispositionsArrayForToReview3,
           milestones: [
             server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'In Progress',
+              dcpActualstartdate: moment().subtract(2, 'days'),
+              displayDate: moment().subtract(2, 'days'),
+              displayDate2: null,
+              dcpPlannedcompletiondate: moment().add(28, 'days'),
+              dcpMilestoneoutcome: null,
+            }),
+            server.create('milestone', 'boroughBoardReview', {
               statuscode: 'In Progress',
               dcpActualstartdate: moment().subtract(2, 'days'),
               displayDate: moment().subtract(2, 'days'),

--- a/mirage/scenarios/borough-president.js
+++ b/mirage/scenarios/borough-president.js
@@ -1,0 +1,777 @@
+import moment from 'moment';
+
+export default function(server) {
+  // Array of dispositions for To Review Project 1
+  const dispositionsArray = [
+    server.create('disposition', 'withAction', {
+      dcpRecommendationsubmittedbyname: 'QNCB4',
+      dcpCommunityboardrecommendation: null,
+      dcpIspublichearingrequired: null,
+      dcpDateofpublichearing: null,
+      dcpDatereceived: null,
+      dcpPublichearinglocation: null,
+    }),
+    server.create('disposition', 'withAction', {
+      dcpRecommendationsubmittedbyname: 'QNCB4',
+      dcpCommunityboardrecommendation: null,
+      dcpIspublichearingrequired: null,
+      dcpDateofpublichearing: null,
+      dcpDatereceived: null,
+      dcpPublichearinglocation: null,
+    }),
+    server.create('disposition', 'withAction', {
+      dcpRecommendationsubmittedbyname: 'QNCB4',
+      dcpCommunityboardrecommendation: null,
+      dcpIspublichearingrequired: null,
+      dcpDateofpublichearing: null,
+      dcpDatereceived: null,
+      dcpPublichearinglocation: null,
+    }),
+  ];
+
+  // Array of dispositions for To Review Project 2 BP role
+  const dispositionsArray2 = [
+    server.create('disposition', 'withAction', {
+      dcpRecommendationsubmittedbyname: 'QNCB4',
+      dcpCommunityboardrecommendation: null,
+      dcpIspublichearingrequired: null,
+      dcpDateofpublichearing: null,
+      dcpDatereceived: null,
+      dcpPublichearinglocation: null,
+    }),
+    server.create('disposition', 'withAction', {
+      dcpRecommendationsubmittedbyname: 'QNCB4',
+      dcpCommunityboardrecommendation: null,
+      dcpIspublichearingrequired: null,
+      dcpDateofpublichearing: null,
+      dcpDatereceived: null,
+      dcpPublichearinglocation: null,
+    }),
+    server.create('disposition', 'withAction', {
+      dcpRecommendationsubmittedbyname: 'QNCB4',
+      dcpCommunityboardrecommendation: null,
+      dcpIspublichearingrequired: null,
+      dcpDateofpublichearing: null,
+      dcpDatereceived: null,
+      dcpPublichearinglocation: null,
+    }),
+  ];
+
+  // Array of dispositions for To Review Project 2 BB role
+  const dispositionsArray3 = [
+    server.create('disposition', 'withAction', {
+      dcpRecommendationsubmittedbyname: 'QNCB4',
+      dcpCommunityboardrecommendation: null,
+      dcpIspublichearingrequired: null,
+      dcpDateofpublichearing: null,
+      dcpDatereceived: null,
+      dcpPublichearinglocation: null,
+    }),
+    server.create('disposition', 'withAction', {
+      dcpRecommendationsubmittedbyname: 'QNCB4',
+      dcpCommunityboardrecommendation: null,
+      dcpIspublichearingrequired: null,
+      dcpDateofpublichearing: null,
+      dcpDatereceived: null,
+      dcpPublichearinglocation: null,
+    }),
+    server.create('disposition', 'withAction', {
+      dcpRecommendationsubmittedbyname: 'QNCB4',
+      dcpCommunityboardrecommendation: null,
+      dcpIspublichearingrequired: null,
+      dcpDateofpublichearing: null,
+      dcpDatereceived: null,
+      dcpPublichearinglocation: null,
+    }),
+  ];
+
+  server.create('user', {
+    assignments: [
+
+      // UPCOMING
+      //----------------------------------------
+
+      // Upcoming Project 1: pre-cert with BP & BB roles >30
+      server.create('assignment', {
+        tab: 'upcoming',
+        dcpLupteammemberrole: 'BP',
+        dcpPublicstatusSimp: 'Filed',
+        publicReviewPlannedStartDate: moment().add(42, 'days'),
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatus: 'Filed',
+          dispositions: [
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNBP',
+              dcpBoroughpresidentrecommendation: null,
+              dcpDatereceived: null,
+            }),
+          ],
+          milestones: [
+            server.create('milestone', 'prepareFiledLandUseApplication', {
+              statuscode: 'Completed',
+              dcpPlannedstartdate: moment().subtract(60, 'days'),
+              displayDate: moment().subtract(60, 'days'),
+              displayDate2: moment().subtract(60, 'days'),
+              dcpActualenddate: moment().subtract(60, 'days'),
+              dcpMilestoneoutcome: null,
+            }),
+            server.create('milestone', 'certifiedReferred', {
+              statuscode: 'Not Started',
+            }),
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'Not Started',
+              dcpPlannedstartdate: moment().add(42, 'days'),
+              displayDate: moment().add(42, 'days'),
+            }),
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'Not Started',
+            }),
+          ],
+        }),
+      }),
+      // Upcoming Project 2: pre-cert with BP & BB roles <30
+      server.create('assignment', {
+        tab: 'upcoming',
+        dcpLupteammemberrole: 'BP',
+        dcpPublicstatusSimp: 'In Public Review',
+        publicReviewPlannedStartDate: moment().add(12, 'days'),
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatus: 'Filed',
+          dispositions: [
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNBP',
+              dcpBoroughpresidentrecommendation: null,
+              dcpDatereceived: null,
+            }),
+          ],
+          milestones: [
+            server.create('milestone', 'prepareFiledLandUseApplication', {
+              statuscode: 'Completed',
+              dcpPlannedstartdate: moment().subtract(100, 'days'),
+              displayDate: moment().subtract(100, 'days'),
+              displayDate2: moment().subtract(100, 'days'),
+              dcpActualenddate: moment().subtract(100, 'days'),
+              dcpMilestoneoutcome: null,
+            }),
+            server.create('milestone', 'certifiedReferred', {
+              statuscode: 'Completed',
+              dcpActualenddate: moment().subtract(75, 'days'),
+            }),
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'In Progress',
+              dcpActualenddate: moment().subtract(75, 'days'),
+              dcpPlannedcompletiondate: moment().add(42, 'days'),
+              displayDate: moment().add(42, 'days'),
+            }),
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'Not Started',
+              dcpPlannedstartdate: moment().add(42, 'days'),
+            }),
+          ],
+        }),
+      }),
+
+      // TO REVIEW
+      //----------------------------------------
+
+      // To Review Project 1: BP role only
+      server.create('assignment', {
+        tab: 'to-review',
+        dcpLupteammemberrole: 'BP',
+        dispositions: dispositionsArray,
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatusSimp: 'In Public Review',
+          dispositions: dispositionsArray,
+          milestones: [
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'In Progress',
+              dcpActualstartdate: moment().subtract(20, 'days'),
+              displayDate: moment().subtract(20, 'days'),
+              displayDate2: null,
+              dcpPlannedcompletiondate: moment().add(10, 'days'),
+              dcpMilestoneoutcome: null,
+            }),
+          ],
+        }),
+      }),
+      // To Review Project 2: BP role for project with both BP and BB roles
+      server.create('assignment', {
+        tab: 'to-review',
+        dcpLupteammemberrole: 'BP',
+        dispositions: dispositionsArray2,
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatusSimp: 'In Public Review',
+          dispositions: dispositionsArray2,
+          milestones: [
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'In Progress',
+              dcpActualstartdate: moment().subtract(2, 'days'),
+              displayDate: moment().subtract(2, 'days'),
+              displayDate2: null,
+              dcpPlannedcompletiondate: moment().add(28, 'days'),
+              dcpMilestoneoutcome: null,
+            }),
+          ],
+        }),
+      }),
+      // To Review Project 2: BB role for project with both BP and BB roles
+      server.create('assignment', {
+        tab: 'to-review',
+        dcpLupteammemberrole: 'BB',
+        dispositions: dispositionsArray3,
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatusSimp: 'In Public Review',
+          dispositions: dispositionsArray3,
+          milestones: [
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'In Progress',
+              dcpActualstartdate: moment().subtract(2, 'days'),
+              displayDate: moment().subtract(2, 'days'),
+              displayDate2: null,
+              dcpPlannedcompletiondate: moment().add(28, 'days'),
+              dcpMilestoneoutcome: null,
+            }),
+          ],
+        }),
+      }),
+
+      // REVIEWED
+      //----------------------------------------
+
+      // Reviewed Project 1: CB Approved w/ Mod, CB Disapproved, BP Approved, CPC Review
+      server.create('assignment', {
+        tab: 'reviewed',
+        dcpLupteammemberrole: 'CB',
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatusSimp: 'In Public Review',
+          dispositions: [
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNBP',
+              dcpBoroughpresidentrecommendation: 'Approved',
+              dcpDatereceived: moment().subtract(90, 'days'),
+            }),
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNCB4',
+              dcpCommunityboardrecommendation: 'Approved with Modifications/Conditions',
+              dcpDatereceived: moment().subtract(120, 'days'),
+            }),
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNCB6',
+              dcpCommunityboardrecommendation: 'Disapproved',
+              dcpDatereceived: moment().subtract(130, 'days'),
+            }),
+          ],
+          milestones: [
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(180, 'days'),
+              displayDate: moment().subtract(180, 'days'),
+              dcpActualenddate: moment().subtract(120, 'days'),
+              displayDate2: moment().subtract(120, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(120, 'days'),
+              displayDate: moment().subtract(120, 'days'),
+              dcpActualenddate: moment().subtract(90, 'days'),
+              displayDate2: moment().subtract(90, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionReview', {
+              statuscode: 'In Progress',
+              dcpActualstartdate: moment().subtract(10, 'days'),
+              displayDate: moment().subtract(10, 'days'),
+              dcpPlannedcompletiondate: moment().add(10, 'days'),
+              displayDate2: moment().add(10, 'days'),
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionVote', {
+              statuscode: 'Not Started',
+            }),
+
+            server.create('milestone', 'cityCouncilReview', {
+              statuscode: 'Not Started',
+            }),
+
+            server.create('milestone', 'mayoralReview', {
+              statuscode: 'Not Started',
+            }),
+
+            server.create('milestone', 'finalLetterSent', {
+              statuscode: 'Not Started',
+            }),
+          ],
+        }),
+      }),
+      // Reviewed Project 2: CB Approved w/ Mod, BP Approved, City Council Review
+      server.create('assignment', {
+        tab: 'reviewed',
+        dcpLupteammemberrole: 'CB',
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatusSimp: 'In Public Review',
+          dispositions: [
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNBP',
+              dcpBoroughpresidentrecommendation: 'Approved',
+              dcpDatereceived: moment().subtract(82, 'days'),
+            }),
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNCB9',
+              dcpCommunityboardrecommendation: 'Approved with Modifications/Conditions',
+              dcpDatereceived: moment().subtract(130, 'days'),
+            }),
+          ],
+          milestones: [
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(160, 'days'),
+              displayDate: moment().subtract(160, 'days'),
+              dcpActualenddate: moment().subtract(130, 'days'),
+              displayDate2: moment().subtract(130, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(130, 'days'),
+              displayDate: moment().subtract(130, 'days'),
+              dcpActualenddate: moment().subtract(82, 'days'),
+              displayDate2: moment().subtract(82, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(82, 'days'),
+              displayDate: moment().subtract(82, 'days'),
+              dcpActualenddate: moment().subtract(47, 'days'),
+              displayDate2: moment().subtract(47, 'days'),
+              dcpMilestoneoutcome: 'Hearing Closed',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionVote', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(46, 'days'),
+              displayDate: moment().subtract(46, 'days'),
+              dcpActualenddate: moment().subtract(16, 'days'),
+              displayDate2: moment().subtract(16, 'days'),
+              dcpMilestoneoutcome: 'Approval',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityCouncilReview', {
+              statuscode: 'In Progress',
+              dcpActualstartdate: moment().subtract(15, 'days'),
+              displayDate: moment().subtract(15, 'days'),
+              dcpPlannedcompletiondate: moment().add(15, 'days'),
+              displayDate2: moment().add(15, 'days'),
+            }),
+
+            server.create('milestone', 'mayoralReview', {
+              statuscode: 'Not Started',
+            }),
+
+            server.create('milestone', 'finalLetterSent', {
+              statuscode: 'Not Started',
+            }),
+          ],
+        }),
+      }),
+      // Reviewed Project 3: CB Waived, BP Approved, Mayoral Review
+      server.create('assignment', {
+        tab: 'reviewed',
+        dcpLupteammemberrole: 'CB',
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatusSimp: 'In Public Review',
+          dispositions: [
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNBP',
+              dcpBoroughpresidentrecommendation: 'Approved',
+              dcpDatereceived: moment().subtract(120, 'days'),
+            }),
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNCB12',
+              dcpCommunityboardrecommendation: 'Waived',
+              dcpDatereceived: moment().subtract(120, 'days'),
+            }),
+          ],
+          milestones: [
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(180, 'days'),
+              displayDate: moment().subtract(180, 'days'),
+              dcpActualenddate: moment().subtract(120, 'days'),
+              displayDate2: moment().subtract(120, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(120, 'days'),
+              displayDate: moment().subtract(120, 'days'),
+              dcpActualenddate: moment().subtract(90, 'days'),
+              displayDate2: moment().subtract(90, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(90, 'days'),
+              displayDate: moment().subtract(90, 'days'),
+              dcpActualenddate: moment().subtract(71, 'days'),
+              displayDate2: moment().subtract(71, 'days'),
+              dcpMilestoneoutcome: 'Hearing Closed',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionVote', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(70, 'days'),
+              displayDate: moment().subtract(70, 'days'),
+              dcpActualenddate: moment().subtract(61, 'days'),
+              displayDate2: moment().subtract(61, 'days'),
+              dcpMilestoneoutcome: 'Approval',
+            }),
+
+            server.create('milestone', 'cityCouncilReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(60, 'days'),
+              displayDate: moment().subtract(60, 'days'),
+              dcpActualenddate: moment().subtract(30, 'days'),
+              displayDate2: moment().subtract(30, 'days'),
+              dcpMilestoneoutcome: 'Approval',
+            }),
+
+            server.create('milestone', 'mayoralReview', {
+              statuscode: 'In Progress',
+              dcpActualstartdate: moment().subtract(30, 'days'),
+              displayDate: moment().subtract(30, 'days'),
+              dcpPlannedcompletiondate: moment().add(8, 'days'),
+              displayDate2: moment().add(8, 'days'),
+            }),
+
+            server.create('milestone', 'finalLetterSent', {
+              statuscode: 'Not Started',
+            }),
+          ],
+        }),
+      }),
+
+      // ARCHIVE
+      //----------------------------------------
+
+      // Archive Project 1: Approved
+      server.create('assignment', {
+        tab: 'archive',
+        dcpLupteammemberrole: 'CB',
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatus: 'Approved',
+          dcpPublicstatusSimp: 'Completed',
+          dcpProjectcompleted: moment().subtract(40, 'days'),
+          dispositions: [
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNBP',
+              dcpBoroughpresidentrecommendation: 'Approved',
+              dcpDatereceived: moment().subtract(90, 'days'),
+            }),
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNCB4',
+              dcpCommunityboardrecommendation: 'Approved with Modifications/Conditions',
+              dcpDatereceived: moment().subtract(120, 'days'),
+            }),
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNCB6',
+              dcpCommunityboardrecommendation: 'Disapproved',
+              dcpDatereceived: moment().subtract(130, 'days'),
+            }),
+          ],
+          milestones: [
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(180, 'days'),
+              displayDate: moment().subtract(180, 'days'),
+              dcpActualenddate: moment().subtract(120, 'days'),
+              displayDate2: moment().subtract(120, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(120, 'days'),
+              displayDate: moment().subtract(120, 'days'),
+              dcpActualenddate: moment().subtract(110, 'days'),
+              displayDate2: moment().subtract(110, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(110, 'days'),
+              displayDate: moment().subtract(110, 'days'),
+              dcpActualenddate: moment().subtract(90, 'days'),
+              displayDate2: moment().subtract(90, 'days'),
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionVote', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(110, 'days'),
+              displayDate: moment().subtract(110, 'days'),
+              dcpActualenddate: moment().subtract(90, 'days'),
+              displayDate2: moment().subtract(90, 'days'),
+            }),
+
+            server.create('milestone', 'cityCouncilReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(90, 'days'),
+              displayDate: moment().subtract(90, 'days'),
+              dcpActualenddate: moment().subtract(60, 'days'),
+              displayDate2: moment().subtract(60, 'days'),
+            }),
+
+            server.create('milestone', 'mayoralReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(60, 'days'),
+              displayDate: moment().subtract(60, 'days'),
+              dcpActualenddate: moment().subtract(50, 'days'),
+              displayDate2: moment().subtract(50, 'days'),
+            }),
+
+            server.create('milestone', 'finalLetterSent', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(40, 'days'),
+              displayDate: moment().subtract(40, 'days'),
+              dcpActualenddate: moment().subtract(40, 'days'),
+              displayDate2: moment().subtract(40, 'days'),
+            }),
+          ],
+        }),
+      }),
+      // Archive Project 2: Approved
+      server.create('assignment', {
+        tab: 'archive',
+        dcpLupteammemberrole: 'CB',
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatus: 'Approved',
+          dcpPublicstatusSimp: 'Completed',
+          dcpProjectcompleted: moment().subtract(140, 'days'),
+          dispositions: [
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNBP',
+              dcpBoroughpresidentrecommendation: 'Approved',
+              dcpDatereceived: moment().subtract(290, 'days'),
+            }),
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNCB9',
+              dcpCommunityboardrecommendation: 'Approved with Modifications/Conditions',
+              dcpDatereceived: moment().subtract(320, 'days'),
+            }),
+          ],
+          milestones: [
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(380, 'days'),
+              displayDate: moment().subtract(380, 'days'),
+              dcpActualenddate: moment().subtract(320, 'days'),
+              displayDate2: moment().subtract(320, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(320, 'days'),
+              displayDate: moment().subtract(320, 'days'),
+              dcpActualenddate: moment().subtract(290, 'days'),
+              displayDate2: moment().subtract(290, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(290, 'days'),
+              displayDate: moment().subtract(290, 'days'),
+              dcpActualenddate: moment().subtract(210, 'days'),
+              displayDate2: moment().subtract(210, 'days'),
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionVote', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(210, 'days'),
+              displayDate: moment().subtract(210, 'days'),
+              dcpActualenddate: moment().subtract(190, 'days'),
+              displayDate2: moment().subtract(190, 'days'),
+            }),
+
+            server.create('milestone', 'cityCouncilReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(190, 'days'),
+              displayDate: moment().subtract(190, 'days'),
+              dcpActualenddate: moment().subtract(160, 'days'),
+              displayDate2: moment().subtract(160, 'days'),
+            }),
+
+            server.create('milestone', 'mayoralReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(160, 'days'),
+              displayDate: moment().subtract(160, 'days'),
+              dcpActualenddate: moment().subtract(150, 'days'),
+              displayDate2: moment().subtract(150, 'days'),
+            }),
+
+            server.create('milestone', 'finalLetterSent', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(140, 'days'),
+              displayDate: moment().subtract(140, 'days'),
+              dcpActualenddate: moment().subtract(140, 'days'),
+              displayDate2: moment().subtract(140, 'days'),
+            }),
+          ],
+        }),
+      }),
+      // Archive Project 3: Withdrawn
+      server.create('assignment', {
+        tab: 'archive',
+        dcpLupteammemberrole: 'CB',
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatus: 'Withdrawn/Terminated/Disapproved',
+          dcpPublicstatusSimp: 'Completed',
+          dcpProjectcompleted: moment().subtract(120, 'days'),
+          dispositions: [
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNBP',
+              dcpBoroughpresidentrecommendation: 'Approved',
+              dcpDatereceived: moment().subtract(120, 'days'),
+            }),
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNCB12',
+              dcpCommunityboardrecommendation: 'Waived',
+              dcpDatereceived: moment().subtract(120, 'days'),
+            }),
+          ],
+          milestones: [
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(180, 'days'),
+              displayDate: moment().subtract(180, 'days'),
+              dcpActualenddate: moment().subtract(120, 'days'),
+              displayDate2: moment().subtract(120, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(120, 'days'),
+              displayDate: moment().subtract(120, 'days'),
+              dcpActualenddate: moment().subtract(90, 'days'),
+              displayDate2: moment().subtract(90, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(90, 'days'),
+              displayDate: moment().subtract(90, 'days'),
+              dcpActualenddate: moment().subtract(71, 'days'),
+              displayDate2: moment().subtract(71, 'days'),
+              dcpMilestoneoutcome: 'Hearing Closed',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionVote', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(70, 'days'),
+              displayDate: moment().subtract(70, 'days'),
+              dcpActualenddate: moment().subtract(61, 'days'),
+              dcpMilestoneoutcome: 'Approval',
+            }),
+
+            server.create('milestone', 'cityCouncilReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(160, 'days'),
+              displayDate: moment().subtract(160, 'days'),
+              dcpActualenddate: moment().subtract(130, 'days'),
+              displayDate2: moment().subtract(130, 'days'),
+              dcpMilestoneoutcome: 'Disapproved',
+            }),
+
+            server.create('milestone', 'mayoralReview', {
+              statuscode: 'Not Started',
+            }),
+
+            server.create('milestone', 'finalLetterSent', {
+              statuscode: 'Not Started',
+            }),
+          ],
+        }),
+      }),
+    ],
+  });
+}

--- a/mirage/scenarios/borough-president.js
+++ b/mirage/scenarios/borough-president.js
@@ -1,43 +1,6 @@
 import moment from 'moment';
 
 export default function(server) {
-  // Project attributes for Upcoming Project 1 which has both BP and BB assignments
-  const projectForUpcoming1 = server.create('project', {
-    dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
-    dcpPublicstatusSimp: 'Filed',
-    dispositions: [
-      server.create('disposition', 'withAction', {
-        dcpRecommendationsubmittedbyname: 'QNBP',
-        dcpBoroughpresidentrecommendation: null,
-        dcpDatereceived: null,
-      }),
-    ],
-    milestones: [
-      server.create('milestone', 'prepareFiledLandUseApplication', {
-        statuscode: 'Completed',
-        dcpPlannedstartdate: moment().subtract(60, 'days'),
-        displayDate: moment().subtract(60, 'days'),
-        displayDate2: moment().subtract(60, 'days'),
-        dcpActualenddate: moment().subtract(60, 'days'),
-        dcpMilestoneoutcome: null,
-      }),
-      server.create('milestone', 'certifiedReferred', {
-        statuscode: 'Not Started',
-      }),
-      server.create('milestone', 'communityBoardReview', {
-        statuscode: 'Not Started',
-        dcpPlannedstartdate: moment().add(42, 'days'),
-        displayDate: moment().add(42, 'days'),
-      }),
-      server.create('milestone', 'boroughPresidentReview', {
-        statuscode: 'Not Started',
-      }),
-      server.create('milestone', 'boroughBoardReview', {
-        statuscode: 'Not Started',
-      }),
-    ],
-  });
-
   // Array of dispositions for To Review Project 1
   const dispositionsArrayForToReview = [
     server.create('disposition', 'withAction', {
@@ -121,6 +84,59 @@ export default function(server) {
       dcpPublichearinglocation: null,
     }),
   ];
+
+  // Project attributes for Upcoming Project 1 which has both BP and BB assignments
+  const projectForUpcoming1 = server.create('project', {
+    dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+    dcpPublicstatusSimp: 'Filed',
+    dispositions: [
+      server.create('disposition', 'withAction', {
+        dcpRecommendationsubmittedbyname: 'QNBP',
+        dcpBoroughpresidentrecommendation: null,
+        dcpDatereceived: null,
+      }),
+    ],
+    milestones: [
+      server.create('milestone', 'prepareFiledLandUseApplication', {
+        statuscode: 'Completed',
+        dcpPlannedstartdate: moment().subtract(60, 'days'),
+        displayDate: moment().subtract(60, 'days'),
+        displayDate2: moment().subtract(60, 'days'),
+        dcpActualenddate: moment().subtract(60, 'days'),
+        dcpMilestoneoutcome: null,
+      }),
+      server.create('milestone', 'certifiedReferred', {
+        statuscode: 'Not Started',
+      }),
+      server.create('milestone', 'communityBoardReview', {
+        statuscode: 'Not Started',
+        dcpPlannedstartdate: moment().add(42, 'days'),
+        displayDate: moment().add(42, 'days'),
+      }),
+      server.create('milestone', 'boroughPresidentReview', {
+        statuscode: 'Not Started',
+      }),
+      server.create('milestone', 'boroughBoardReview', {
+        statuscode: 'Not Started',
+      }),
+    ],
+  });
+
+  const projectForToReview2 = server.create('project', {
+    dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+    dcpPublicstatusSimp: 'In Public Review',
+    dispositions: dispositionsArrayForToReview2,
+    milestones: [
+      server.create('milestone', 'boroughPresidentReview', {
+        statuscode: 'In Progress',
+        dcpActualstartdate: moment().subtract(2, 'days'),
+        displayDate: moment().subtract(2, 'days'),
+        displayDate2: null,
+        dcpPlannedcompletiondate: moment().add(28, 'days'),
+        dcpMilestoneoutcome: null,
+      }),
+    ],
+  });
 
   server.create('user', {
     assignments: [
@@ -254,16 +270,36 @@ export default function(server) {
         dispositions: dispositionsArrayForToReview2,
         project: server.create('project', {
           dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
-          dcpPublicstatusSimp: 'In Public Review',
-          dispositions: dispositionsArrayForToReview2,
+          dcpPublicstatusSimp: 'Filed',
+          dispositions: [
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNBP',
+              dcpBoroughpresidentrecommendation: null,
+              dcpDatereceived: null,
+            }),
+          ],
           milestones: [
-            server.create('milestone', 'boroughPresidentReview', {
-              statuscode: 'In Progress',
-              dcpActualstartdate: moment().subtract(2, 'days'),
-              displayDate: moment().subtract(2, 'days'),
-              displayDate2: null,
-              dcpPlannedcompletiondate: moment().add(28, 'days'),
+            server.create('milestone', 'prepareFiledLandUseApplication', {
+              statuscode: 'Completed',
+              dcpPlannedstartdate: moment().subtract(60, 'days'),
+              displayDate: moment().subtract(60, 'days'),
+              displayDate2: moment().subtract(60, 'days'),
+              dcpActualenddate: moment().subtract(60, 'days'),
               dcpMilestoneoutcome: null,
+            }),
+            server.create('milestone', 'certifiedReferred', {
+              statuscode: 'Not Started',
+            }),
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'Not Started',
+              dcpPlannedstartdate: moment().add(42, 'days'),
+              displayDate: moment().add(42, 'days'),
+            }),
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'Not Started',
+            }),
+            server.create('milestone', 'boroughBoardReview', {
+              statuscode: 'Not Started',
             }),
           ],
         }),
@@ -273,29 +309,7 @@ export default function(server) {
         tab: 'to-review',
         dcpLupteammemberrole: 'BB',
         dispositions: dispositionsArrayForToReview3,
-        project: server.create('project', {
-          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
-          dcpPublicstatusSimp: 'In Public Review',
-          dispositions: dispositionsArrayForToReview3,
-          milestones: [
-            server.create('milestone', 'boroughPresidentReview', {
-              statuscode: 'In Progress',
-              dcpActualstartdate: moment().subtract(2, 'days'),
-              displayDate: moment().subtract(2, 'days'),
-              displayDate2: null,
-              dcpPlannedcompletiondate: moment().add(28, 'days'),
-              dcpMilestoneoutcome: null,
-            }),
-            server.create('milestone', 'boroughBoardReview', {
-              statuscode: 'In Progress',
-              dcpActualstartdate: moment().subtract(2, 'days'),
-              displayDate: moment().subtract(2, 'days'),
-              displayDate2: null,
-              dcpPlannedcompletiondate: moment().add(28, 'days'),
-              dcpMilestoneoutcome: null,
-            }),
-          ],
-        }),
+        project: projectForToReview2,
       }),
 
       // REVIEWED

--- a/mirage/scenarios/community-board.js
+++ b/mirage/scenarios/community-board.js
@@ -2,7 +2,7 @@ import moment from 'moment';
 
 export default function(server) {
   // Array of dispositions for To Review Project 1
-  const dispositionsArray = [
+  const dispositionsArrayForToReview = [
     server.create('disposition', 'withAction', {
       dcpRecommendationsubmittedbyname: 'QNCB4',
       dcpCommunityboardrecommendation: null,
@@ -30,7 +30,7 @@ export default function(server) {
   ];
 
   // Array of dispositions for To Review Project 2
-  const dispositionsArray2 = [
+  const dispositionsArrayForToReview2 = [
     server.create('disposition', 'withAction', {
       dcpRecommendationsubmittedbyname: 'QNCB4',
       dcpCommunityboardrecommendation: null,
@@ -67,7 +67,6 @@ export default function(server) {
       server.create('assignment', {
         tab: 'upcoming',
         dcpLupteammemberrole: 'CB',
-        dcpPublicstatusSimp: 'Filed',
         publicReviewPlannedStartDate: moment().add(42, 'days'),
         project: server.create('project', {
           dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
@@ -95,11 +94,10 @@ export default function(server) {
       server.create('assignment', {
         tab: 'upcoming',
         dcpLupteammemberrole: 'CB',
-        dcpPublicstatusSimp: 'Filed',
         publicReviewPlannedStartDate: moment().add(12, 'days'),
         project: server.create('project', {
           dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
-          dcpPublicstatus: 'Filed',
+          dcpPublicstatusSimp: 'Filed',
           milestones: [
             server.create('milestone', 'prepareFiledLandUseApplication', {
               statuscode: 'Completed',
@@ -127,11 +125,11 @@ export default function(server) {
       server.create('assignment', {
         tab: 'to-review',
         dcpLupteammemberrole: 'CB',
-        dispositions: dispositionsArray,
+        dispositions: dispositionsArrayForToReview,
         project: server.create('project', {
           dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
           dcpPublicstatusSimp: 'In Public Review',
-          dispositions: dispositionsArray,
+          dispositions: dispositionsArrayForToReview,
           milestones: [
             server.create('milestone', 'communityBoardReview', {
               statuscode: 'In Progress',
@@ -148,11 +146,11 @@ export default function(server) {
       server.create('assignment', {
         tab: 'to-review',
         dcpLupteammemberrole: 'CB',
-        dispositions: dispositionsArray2,
+        dispositions: dispositionsArrayForToReview2,
         project: server.create('project', {
           dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
           dcpPublicstatusSimp: 'In Public Review',
-          dispositions: dispositionsArray2,
+          dispositions: dispositionsArrayForToReview2,
           milestones: [
             server.create('milestone', 'communityBoardReview', {
               statuscode: 'In Progress',

--- a/mirage/scenarios/community-board.js
+++ b/mirage/scenarios/community-board.js
@@ -1,0 +1,703 @@
+import moment from 'moment';
+
+export default function(server) {
+  // Array of dispositions for To Review Project 1
+  const dispositionsArray = [
+    server.create('disposition', 'withAction', {
+      dcpRecommendationsubmittedbyname: 'QNCB4',
+      dcpCommunityboardrecommendation: null,
+      dcpIspublichearingrequired: null,
+      dcpDateofpublichearing: null,
+      dcpDatereceived: null,
+      dcpPublichearinglocation: null,
+    }),
+    server.create('disposition', 'withAction', {
+      dcpRecommendationsubmittedbyname: 'QNCB4',
+      dcpCommunityboardrecommendation: null,
+      dcpIspublichearingrequired: null,
+      dcpDateofpublichearing: null,
+      dcpDatereceived: null,
+      dcpPublichearinglocation: null,
+    }),
+    server.create('disposition', 'withAction', {
+      dcpRecommendationsubmittedbyname: 'QNCB4',
+      dcpCommunityboardrecommendation: null,
+      dcpIspublichearingrequired: null,
+      dcpDateofpublichearing: null,
+      dcpDatereceived: null,
+      dcpPublichearinglocation: null,
+    }),
+  ];
+
+  // Array of dispositions for To Review Project 2
+  const dispositionsArray2 = [
+    server.create('disposition', 'withAction', {
+      dcpRecommendationsubmittedbyname: 'QNCB4',
+      dcpCommunityboardrecommendation: null,
+      dcpIspublichearingrequired: null,
+      dcpDateofpublichearing: null,
+      dcpDatereceived: null,
+      dcpPublichearinglocation: null,
+    }),
+    server.create('disposition', 'withAction', {
+      dcpRecommendationsubmittedbyname: 'QNCB4',
+      dcpCommunityboardrecommendation: null,
+      dcpIspublichearingrequired: null,
+      dcpDateofpublichearing: null,
+      dcpDatereceived: null,
+      dcpPublichearinglocation: null,
+    }),
+    server.create('disposition', 'withAction', {
+      dcpRecommendationsubmittedbyname: 'QNCB4',
+      dcpCommunityboardrecommendation: null,
+      dcpIspublichearingrequired: null,
+      dcpDateofpublichearing: null,
+      dcpDatereceived: null,
+      dcpPublichearinglocation: null,
+    }),
+  ];
+
+  server.create('user', {
+    assignments: [
+
+      // UPCOMING
+      //----------------------------------------
+
+      // Upcoming Project 1: pre-cert  >30
+      server.create('assignment', {
+        tab: 'upcoming',
+        dcpLupteammemberrole: 'CB',
+        dcpPublicstatusSimp: 'Filed',
+        publicReviewPlannedStartDate: moment().add(42, 'days'),
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatusSimp: 'Filed',
+          milestones: [
+            server.create('milestone', 'prepareFiledLandUseApplication', {
+              statuscode: 'Completed',
+              dcpPlannedstartdate: moment().subtract(60, 'days'),
+              displayDate: moment().subtract(60, 'days'),
+              displayDate2: moment().subtract(60, 'days'),
+              dcpActualenddate: moment().subtract(60, 'days'),
+              dcpMilestoneoutcome: null,
+            }),
+            server.create('milestone', 'certifiedReferred', {
+              statuscode: 'Not Started',
+            }),
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'Not Started',
+              dcpPlannedstartdate: moment().add(42, 'days'),
+            }),
+          ],
+        }),
+      }),
+      // Upcoming Project 2: pre-cert  <30
+      server.create('assignment', {
+        tab: 'upcoming',
+        dcpLupteammemberrole: 'CB',
+        dcpPublicstatusSimp: 'Filed',
+        publicReviewPlannedStartDate: moment().add(12, 'days'),
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatus: 'Filed',
+          milestones: [
+            server.create('milestone', 'prepareFiledLandUseApplication', {
+              statuscode: 'Completed',
+              dcpPlannedstartdate: moment().subtract(75, 'days'),
+              displayDate: moment().subtract(75, 'days'),
+              displayDate2: moment().subtract(75, 'days'),
+              dcpActualenddate: moment().subtract(75, 'days'),
+              dcpMilestoneoutcome: null,
+            }),
+            server.create('milestone', 'certifiedReferred', {
+              statuscode: 'Not Started',
+            }),
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'Not Started',
+              dcpPlannedstartdate: moment().add(12, 'days'),
+            }),
+          ],
+        }),
+      }),
+
+      // TO REVIEW
+      //----------------------------------------
+
+      // To Review Project 1: CB
+      server.create('assignment', {
+        tab: 'to-review',
+        dcpLupteammemberrole: 'CB',
+        dispositions: dispositionsArray,
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatusSimp: 'In Public Review',
+          dispositions: dispositionsArray,
+          milestones: [
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'In Progress',
+              dcpActualstartdate: moment().subtract(2, 'days'),
+              displayDate: moment().subtract(2, 'days'),
+              displayDate2: null,
+              dcpPlannedcompletiondate: moment().add(58, 'days'),
+              dcpMilestoneoutcome: null,
+            }),
+          ],
+        }),
+      }),
+      // To Review Project 2: CB
+      server.create('assignment', {
+        tab: 'to-review',
+        dcpLupteammemberrole: 'CB',
+        dispositions: dispositionsArray2,
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatusSimp: 'In Public Review',
+          dispositions: dispositionsArray2,
+          milestones: [
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'In Progress',
+              dcpActualstartdate: moment().subtract(35, 'days'),
+              displayDate: moment().subtract(35, 'days'),
+              displayDate2: null,
+              dcpPlannedcompletiondate: moment().add(25, 'days'),
+              dcpMilestoneoutcome: null,
+            }),
+          ],
+        }),
+      }),
+
+      // REVIEWED
+      //----------------------------------------
+
+      // Reviewed Project 1: CB Approved w/ Mod, CB Disapproved, BP Approved, CPC Review
+      server.create('assignment', {
+        tab: 'reviewed',
+        dcpLupteammemberrole: 'CB',
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatusSimp: 'In Public Review',
+          dispositions: [
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNBP',
+              dcpBoroughpresidentrecommendation: 'Approved',
+              dcpDatereceived: moment().subtract(90, 'days'),
+            }),
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNCB4',
+              dcpCommunityboardrecommendation: 'Approved with Modifications/Conditions',
+              dcpDatereceived: moment().subtract(120, 'days'),
+            }),
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNCB6',
+              dcpCommunityboardrecommendation: 'Disapproved',
+              dcpDatereceived: moment().subtract(130, 'days'),
+            }),
+          ],
+          milestones: [
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(180, 'days'),
+              displayDate: moment().subtract(180, 'days'),
+              dcpActualenddate: moment().subtract(120, 'days'),
+              displayDate2: moment().subtract(120, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(120, 'days'),
+              displayDate: moment().subtract(120, 'days'),
+              dcpActualenddate: moment().subtract(90, 'days'),
+              displayDate2: moment().subtract(90, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionReview', {
+              statuscode: 'In Progress',
+              dcpActualstartdate: moment().subtract(10, 'days'),
+              displayDate: moment().subtract(10, 'days'),
+              dcpPlannedcompletiondate: moment().add(10, 'days'),
+              displayDate2: moment().add(10, 'days'),
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionVote', {
+              statuscode: 'Not Started',
+            }),
+
+            server.create('milestone', 'cityCouncilReview', {
+              statuscode: 'Not Started',
+            }),
+
+            server.create('milestone', 'mayoralReview', {
+              statuscode: 'Not Started',
+            }),
+
+            server.create('milestone', 'finalLetterSent', {
+              statuscode: 'Not Started',
+            }),
+          ],
+        }),
+      }),
+      // Reviewed Project 2: CB Approved w/ Mod, BP Approved, City Council Review
+      server.create('assignment', {
+        tab: 'reviewed',
+        dcpLupteammemberrole: 'CB',
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatusSimp: 'In Public Review',
+          dispositions: [
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNBP',
+              dcpBoroughpresidentrecommendation: 'Approved',
+              dcpDatereceived: moment().subtract(82, 'days'),
+            }),
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNCB9',
+              dcpCommunityboardrecommendation: 'Approved with Modifications/Conditions',
+              dcpDatereceived: moment().subtract(130, 'days'),
+            }),
+          ],
+          milestones: [
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(160, 'days'),
+              displayDate: moment().subtract(160, 'days'),
+              dcpActualenddate: moment().subtract(130, 'days'),
+              displayDate2: moment().subtract(130, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(130, 'days'),
+              displayDate: moment().subtract(130, 'days'),
+              dcpActualenddate: moment().subtract(82, 'days'),
+              displayDate2: moment().subtract(82, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(82, 'days'),
+              displayDate: moment().subtract(82, 'days'),
+              dcpActualenddate: moment().subtract(47, 'days'),
+              displayDate2: moment().subtract(47, 'days'),
+              dcpMilestoneoutcome: 'Hearing Closed',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionVote', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(46, 'days'),
+              displayDate: moment().subtract(46, 'days'),
+              dcpActualenddate: moment().subtract(16, 'days'),
+              displayDate2: moment().subtract(16, 'days'),
+              dcpMilestoneoutcome: 'Approval',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityCouncilReview', {
+              statuscode: 'In Progress',
+              dcpActualstartdate: moment().subtract(15, 'days'),
+              displayDate: moment().subtract(15, 'days'),
+              dcpPlannedcompletiondate: moment().add(15, 'days'),
+              displayDate2: moment().add(15, 'days'),
+            }),
+
+            server.create('milestone', 'mayoralReview', {
+              statuscode: 'Not Started',
+            }),
+
+            server.create('milestone', 'finalLetterSent', {
+              statuscode: 'Not Started',
+            }),
+          ],
+        }),
+      }),
+      // Reviewed Project 3: CB Waived, BP Approved, Mayoral Review
+      server.create('assignment', {
+        tab: 'reviewed',
+        dcpLupteammemberrole: 'CB',
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatusSimp: 'In Public Review',
+          dispositions: [
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNBP',
+              dcpBoroughpresidentrecommendation: 'Approved',
+              dcpDatereceived: moment().subtract(120, 'days'),
+            }),
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNCB12',
+              dcpCommunityboardrecommendation: 'Waived',
+              dcpDatereceived: moment().subtract(120, 'days'),
+            }),
+          ],
+          milestones: [
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(180, 'days'),
+              displayDate: moment().subtract(180, 'days'),
+              dcpActualenddate: moment().subtract(120, 'days'),
+              displayDate2: moment().subtract(120, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(120, 'days'),
+              displayDate: moment().subtract(120, 'days'),
+              dcpActualenddate: moment().subtract(90, 'days'),
+              displayDate2: moment().subtract(90, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(90, 'days'),
+              displayDate: moment().subtract(90, 'days'),
+              dcpActualenddate: moment().subtract(71, 'days'),
+              displayDate2: moment().subtract(71, 'days'),
+              dcpMilestoneoutcome: 'Hearing Closed',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionVote', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(70, 'days'),
+              displayDate: moment().subtract(70, 'days'),
+              dcpActualenddate: moment().subtract(61, 'days'),
+              displayDate2: moment().subtract(61, 'days'),
+              dcpMilestoneoutcome: 'Approval',
+            }),
+
+            server.create('milestone', 'cityCouncilReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(60, 'days'),
+              displayDate: moment().subtract(60, 'days'),
+              dcpActualenddate: moment().subtract(30, 'days'),
+              displayDate2: moment().subtract(30, 'days'),
+              dcpMilestoneoutcome: 'Approval',
+            }),
+
+            server.create('milestone', 'mayoralReview', {
+              statuscode: 'In Progress',
+              dcpActualstartdate: moment().subtract(30, 'days'),
+              displayDate: moment().subtract(30, 'days'),
+              dcpPlannedcompletiondate: moment().add(8, 'days'),
+              displayDate2: moment().add(8, 'days'),
+            }),
+
+            server.create('milestone', 'finalLetterSent', {
+              statuscode: 'Not Started',
+            }),
+          ],
+        }),
+      }),
+
+      // ARCHIVE
+      //----------------------------------------
+
+      // Archive Project 1: Approved
+      server.create('assignment', {
+        tab: 'archive',
+        dcpLupteammemberrole: 'CB',
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatus: 'Approved',
+          dcpPublicstatusSimp: 'Completed',
+          dcpProjectcompleted: moment().subtract(40, 'days'),
+          dispositions: [
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNBP',
+              dcpBoroughpresidentrecommendation: 'Approved',
+              dcpDatereceived: moment().subtract(90, 'days'),
+            }),
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNCB4',
+              dcpCommunityboardrecommendation: 'Approved with Modifications/Conditions',
+              dcpDatereceived: moment().subtract(120, 'days'),
+            }),
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNCB6',
+              dcpCommunityboardrecommendation: 'Disapproved',
+              dcpDatereceived: moment().subtract(130, 'days'),
+            }),
+          ],
+          milestones: [
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(180, 'days'),
+              displayDate: moment().subtract(180, 'days'),
+              dcpActualenddate: moment().subtract(120, 'days'),
+              displayDate2: moment().subtract(120, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(120, 'days'),
+              displayDate: moment().subtract(120, 'days'),
+              dcpActualenddate: moment().subtract(110, 'days'),
+              displayDate2: moment().subtract(110, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(110, 'days'),
+              displayDate: moment().subtract(110, 'days'),
+              dcpActualenddate: moment().subtract(90, 'days'),
+              displayDate2: moment().subtract(90, 'days'),
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionVote', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(110, 'days'),
+              displayDate: moment().subtract(110, 'days'),
+              dcpActualenddate: moment().subtract(90, 'days'),
+              displayDate2: moment().subtract(90, 'days'),
+            }),
+
+            server.create('milestone', 'cityCouncilReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(90, 'days'),
+              displayDate: moment().subtract(90, 'days'),
+              dcpActualenddate: moment().subtract(60, 'days'),
+              displayDate2: moment().subtract(60, 'days'),
+            }),
+
+            server.create('milestone', 'mayoralReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(60, 'days'),
+              displayDate: moment().subtract(60, 'days'),
+              dcpActualenddate: moment().subtract(50, 'days'),
+              displayDate2: moment().subtract(50, 'days'),
+            }),
+
+            server.create('milestone', 'finalLetterSent', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(40, 'days'),
+              displayDate: moment().subtract(40, 'days'),
+              dcpActualenddate: moment().subtract(40, 'days'),
+              displayDate2: moment().subtract(40, 'days'),
+            }),
+          ],
+        }),
+      }),
+      // Archive Project 2: Approved
+      server.create('assignment', {
+        tab: 'archive',
+        dcpLupteammemberrole: 'CB',
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatus: 'Approved',
+          dcpPublicstatusSimp: 'Completed',
+          dcpProjectcompleted: moment().subtract(140, 'days'),
+          dispositions: [
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNBP',
+              dcpBoroughpresidentrecommendation: 'Approved',
+              dcpDatereceived: moment().subtract(290, 'days'),
+            }),
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNCB9',
+              dcpCommunityboardrecommendation: 'Approved with Modifications/Conditions',
+              dcpDatereceived: moment().subtract(320, 'days'),
+            }),
+          ],
+          milestones: [
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(380, 'days'),
+              displayDate: moment().subtract(380, 'days'),
+              dcpActualenddate: moment().subtract(320, 'days'),
+              displayDate2: moment().subtract(320, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(320, 'days'),
+              displayDate: moment().subtract(320, 'days'),
+              dcpActualenddate: moment().subtract(290, 'days'),
+              displayDate2: moment().subtract(290, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(290, 'days'),
+              displayDate: moment().subtract(290, 'days'),
+              dcpActualenddate: moment().subtract(210, 'days'),
+              displayDate2: moment().subtract(210, 'days'),
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionVote', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(210, 'days'),
+              displayDate: moment().subtract(210, 'days'),
+              dcpActualenddate: moment().subtract(190, 'days'),
+              displayDate2: moment().subtract(190, 'days'),
+            }),
+
+            server.create('milestone', 'cityCouncilReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(190, 'days'),
+              displayDate: moment().subtract(190, 'days'),
+              dcpActualenddate: moment().subtract(160, 'days'),
+              displayDate2: moment().subtract(160, 'days'),
+            }),
+
+            server.create('milestone', 'mayoralReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(160, 'days'),
+              displayDate: moment().subtract(160, 'days'),
+              dcpActualenddate: moment().subtract(150, 'days'),
+              displayDate2: moment().subtract(150, 'days'),
+            }),
+
+            server.create('milestone', 'finalLetterSent', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(140, 'days'),
+              displayDate: moment().subtract(140, 'days'),
+              dcpActualenddate: moment().subtract(140, 'days'),
+              displayDate2: moment().subtract(140, 'days'),
+            }),
+          ],
+        }),
+      }),
+      // Archive Project 3: Withdrawn
+      server.create('assignment', {
+        tab: 'archive',
+        dcpLupteammemberrole: 'CB',
+        project: server.create('project', {
+          dcpProjectbrief: 'This is a private application requesting a zoning map amendment (ZM) from R5 and R5/C2-2 to C4-4A, and a zoning text amendment (ZR) to the zoning resolution to facilitate a new 6-story, 15,924 zsf, commercial development at 580 16th Ave...',
+          dcpPublicstatus: 'Withdrawn/Terminated/Disapproved',
+          dcpPublicstatusSimp: 'Completed',
+          dcpProjectcompleted: moment().subtract(120, 'days'),
+          dispositions: [
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNBP',
+              dcpBoroughpresidentrecommendation: 'Approved',
+              dcpDatereceived: moment().subtract(120, 'days'),
+            }),
+            server.create('disposition', 'withAction', {
+              dcpRecommendationsubmittedbyname: 'QNCB12',
+              dcpCommunityboardrecommendation: 'Waived',
+              dcpDatereceived: moment().subtract(120, 'days'),
+            }),
+          ],
+          milestones: [
+            server.create('milestone', 'communityBoardReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(180, 'days'),
+              displayDate: moment().subtract(180, 'days'),
+              dcpActualenddate: moment().subtract(120, 'days'),
+              displayDate2: moment().subtract(120, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+            server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(120, 'days'),
+              displayDate: moment().subtract(120, 'days'),
+              dcpActualenddate: moment().subtract(90, 'days'),
+              displayDate2: moment().subtract(90, 'days'),
+              dcpMilestoneoutcome: 'Approved',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(90, 'days'),
+              displayDate: moment().subtract(90, 'days'),
+              dcpActualenddate: moment().subtract(71, 'days'),
+              displayDate2: moment().subtract(71, 'days'),
+              dcpMilestoneoutcome: 'Hearing Closed',
+              milestoneLinks: [{
+                filename: '2020_QB.pdf',
+                url: 'https://www1.nyc.gov/site/planning/index.page',
+              }],
+            }),
+
+            server.create('milestone', 'cityPlanningCommissionVote', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(70, 'days'),
+              displayDate: moment().subtract(70, 'days'),
+              dcpActualenddate: moment().subtract(61, 'days'),
+              dcpMilestoneoutcome: 'Approval',
+            }),
+
+            server.create('milestone', 'cityCouncilReview', {
+              statuscode: 'Completed',
+              dcpActualstartdate: moment().subtract(160, 'days'),
+              displayDate: moment().subtract(160, 'days'),
+              dcpActualenddate: moment().subtract(130, 'days'),
+              displayDate2: moment().subtract(130, 'days'),
+              dcpMilestoneoutcome: 'Disapproved',
+            }),
+
+            server.create('milestone', 'mayoralReview', {
+              statuscode: 'Not Started',
+            }),
+
+            server.create('milestone', 'finalLetterSent', {
+              statuscode: 'Not Started',
+            }),
+          ],
+        }),
+      }),
+    ],
+  });
+}

--- a/tests/acceptance/upcoming-project-cards-renders-test.js
+++ b/tests/acceptance/upcoming-project-cards-renders-test.js
@@ -54,7 +54,7 @@ module('Acceptance | upcoming project cards renders', function(hooks) {
     await visit('/my-projects/upcoming');
 
     const timeRemainingValue = find('[data-test-fuzzy-time-remaining]').textContent.trim();
-    assert.equal(timeRemainingValue, 'over 30 days', 'Time remaining displays over 30 days');
+    assert.equal(timeRemainingValue, 'in more than 30 days', 'Time remaining displays over 30 days');
     assert.notOk(find('[data-test-time-remaining]'));
   });
 
@@ -86,7 +86,7 @@ module('Acceptance | upcoming project cards renders', function(hooks) {
     await visit('/my-projects/upcoming');
 
     const timeRemainingValue = find('[data-test-fuzzy-time-remaining]').textContent.trim();
-    assert.equal(timeRemainingValue, 'under 30 days', 'Time remaining displays under 30 days');
+    assert.equal(timeRemainingValue, 'in fewer than 30 days', 'Time remaining displays under 30 days');
     assert.notOk(find('[data-test-time-remaining]'));
   });
 
@@ -141,7 +141,7 @@ module('Acceptance | upcoming project cards renders', function(hooks) {
             dcpPublicstatusSimp: '',
             milestones: [this.server.create('milestone', 'communityBoardReview', {
               // note how Community Board Review has already started, but we still display
-              // the fuzzy public review start date ('under 30 days')
+              // the fuzzy public review start date ('in fewer than 30 days')
               dcpPlannedstartdate: moment().subtract(15, 'days'),
             })],
           }),
@@ -156,7 +156,7 @@ module('Acceptance | upcoming project cards renders', function(hooks) {
     await visit('/my-projects/upcoming');
 
     const timeRemainingValue = find('[data-test-fuzzy-time-remaining]').textContent.trim();
-    assert.equal(timeRemainingValue, 'under 30 days', 'Time remaining displays under 30 days');
+    assert.equal(timeRemainingValue, 'in fewer than 30 days', 'Time remaining displays under 30 days');
     assert.notOk(find('[data-test-time-remaining]'));
   });
 });


### PR DESCRIPTION
Changes:
- New mirage CB scenario file for usability testing!
- New mirage BP scenario file for usability testing! (help uncover a few little bugs I'll create issues for)
- Skips auth step so it's easier to review work when running the app locally
- Fixes the hearingsWaived computed value on the assignment model. We were getting back an empty array which the app was incorrectly thinking meant the hearings had been waived.
- Adds conditional date display on the archive tab, only showing actual end dates when available
- Updates fuzzy upcoming start date text