### PR TITLE
834 confirmation modals

### DIFF
--- a/app/templates/my-projects/assignment/hearing/add.hbs
+++ b/app/templates/my-projects/assignment/hearing/add.hbs
@@ -90,80 +90,80 @@
         {{else}}
           <h3>Confirm hearing information</h3>
 
-            {{#if (or allActions (lte model.dispositions.length 1))}}
-              <li class="grid-x">
+          {{#if (or allActions (lte model.dispositions.length 1))}}
+            <ul class="no-bullet">
+              <li class="grid-x small-margin-bottom">
                 <div class="cell shrink small-margin-right">
                     {{fa-icon "calendar" class="light-gray" fixedWidth=true}}
                 </div>
                 <div class="cell auto">
-                  <strong class="display-block hearing-location">
+                  <strong class="display-inline-block">
                     {{~dispositionForAllActions.dcpPublichearinglocation~}}
                   </strong>
-                  <span class="hearing-date">{{!--
+
+                  <span class="display-inline-block">{{!--
                 --}}<DateDisplay
                       @date={{dispositionForAllActions.dcpDateofpublichearing}}
                     />{{!--
-              --}}</span>
-                  <span class="light-gray">|</span>
-                  <span class="hearing-time">{{!--
-                --}}<DateDisplay
+                --}}<span class="light-gray">|</span>
+                    <DateDisplay
                       @date={{dispositionForAllActions.dcpDateofpublichearing}}
                       @outputFormat="h:mm A"
                     />{{!--
               --}}</span>
                 </div>
               </li>
-            {{else}}
-              {{#deduped-hearings-list dispositions=model.dispositions as |dedupedHearings|}}
-                <h5 class="column-header">Hearing Information</h5>
-                    <ul class="no-bullet">
-                    {{#each dedupedHearings as |hearing|}}
-                      <li class="grid-x small-margin-bottom">
-                        <div class="cell shrink small-margin-right">
-                          {{#if (is-before hearing.disposition.dcpDateofpublichearing)}}
-                            {{fa-icon "calendar" class="light-gray" fixedWidth=true}}
-                          {{else}}
-                            {{fa-icon "check" class="blue" fixedWidth=true}}
-                          {{/if}}
-                        </div>
-                        <div class="cell auto">
-                          <strong data-test-hearing-location="{{hearing.disposition.id}}" class="display-inline-block">
-                            {{~hearing.disposition.dcpPublichearinglocation~}}
-                          </strong>
+            </ul>
+          {{else}}
+            {{#deduped-hearings-list dispositions=model.dispositions as |dedupedHearings|}}
+              <ul class="no-bullet">
+                {{#each dedupedHearings as |hearing|}}
+                  <li class="grid-x small-margin-bottom">
+                    <div class="cell shrink small-margin-right">
+                      {{#if (is-before hearing.disposition.dcpDateofpublichearing)}}
+                        {{fa-icon "calendar" class="light-gray" fixedWidth=true}}
+                      {{else}}
+                        {{fa-icon "check" class="blue" fixedWidth=true}}
+                      {{/if}}
+                    </div>
+                    <div class="cell auto">
+                      <strong data-test-hearing-location="{{hearing.disposition.id}}" class="display-inline-block">
+                        {{~hearing.disposition.dcpPublichearinglocation~}}
+                      </strong>
 
-                          <span class="display-inline-block">
-                            <span data-test-hearing-date="{{hearing.disposition.id}}"
-                            >{{!--
-                          --}}<DateDisplay
-                                @date={{hearing.disposition.dcpDateofpublichearing}}
-                              />{{!--
-                        --}}</span>
-                            <span class="light-gray">|</span>
-                            <span data-test-hearing-time="{{hearing.disposition.id}}">{{!--
-                            --}}<DateDisplay
-                                @date={{hearing.disposition.dcpDateofpublichearing}}
-                                @outputFormat="h:mm A"
-                              />{{!--
-                        --}}</span>
+                      <span class="display-inline-block">
+                        <span data-test-hearing-date="{{hearing.disposition.id}}"
+                        >{{!--
+                      --}}<DateDisplay
+                            @date={{hearing.disposition.dcpDateofpublichearing}}
+                          />{{!--
+                    --}}</span>
+                        <span class="light-gray">|</span>
+                        <span data-test-hearing-time="{{hearing.disposition.id}}">{{!--
+                        --}}<DateDisplay
+                            @date={{hearing.disposition.dcpDateofpublichearing}}
+                            @outputFormat="h:mm A"
+                          />{{!--
+                    --}}</span>
+                      </span>
+
+                      <div class="text-tiny" data-test-hearing-actions-list="{{hearing.disposition.id}}">
+                        {{#each hearing.hearingActions as |action index| ~}}
+                          <span class="label light-gray tiny-margin-bottom tiny-margin-right">
+                            {{action.dcpName}}
+                            <small>{{action.dcpUlurpnumber}}</small>
                           </span>
-
-                          <small data-test-hearing-actions-list="{{hearing.disposition.id}}">
-                            {{#each hearing.hearingActions as |action index| ~}}
-                              <span class="label light-gray tiny-margin-bottom tiny-margin-right">
-                                {{action.dcpName}}
-                                <small>{{action.dcpUlurpnumber}}</small>
-                              </span>
-                            {{~/each}}
-                          </small>
-                        </div>
-                      </li>
-                    {{/each}}
-                    </ul>
-              {{/deduped-hearings-list}}
-            {{/if}}
+                        {{~/each}}
+                      </div>
+                    </div>
+                  </li>
+                {{/each}}
+              </ul>
+            {{/deduped-hearings-list}}
+          {{/if}}
 
           <p class="callout warning text-small">
-            Once you submit hearing information, you cannot edit it. You'll need to contact NYC Planning to make any changes (ZAP_feedback_DL@planning.nyc.gov or 212-720-3300).
+            Once hearing information is submitted, you cannot edit it. You'll need to contact NYC Planning to make any changes (ZAP_feedback_DL@planning.nyc.gov or 212-720-3300).
           </p>
 
           <p>

--- a/app/templates/my-projects/assignment/hearing/add.hbs
+++ b/app/templates/my-projects/assignment/hearing/add.hbs
@@ -97,19 +97,23 @@
                     {{fa-icon "calendar" class="light-gray" fixedWidth=true}}
                 </div>
                 <div class="cell auto">
-                  <strong class="display-inline-block">
+                  <strong class="hearing-location display-inline-block">
                     {{~dispositionForAllActions.dcpPublichearinglocation~}}
                   </strong>
 
                   <span class="display-inline-block">{{!--
-                --}}<DateDisplay
-                      @date={{dispositionForAllActions.dcpDateofpublichearing}}
-                    />{{!--
-                --}}<span class="light-gray">|</span>
-                    <DateDisplay
-                      @date={{dispositionForAllActions.dcpDateofpublichearing}}
-                      @outputFormat="h:mm A"
-                    />{{!--
+                --}}<span class="hearing-date">{{!--
+                  --}}<DateDisplay
+                        @date={{dispositionForAllActions.dcpDateofpublichearing}}
+                      />{{!--
+                --}}</span>{{!--
+                --}}<span class="light-gray">|</span>{{!--
+                --}}<span class="hearing-time">{{!--
+                  --}}<DateDisplay
+                        @date={{dispositionForAllActions.dcpDateofpublichearing}}
+                        @outputFormat="h:mm A"
+                      />{{!--
+                --}}</span>{{!--
               --}}</span>
                 </div>
               </li>

--- a/app/templates/my-projects/assignment/hearing/add.hbs
+++ b/app/templates/my-projects/assignment/hearing/add.hbs
@@ -88,7 +88,7 @@
             Back to hearing form
           </button>
         {{else}}
-          <h3>Confirm hearing information</h3>
+          <h3 class="large-margin-right">Please confirm your hearing information.</h3>
 
           {{#if (or allActions (lte model.dispositions.length 1))}}
             <ul class="no-bullet">
@@ -161,11 +161,10 @@
               </ul>
             {{/deduped-hearings-list}}
           {{/if}}
-
+          <hr>
           <p class="callout warning text-small">
-            Once hearing information is submitted, you cannot edit it. You'll need to contact NYC Planning to make any changes (ZAP_feedback_DL@planning.nyc.gov or 212-720-3300).
+            Once your hearing information is submitted, you cannot edit it. You'll need to contact NYC Planning to make any changes (ZAP_feedback_DL@planning.nyc.gov or 212-720-3300).
           </p>
-
           <p>
             <button
               class="button"
@@ -175,7 +174,6 @@
             >
               Submit Hearing Information
             </button>
-
             <button
               class="button clear"
               data-test-button="closeModal"

--- a/app/templates/my-projects/assignment/recommendations/add.hbs
+++ b/app/templates/my-projects/assignment/recommendations/add.hbs
@@ -512,7 +512,9 @@
             {{#confirmation-modal open=modalOpen}}
               <h3 class="large-margin-right">Please confirm your recommendation information.</h3>
               {{#unless assignment.hearingsWaived}}
-                <h5>
+                <h5
+                  data-test-confirmation-quorum-answer
+                >
                   Was a Quorum Present at your Hearing(s)?
                 </h5>
                 {{#deduped-hearings-list dispositions=assignment.dispositions as |dedupedHearings|}}

--- a/app/templates/my-projects/assignment/recommendations/add.hbs
+++ b/app/templates/my-projects/assignment/recommendations/add.hbs
@@ -552,33 +552,28 @@
                 <p
                   data-test-confirmation-all-actions-recommendation
                 >
-                  <strong>Recommendation:</strong>
-                  {{recommendation-label-lookup participantType this.dispositionForAllActionsChangeset.recommendation}}
+                  <strong>Recommendation:</strong> {{recommendation-label-lookup participantType this.dispositionForAllActionsChangeset.recommendation}}
                 </p>
                 {{#if (or (eq participantType 'CB') (eq participantType 'BB'))}}
                   <p
                     data-test-confirmation-all-actions-dcpVotinginfavorrecommendation
                   >
-                    <strong>Votes in Favor:</strong>
-                    {{this.dispositionForAllActionsChangeset.dcpVotinginfavorrecommendation}}
+                    <strong>Votes in Favor:</strong> {{this.dispositionForAllActionsChangeset.dcpVotinginfavorrecommendation}}
                   </p>
                   <p
                     data-test-confirmation-all-actions-dcpVotingagainstrecommendation
                   >
-                    <strong>Votes Against:</strong>
-                    {{this.dispositionForAllActionsChangeset.dcpVotingagainstrecommendation}}
+                    <strong>Votes Against:</strong> {{this.dispositionForAllActionsChangeset.dcpVotingagainstrecommendation}}
                   </p>
                   <p
                     data-test-confirmation-all-actions-dcpVotingabstainingonrecommendation
                   >
-                    <strong>Abstain:</strong>
-                    {{this.dispositionForAllActionsChangeset.dcpVotingabstainingonrecommendation}}
+                    <strong>Abstain:</strong> {{this.dispositionForAllActionsChangeset.dcpVotingabstainingonrecommendation}}
                   </p>
                   <p
                     data-test-confirmation-all-actions-dcpTotalmembersappointedtotheboard
                   >
-                    <strong>Total Members:</strong>
-                    {{this.dispositionForAllActionsChangeset.dcpTotalmembersappointedtotheboard}}
+                    <strong>Total Members:</strong> {{this.dispositionForAllActionsChangeset.dcpTotalmembersappointedtotheboard}}
                   </p>
                 {{/if}}
               {{else}}
@@ -592,42 +587,34 @@
                   <p
                     data-test-confirmation-each-action-recommendation={{idx}}
                   >
-                    <strong>Recommendation:</strong>
-                    <strong>
-                      {{recommendation-label-lookup participantType (get dispositionChangesetPair.changeset (rec-field-by-parttype-lookup this.participantType))}}
-                    </strong>
+                    <strong>Recommendation:</strong> {{recommendation-label-lookup participantType (get dispositionChangesetPair.changeset (rec-field-by-parttype-lookup this.participantType))}}
                   </p>
                   {{#if (or (eq participantType 'CB') (eq participantType 'BB'))}}
                     <p
                       data-test-confirmation-each-action-votes={{concat "in-favor-" idx}}
                     >
-                      <strong>Votes in Favor:</strong>
-                      {{dispositionChangesetPair.changeset.dcpVotinginfavorrecommendation}}
+                      <strong>Votes in Favor:</strong> {{dispositionChangesetPair.changeset.dcpVotinginfavorrecommendation}}
                     </p>
                     <p
                       data-test-confirmation-each-action-votes={{concat "against-" idx}}
                     >
-                      <strong>Votes Against:</strong>
-                      {{dispositionChangesetPair.changeset.dcpVotingagainstrecommendation}}
+                      <strong>Votes Against:</strong> {{dispositionChangesetPair.changeset.dcpVotingagainstrecommendation}}
                     </p>
                     <p
                       data-test-confirmation-each-action-votes={{concat "abstain-" idx}}
                     >
-                      <strong>Abstain:</strong>
-                      {{dispositionChangesetPair.changeset.dcpVotingabstainingonrecommendation}}
+                      <strong>Abstain:</strong> {{dispositionChangesetPair.changeset.dcpVotingabstainingonrecommendation}}
                     </p>
                     <p
                       data-test-confirmation-each-action-votes={{concat "total-members-" idx}}
                     >
-                      <strong>Total Members:</strong>
-                      {{dispositionChangesetPair.changeset.dcpTotalmembersappointedtotheboard}}
+                      <strong>Total Members:</strong> {{dispositionChangesetPair.changeset.dcpTotalmembersappointedtotheboard}}
                     </p>
                   {{/if}}
                   <div class="display-block"
                     data-test-confirmation-each-action-dcpConsideration={{idx}}
                   >
-                    <strong>Comment:</strong>
-                    {{dispositionChangesetPair.changeset.dcpConsideration}}
+                    <strong>Comment:</strong> {{dispositionChangesetPair.changeset.dcpConsideration}}
                   </div>
                 {{/each}}
               {{/if}}
@@ -636,22 +623,19 @@
                   <p
                     data-test-confirmation-all-actions-dcpVotelocation
                   >
-                    <strong>Vote Location:</strong>
-                    {{this.dispositionForAllActionsChangeset.dcpVotelocation}}
+                    <strong>Vote Location:</strong> {{this.dispositionForAllActionsChangeset.dcpVotelocation}}
                   </p>
                   <p
                     data-test-confirmation-all-actions-dcpDateofvote
                   >
-                    <strong>Vote Date:</strong>
-                    {{moment-format this.dispositionForAllActionsChangeset.dcpDateofvote 'MM/DD/YYYY'}}
+                    <strong>Vote Date:</strong> {{moment-format this.dispositionForAllActionsChangeset.dcpDateofvote 'MM/DD/YYYY'}}
                   </p>
                 {{/if}}
                 {{#if (eq this.allActions true)}}
                   <p
                     data-test-confirmation-all-actions-dcpConsideration
                   >
-                    <strong>Comment:</strong>
-                    {{this.dispositionForAllActionsChangeset.dcpConsideration}}
+                    <strong>Comment:</strong> {{this.dispositionForAllActionsChangeset.dcpConsideration}}
                   </p>
                 {{/if}}
                 <p><strong>Attached files:</strong></p>

--- a/app/templates/my-projects/assignment/recommendations/add.hbs
+++ b/app/templates/my-projects/assignment/recommendations/add.hbs
@@ -103,11 +103,10 @@
             {{/deduped-hearings-list}}
           {{/if}}
           {{#if assignment.hearingsWaived}}
-            <div data-test-hearings-waived-message>
-              <h5>Note: You have opted out of submitting hearings for this project.</h5>
+            <div class="callout warning large-margin-bottom" data-test-hearings-waived-message>
+              <h5 class="small-margin-bottom">Note: You have opted out of submitting hearings for this project.</h5>
               <p class="text-small">Without proper notice of a public hearing, the {{participant-type-label assignment.dcpLupteammemberrole}}'s recommendation does not comply with City Charter requirements. NYC Planning will still accept a recommendation, but a disapproval will not trigger an automatic City Council call up.</p>
             </div>
-            <hr>
           {{/if}}
           {{#if (gt this.dispositions.length 1)}}
             <fieldset class="medium-margin-bottom medium-margin-top"
@@ -511,79 +510,81 @@
 
           {{#ember-wormhole to="reveal-modal-container"}}
             {{#confirmation-modal open=modalOpen}}
-              <h3>Confirm recommendation information</h3>
-              <h5>
-                Was a Quorum Present at your Hearing(s)?
-              </h5>
-              {{#deduped-hearings-list dispositions=assignment.dispositions as |dedupedHearings|}}
-                {{#each dedupedHearings as |hearing idx|}}
-                  <p class="grid-x">
-                    <strong class="cell small-1"
-                      data-test-quorum-answer={{idx}}
-                    >
-                      {{if hearing.disposition.dcpWasaquorumpresent "Yes" "No"}}
-                    </strong>
-                    <span class="cell auto">
-                      <span class="display-block">
-                        <strong>
-                          <DateDisplay
-                            @date={{hearing.disposition.dcpDateofpublichearing}}
-                          />
-                        </strong>
-                        <span class="light-gray">|</span>
-                        <strong>{{hearing.disposition.dcpPublichearinglocation}}</strong>
-                      </span>
-                      <small data-test-hearing-actions-list="{{hearing.disposition.id}}">
-                        {{#each hearing.hearingActions as |action index| ~}}
-                          {{#if action.dcpName}}
-                            <span class="label light-gray tiny-margin-bottom tiny-margin-right">
-                              {{action.dcpName}}
-                              <small>{{action.dcpUlurpnumber}}</small>
-                            </span>
-                          {{/if}}
-                        {{~/each}}
-                      </small>
-                    </span>
-                  </p>
-                {{/each}}
-              {{/deduped-hearings-list}}
-              {{#if this.allActions}}
+              <h3 class="large-margin-right">Please confirm your recommendation information.</h3>
+              {{#unless assignment.hearingsWaived}}
                 <h5>
-                  Recommendation:
+                  Was a Quorum Present at your Hearing(s)?
                 </h5>
+                {{#deduped-hearings-list dispositions=assignment.dispositions as |dedupedHearings|}}
+                  {{#each dedupedHearings as |hearing idx|}}
+                    <p class="grid-x">
+                      <strong class="cell small-1"
+                        data-test-quorum-answer={{idx}}
+                      >
+                        {{if hearing.disposition.dcpWasaquorumpresent "Yes" "No"}}
+                      </strong>
+                      <span class="cell auto">
+                        <span class="display-block">
+                          <strong>
+                            <DateDisplay
+                              @date={{hearing.disposition.dcpDateofpublichearing}}
+                            />
+                          </strong>
+                          <span class="light-gray">|</span>
+                          <strong>{{hearing.disposition.dcpPublichearinglocation}}</strong>
+                        </span>
+                        <small data-test-hearing-actions-list="{{hearing.disposition.id}}">
+                          {{#each hearing.hearingActions as |action index| ~}}
+                            {{#if action.dcpName}}
+                              <span class="label light-gray tiny-margin-bottom tiny-margin-right">
+                                {{action.dcpName}}
+                                <small>{{action.dcpUlurpnumber}}</small>
+                              </span>
+                            {{/if}}
+                          {{~/each}}
+                        </small>
+                      </span>
+                    </p>
+                  {{/each}}
+                {{/deduped-hearings-list}}
+              {{/unless}}
+              {{#if this.allActions}}
                 <p
                   data-test-confirmation-all-actions-recommendation
                 >
-                  <strong>
-                    {{recommendation-label-lookup participantType this.dispositionForAllActionsChangeset.recommendation}}
-                  </strong>
+                  <strong>Recommendation:</strong>
+                  {{recommendation-label-lookup participantType this.dispositionForAllActionsChangeset.recommendation}}
                 </p>
                 {{#if (or (eq participantType 'CB') (eq participantType 'BB'))}}
                   <p
                     data-test-confirmation-all-actions-dcpVotinginfavorrecommendation
                   >
-                    Votes in Favor: {{this.dispositionForAllActionsChangeset.dcpVotinginfavorrecommendation}}
+                    <strong>Votes in Favor:</strong>
+                    {{this.dispositionForAllActionsChangeset.dcpVotinginfavorrecommendation}}
                   </p>
                   <p
                     data-test-confirmation-all-actions-dcpVotingagainstrecommendation
                   >
-                    Votes Against: {{this.dispositionForAllActionsChangeset.dcpVotingagainstrecommendation}}
+                    <strong>Votes Against:</strong>
+                    {{this.dispositionForAllActionsChangeset.dcpVotingagainstrecommendation}}
                   </p>
                   <p
                     data-test-confirmation-all-actions-dcpVotingabstainingonrecommendation
                   >
-                    Abstain: {{this.dispositionForAllActionsChangeset.dcpVotingabstainingonrecommendation}}
+                    <strong>Abstain:</strong>
+                    {{this.dispositionForAllActionsChangeset.dcpVotingabstainingonrecommendation}}
                   </p>
                   <p
                     data-test-confirmation-all-actions-dcpTotalmembersappointedtotheboard
                   >
-                    Total Members: {{this.dispositionForAllActionsChangeset.dcpTotalmembersappointedtotheboard}}
+                    <strong>Total Members:</strong>
+                    {{this.dispositionForAllActionsChangeset.dcpTotalmembersappointedtotheboard}}
                   </p>
                 {{/if}}
               {{else}}
                 {{#each this.dispositionAndChangesetPairs as |dispositionChangesetPair idx|}}
                   <h5 class="large-margin-top">
-                    Recommendation: {{dispositionChangesetPair.disposition.action.dcpName}}
+                    {{dispositionChangesetPair.disposition.action.dcpName}}
                     <small class="dark-gray">
                       ({{dispositionChangesetPair.disposition.action.dcpUlurpnumber}})
                     </small>
@@ -591,6 +592,7 @@
                   <p
                     data-test-confirmation-each-action-recommendation={{idx}}
                   >
+                    <strong>Recommendation:</strong>
                     <strong>
                       {{recommendation-label-lookup participantType (get dispositionChangesetPair.changeset (rec-field-by-parttype-lookup this.participantType))}}
                     </strong>
@@ -599,28 +601,33 @@
                     <p
                       data-test-confirmation-each-action-votes={{concat "in-favor-" idx}}
                     >
-                      Votes in Favor: {{dispositionChangesetPair.changeset.dcpVotinginfavorrecommendation}}
+                      <strong>Votes in Favor:</strong>
+                      {{dispositionChangesetPair.changeset.dcpVotinginfavorrecommendation}}
                     </p>
                     <p
                       data-test-confirmation-each-action-votes={{concat "against-" idx}}
                     >
-                      Votes Against: {{dispositionChangesetPair.changeset.dcpVotingagainstrecommendation}}
+                      <strong>Votes Against:</strong>
+                      {{dispositionChangesetPair.changeset.dcpVotingagainstrecommendation}}
                     </p>
                     <p
                       data-test-confirmation-each-action-votes={{concat "abstain-" idx}}
                     >
-                      Abstain: {{dispositionChangesetPair.changeset.dcpVotingabstainingonrecommendation}}
+                      <strong>Abstain:</strong>
+                      {{dispositionChangesetPair.changeset.dcpVotingabstainingonrecommendation}}
                     </p>
                     <p
                       data-test-confirmation-each-action-votes={{concat "total-members-" idx}}
                     >
-                      Total Members: {{dispositionChangesetPair.changeset.dcpTotalmembersappointedtotheboard}}
+                      <strong>Total Members:</strong>
+                      {{dispositionChangesetPair.changeset.dcpTotalmembersappointedtotheboard}}
                     </p>
                   {{/if}}
                   <div class="display-block"
                     data-test-confirmation-each-action-dcpConsideration={{idx}}
                   >
-                    Comment: {{dispositionChangesetPair.changeset.dcpConsideration}}
+                    <strong>Comment:</strong>
+                    {{dispositionChangesetPair.changeset.dcpConsideration}}
                   </div>
                 {{/each}}
               {{/if}}
@@ -629,22 +636,25 @@
                   <p
                     data-test-confirmation-all-actions-dcpVotelocation
                   >
-                    Vote Location: {{this.dispositionForAllActionsChangeset.dcpVotelocation}}
+                    <strong>Vote Location:</strong>
+                    {{this.dispositionForAllActionsChangeset.dcpVotelocation}}
                   </p>
                   <p
                     data-test-confirmation-all-actions-dcpDateofvote
                   >
-                    Vote Date: {{this.dispositionForAllActionsChangeset.dcpDateofvote}}
+                    <strong>Vote Date:</strong>
+                    {{moment-format this.dispositionForAllActionsChangeset.dcpDateofvote 'MM/DD/YYYY'}}
                   </p>
                 {{/if}}
                 {{#if (eq this.allActions true)}}
                   <p
                     data-test-confirmation-all-actions-dcpConsideration
                   >
-                    Comment: {{this.dispositionForAllActionsChangeset.dcpConsideration}}
+                    <strong>Comment:</strong>
+                    {{this.dispositionForAllActionsChangeset.dcpConsideration}}
                   </p>
                 {{/if}}
-                <p>Attached files:</p>
+                <p><strong>Attached files:</strong></p>
                 <ul>
                   {{#with (file-queue name="files") as |queue|}}
                     {{#each queue.files as |file|}}
@@ -653,8 +663,9 @@
                   {{/with}}
                 </ul>
               {{/if}}
+              <hr>
               <p class="callout warning text-small">
-                Once you submit recommendation information, you can not edit it. You'll need to contact NYC Planning to make any changes (ZAP_feedback_DL@planning.nyc.gov or 212-720-3300).
+                Once your recommendation is submitted, you can not edit it. You'll need to contact NYC Planning to make any changes (ZAP_feedback_DL@planning.nyc.gov or 212-720-3300).
               </p>
               <p>
                 <button

--- a/tests/acceptance/user-can-submit-recommendation-form-test.js
+++ b/tests/acceptance/user-can-submit-recommendation-form-test.js
@@ -53,6 +53,7 @@ function setUpProjectAndDispos(server, participantType) {
         dispositions: [
           server.create('disposition', {
             id: 5,
+            dcpIspublichearingrequired: 'No',
             dcpPublichearinglocation: null,
             dcpDateofpublichearing: null,
             action: server.create('action'),
@@ -93,7 +94,7 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
     assert.ok(find('[data-test-hearing-actions-list]'));
   });
 
-  test('CB User does not see quorum question on project 2 if no hearings submitted', async function(assert) {
+  test('CB User does not see quorum question on project 2 if hearings were waived', async function(assert) {
     setUpProjectAndDispos(server, 'CB');
 
     await authenticateSession();
@@ -102,6 +103,24 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
 
     assert.notOk(find('[data-test-quorum-question]'));
     assert.notOk(find('[data-test-hearing-actions-list]'));
+
+    await find('[data-test-all-actions-recommendation-select]');
+
+    await selectChoose('[data-test-all-actions-recommendation]', 'Disapproved');
+
+    await fillIn('[data-test-all-actions-dcpVotinginfavorrecommendation]', 1);
+    await fillIn('[data-test-all-actions-dcpVotingagainstrecommendation]', 2);
+    await fillIn('[data-test-all-actions-dcpVotingabstainingonrecommendation]', 3);
+    await fillIn('[data-test-all-actions-dcpTotalmembersappointedtotheboard]', 4);
+
+    await fillIn('[data-test-all-actions-dcpVotelocation]', 'Smith Street');
+    await fillIn('[data-test-all-actions-dcpDateofvote]', '10/17/2019');
+    await fillIn('[data-test-all-actions-dcpConsideration]', 'My All Actions Comment');
+
+    await click('[data-test-continue]');
+
+    assert.notOk(find('[data-test-confirmation-quorum-answer]'), 'Confirmation modal does not show quorum header');
+    assert.notOk(find('[data-test-quorum-answer="0"]'), 'Confirmation modal does not show quorum answers');
   });
 
   test('CB User does not see "All Actions" question if project has only one disposition', async function(assert) {
@@ -143,6 +162,8 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
     await fillIn('[data-test-all-actions-dcpConsideration]', 'My All Actions Comment');
 
     await click('[data-test-continue]');
+
+    assert.ok(find('[data-test-confirmation-quorum-answer]'), 'Confirmation modal shows quorum question header');
 
     assert.equal(this.element.querySelector('[data-test-quorum-answer="0').textContent.trim(), 'Yes', 'Confirmation modal shows answer to first quorum quesiton');
     assert.equal(this.element.querySelector('[data-test-quorum-answer="1').textContent.trim(), 'No', 'Confirmation modal shows answer to second quorum quesiton');

--- a/tests/acceptance/user-can-submit-recommendation-form-test.js
+++ b/tests/acceptance/user-can-submit-recommendation-form-test.js
@@ -147,7 +147,7 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
     assert.equal(this.element.querySelector('[data-test-quorum-answer="0').textContent.trim(), 'Yes', 'Confirmation modal shows answer to first quorum quesiton');
     assert.equal(this.element.querySelector('[data-test-quorum-answer="1').textContent.trim(), 'No', 'Confirmation modal shows answer to second quorum quesiton');
 
-    assert.equal(this.element.querySelector('[data-test-confirmation-all-actions-recommendation]').textContent.trim(), 'Disapproved');
+    assert.equal(this.element.querySelector('[data-test-confirmation-all-actions-recommendation]').textContent.trim(), 'Recommendation: Disapproved');
 
     assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpVotinginfavorrecommendation]').textContent.trim().includes('1'), 'Confirmation modal shows votes in favor for all actions');
     assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpVotingagainstrecommendation]').textContent.trim().includes('2'), 'Confirmation modal shows votes against for all actions');
@@ -155,7 +155,7 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
     assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpTotalmembersappointedtotheboard]').textContent.trim().includes('4'), 'Confirmation modal shows total members appointed for all actions');
 
     assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpVotelocation]').textContent.trim().includes('Smith Street'), 'Confirmation modal shows vote location for all actions.');
-    assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpDateofvote]').textContent.includes('Thu Oct 17 2019'), 'Confirmation modal shows date of vote for all actions.');
+    assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpDateofvote]').textContent.includes('10/17/2019'), 'Confirmation modal shows date of vote for all actions.');
     assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpConsideration]').textContent.trim().includes('My All Actions Comment'), 'Confirmation modal shows dcpConsideration for all actions.');
 
     await click('[data-test-submit]');
@@ -224,7 +224,7 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
     assert.ok(this.element.querySelector('[data-test-confirmation-each-action-dcpConsideration="2"]').textContent.trim().includes('My comment for dcpConsideration 2'), 'Confirmation modal shows dcpConsideration for action 2');
 
     assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpVotelocation]').textContent.trim().includes('Bergen Street'), 'Confirmation modal shows vote location for all actions.');
-    assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpDateofvote]').textContent.includes('Wed Dec 11 2019'), 'Confirmation modal shows date of vote for all actions.');
+    assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpDateofvote]').textContent.includes('12/11/2019'), 'Confirmation modal shows date of vote for all actions.');
 
     await click('[data-test-submit]');
 
@@ -249,7 +249,8 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
 
     await click('[data-test-continue]');
 
-    assert.equal(this.element.querySelector('[data-test-confirmation-all-actions-recommendation]').textContent.trim(), 'Unfavorable');
+    assert.equal(this.element.querySelector('[data-test-confirmation-all-actions-recommendation]').textContent.trim(), 'Recommendation: Unfavorable');
+
     assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpConsideration]').textContent.trim().includes('My comment for all actions'), 'Confirmation modal shows dcpConsideration for all actions.');
 
     await click('[data-test-submit]');
@@ -478,7 +479,7 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
 
     assert.equal(this.element.querySelector('[data-test-quorum-answer="0').textContent.trim(), 'No', 'Confirmation modal shows answer to first quorum quesiton');
 
-    assert.equal(this.element.querySelector('[data-test-confirmation-all-actions-recommendation]').textContent.trim(), 'Unfavorable');
+    assert.equal(this.element.querySelector('[data-test-confirmation-all-actions-recommendation]').textContent.trim(), 'Recommendation: Unfavorable');
 
     assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpVotinginfavorrecommendation]').textContent.trim().includes('1'), 'Confirmation modal shows votes in favor for all actions');
     assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpVotingagainstrecommendation]').textContent.trim().includes('2'), 'Confirmation modal shows votes against for all actions');
@@ -486,7 +487,7 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
     assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpTotalmembersappointedtotheboard]').textContent.trim().includes('4'), 'Confirmation modal shows total members appointed for all actions');
 
     assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpVotelocation]').textContent.trim().includes('Smith Street'), 'Confirmation modal shows vote location for all actions.');
-    assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpDateofvote]').textContent.includes('Thu Oct 17 2019'), 'Confirmation modal shows date of vote for all actions.');
+    assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpDateofvote]').textContent.includes('10/17/2019'), 'Confirmation modal shows date of vote for all actions.');
     assert.ok(this.element.querySelector('[data-test-confirmation-all-actions-dcpConsideration]').textContent.trim().includes('My All Actions Comment'), 'Confirmation modal shows dcpConsideration for all actions.');
 
     await click('[data-test-submit]');


### PR DESCRIPTION
This PR cleans up the design of the hearing and recommendation confirmation modals. Mostly this is adjusting layout. Also little bit of code formatting (indents). 

The biggest change here @NYCPlanning/engineering should review is I've wrapped an `{{unless assignment.hearingsWaived}}` around the quorum information in the confirmation modal. I did so because the modal was showing the "was a quorum present" question and looping through the empty dispositions if there were hearings. 