### PR TITLE
⏮ Bring back the project-list-map-pin component 

### DIFF
--- a/app/components/project-list-map-pin.js
+++ b/app/components/project-list-map-pin.js
@@ -1,0 +1,28 @@
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
+import { classNames, tagName } from '@ember-decorators/component';
+
+@tagName('a')
+@classNames('button hollow expanded map-marker-button')
+export default class ProjectListMapPinComponent extends Component {
+  @service resultMapEvents;
+
+  // required
+  // @argument
+  project = null;
+
+  mouseEnter() {
+    const { id } = this.project;
+
+    this.resultMapEvents.trigger('hover', { id, layerId: 'project-centroids-circle-hover' });
+  }
+
+  mouseLeave() {
+    this.resultMapEvents.trigger('unhover', { layerId: 'project-centroids-circle-hover' });
+  }
+
+  click () {
+    const { project } = this;
+    this.resultMapEvents.trigger('click', { project, layerId: 'project-centroids-circle' });
+  }
+}

--- a/app/templates/components/project-list-item.hbs
+++ b/app/templates/components/project-list-item.hbs
@@ -1,13 +1,14 @@
 <li class="grid-x grid-padding-small projects-list-result">
   <div class="cell results-meta {{if project.dcpPublicstatusSimp (concat 'publicstatus-' (dasherize project.dcpPublicstatusSimp))}}" style="width:5rem;">
-    {{!-- commented out because it was if-gated by .has_centroid which --}}
-    {{!-- no longer exists --}}
-    {{!-- project-list-map-pin project=project --}}
-    <a class="button hollow expanded map-marker-button" style="opacity:1;" disabled>
-      <span class="fa-layers fa-fw" style="font-size: 1.5rem;">
-        <span class="fa-layers-text" style="font-size:0.625rem;color:#000;">Not Mapped</span>
-      </span>
-    </a>
+    {{#if project.hasCentroid}}
+      {{project-list-map-pin project=project}}
+    {{else}}
+      <a class="button hollow expanded map-marker-button" style="opacity:1;" disabled>
+        <span class="fa-layers fa-fw" style="font-size: 1.5rem;">
+          <span class="fa-layers-text" style="font-size:0.625rem;color:#333;">Not Mapped</span>
+        </span>
+      </a>
+    {{/if}}
     <span class="label publicstatus-label">{{unless (eq project.dcpPublicstatusSimp 'Unknown') project.dcpPublicstatusSimp "Unknown Status"}}</span>
   </div>
   <div class="cell auto">

--- a/app/templates/components/project-list-map-pin.hbs
+++ b/app/templates/components/project-list-map-pin.hbs
@@ -1,0 +1,3 @@
+<span class="fa-layers fa-fw" style="font-size: 1.5rem;">
+  {{fa-icon 'map-marker-alt' fixedWidth=true}}
+</span>

--- a/tests/integration/components/project-list-map-pin-test.js
+++ b/tests/integration/components/project-list-map-pin-test.js
@@ -1,0 +1,26 @@
+import { module, skip } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | project-list-map-pin', function(hooks) {
+  setupRenderingTest(hooks);
+
+  skip('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{project-list-map-pin}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#project-list-map-pin}}
+        template block text
+      {{/project-list-map-pin}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});


### PR DESCRIPTION
This PR fixes the issue where all projects (regardless of having geoms) are listing as "Not Mapped" in Search, and none had a pin so couldn't be hovered to show their location. The solution was re-add the `{{project-list-map-pin}}` component (which was deleted in 2d44735fe7ad03f13212c6e6e944edd1bad3245f) and re-add the logic for which pin color/status to show (which was removed in edd346dabd4f1e604ef141959301e140ae2da6e0). 