### PR TITLE
889: fix bug in single disposition option confirmation modal on hearing form

### DIFF
--- a/app/controllers/my-projects/assignment/hearing/add.js
+++ b/app/controllers/my-projects/assignment/hearing/add.js
@@ -86,7 +86,7 @@ export default class MyProjectsProjectHearingAddController extends Controller {
   @action
   async onConfirm() {
     const { dispositions } = this.model;
-    const allActions = this.get('allActions');
+    const allActions = this.get('allActions') || (dispositions.length <= 1);
 
     // if user is submitting ONE hearing for ALL actions
     if (allActions) {

--- a/app/templates/my-projects/assignment/hearing/add.hbs
+++ b/app/templates/my-projects/assignment/hearing/add.hbs
@@ -90,7 +90,7 @@
         {{else}}
           <h3>Confirm hearing information</h3>
 
-            {{#if allActions}}
+            {{#if (or allActions (lte model.dispositions.length 1))}}
               <li class="grid-x">
                 <div class="cell shrink small-margin-right">
                     {{fa-icon "calendar" class="light-gray" fixedWidth=true}}

--- a/tests/acceptance/user-can-fill-out-hearing-form-test.js
+++ b/tests/acceptance/user-can-fill-out-hearing-form-test.js
@@ -474,8 +474,9 @@ module('Acceptance | user can fill out hearing form', function(hooks) {
       dispositions: [
         server.create('disposition', {
           id: 17,
-          dcpPublichearinglocation: null,
-          dcpDateofpublichearing: '',
+          dcpPublichearinglocation: '',
+          dcpDateofpublichearing: null,
+          action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C1009383' }),
         }),
       ],
       project: this.server.create('project', {
@@ -509,9 +510,22 @@ module('Acceptance | user can fill out hearing form', function(hooks) {
 
     await click('[data-test-button="checkHearing"]');
 
+    // make sure that the hearing location in the modal equals the input value
+    assert.equal(this.element.querySelector('.hearing-location').textContent, '121 Bananas Ave, Queens, NY');
+    assert.equal(this.element.querySelector('.hearing-time').textContent, '6:30 PM');
+    assert.equal(this.element.querySelector('.hearing-date').textContent, '10/21/2020');
+
     await click('[data-test-button="confirmHearing"]');
 
     assert.equal(currentURL(), '/my-projects/4/hearing/done');
+
+    // clicking back to to-review
+    await click('[data-test-button="back-to-review"]');
+
+    assert.equal(this.element.querySelector('[data-test-hearing-location="17"]').textContent, '121 Bananas Ave, Queens, NY');
+    assert.ok(this.element.querySelector('[data-test-hearing-date="17"]').textContent.includes('10/21/2020'));
+    assert.ok(this.element.querySelector('[data-test-hearing-time="17"]').textContent.includes('6:30 PM'));
+    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="17"]').textContent.includes('Zoning Special Permit'));
   });
 
   test('if there is a server error when running .save(), user will see error message', async function(assert) {


### PR DESCRIPTION
Fix bug where, for assignments with only one disposition, data wasn't showing up in the confirmation modal. 

Closes #889 