### PR TITLE
Better modal closing

### DIFF
--- a/app/styles/modules/_m-reveal-modal.scss
+++ b/app/styles/modules/_m-reveal-modal.scss
@@ -15,6 +15,14 @@
   }
 }
 
+.reveal-overlay-target {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
 .reveal {
   border: 0;
   box-shadow: 0 0 0 rem-calc(4) rgba(0,0,0,0.1);

--- a/app/templates/components/confirmation-modal.hbs
+++ b/app/templates/components/confirmation-modal.hbs
@@ -1,5 +1,6 @@
 {{#if open}}
   <div class="reveal-overlay" style="display:block;">
+    <div class="reveal-overlay-target" {{action closeModal}}></div>
     <div
       class="reveal"
       role="dialog"


### PR DESCRIPTION
Rahul's testing shows the modal is difficult to cancel. This PR makes it easier by allowing the user to click anywhere outside the content to close the modal. 