### PR TITLE
774: hide countdown on reviewed if nothing is "in progress"

### DIFF
--- a/app/templates/components/reviewed-project-card.hbs
+++ b/app/templates/components/reviewed-project-card.hbs
@@ -13,17 +13,19 @@
       </div>
       <div class="cell medium-4 large-3 xlarge-2">
         <div class="text-center medium-margin-right medium-margin-left">
-          <p class="tiny-margin-bottom">{{timeDisplayLabel}}</p>
-          <p>
-            <strong
-              class="stat"
-              data-test-estimated-time-remaining
-            >{{plannedTimeDisplay.estTimeRemaining}}</strong>
-            <strong class="display-block">of {{plannedTimeDisplay.estTimeDuration}} estimated days remain</strong>
-          </p>
-          <p class="text-tiny">
-            Estimated End <DateDisplay @date={{plannedTimeDisplay.dcpPlannedcompletiondate}} outputFormat="M/D/YYYY" />
-          </p>
+          {{#if timeDisplayLabel}}
+            <p class="tiny-margin-bottom">{{timeDisplayLabel}}</p>
+            <p>
+              <strong
+                class="stat"
+                data-test-estimated-time-remaining
+              >{{plannedTimeDisplay.estTimeRemaining}}</strong>
+              <strong class="display-block">of {{plannedTimeDisplay.estTimeDuration}} estimated days remain</strong>
+            </p>
+            <p class="text-tiny">
+              Estimated End <DateDisplay @date={{plannedTimeDisplay.dcpPlannedcompletiondate}} outputFormat="M/D/YYYY" />
+            </p>
+          {{/if}}
         </div>
       </div>
       <div class="cell medium-auto">


### PR DESCRIPTION
Addresses #774. Leaves empty white space column if no milestones are currently "in progress" on reviewed tab.