### PR TITLE
895: check that dcpRecommendationsubmittedbyname is not NULL

### DIFF
--- a/app/components/hearings-list-for-milestones-list.js
+++ b/app/components/hearings-list-for-milestones-list.js
@@ -68,13 +68,23 @@ export default class HearingsListForMilestonesListComponent extends Component {
     const dispositions = milestone.get('project.dispositions');
     const milestoneParticipantReviewLookup = this.get('milestoneParticipantReviewLookup');
 
+    const filteredDispositionsArray = [];
+
     // Iterate through ALL of the current project's dispositions.
     // Filter by IF a single disposition's dcpRecommendationsubmittedbyname matches the
     // current milestone's displayName based on the milestoneParticipantReviewLookup.
     // disposition.dcpRecommendationsubmittedbyname = e.g. 'QNBP'
     // disposition.dcpRecommendationsubmittedbyname.substring(2,4) = e.g. 'BP'
     // matching e.g. 'BP' with the milestoneParticipantReviewLookup provides 'Borough President Review'
-    return dispositions.filter(disposition => milestoneParticipantReviewLookup[milestone.displayName] === disposition.dcpRecommendationsubmittedbyname.substring(2, 4));
+    dispositions.forEach(function(disposition) {
+      // make sure that dcpRecommendationsubmittedbyname is not NULL
+      if (disposition.dcpRecommendationsubmittedbyname) {
+        if (milestoneParticipantReviewLookup[milestone.displayName] === disposition.dcpRecommendationsubmittedbyname.substring(2, 4)) {
+          filteredDispositionsArray.push(disposition);
+        }
+      }
+    });
+    return filteredDispositionsArray;
   }
 
   // An array of objects that contain the `landUseParticipantFullName` value and an array of dispositions that match that landUseParticipantFullName

--- a/tests/acceptance/hearings-list-for-milestones-list-shows-up-correctly-test.js
+++ b/tests/acceptance/hearings-list-for-milestones-list-shows-up-correctly-test.js
@@ -723,4 +723,103 @@ module('Acceptance | hearings list for milestones list shows up correctly', func
     assert.ok(this.element.querySelector('[data-test-hearing-location="18"]').textContent.includes('Green Street'));
     assert.ok(this.element.querySelector('[data-test-hearing-date="18"]').textContent.includes('April 21'));
   });
+
+  test('hearings-list-for-milestones-list does not break when NULL value for dcpRecommendationsubmittedbyname on upcoming tab', async function(assert) {
+    this.server.create('assignment', {
+      id: 5,
+      tab: 'upcoming',
+      dispositions: [
+        server.create('disposition', {
+          id: 17,
+          dcpPublichearinglocation: 'Purple Street',
+          dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
+          dcpRecommendationsubmittedbyname: null,
+          action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+        }),
+      ],
+      project: this.server.create('project', {
+        dispositions: [
+          server.create('disposition', {
+            id: 17,
+            dcpPublichearinglocation: 'Purple Street',
+            dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
+            // database has many null values for this field dcpRecommendationsubmittedbyname
+            dcpRecommendationsubmittedbyname: null,
+            action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+          }),
+        ],
+        milestones: [
+          server.create('milestone', {
+            displayName: 'Land Use Application Filed',
+            dcpMilestonesequence: 26,
+            milestonename: 'Land Use Application Filed',
+            dcpMilestone: '663beec4-dad0-e711-8116-1458d04e2fb8',
+            dcpMilestoneoutcome: null,
+            displayDate2: null,
+            displayDate: '2019-07-13T19:31:57.763Z',
+            statuscode: 'Completed',
+            dcpActualenddate: null,
+            dcpActualstartdate: '2019-07-13T19:31:57.763Z',
+            dcpPlannedcompletiondate: null,
+            dcpPlannedstartdate: null,
+            id: '1',
+          }),
+          server.create('milestone', {
+            displayName: 'Application Reviewed at City Planning Commission Review Session',
+            dcpMilestonesequence: 46,
+            milestonename: 'Application Reviewed at City Planning Commission Review Session',
+            dcpMilestone: '8e3beec4-dad0-e711-8116-1458d04e2fb8',
+            milestoneLinks: [],
+            dcpMilestoneoutcome: null,
+            displayDate2: null,
+            displayDate: '2019-10-18T19:31:57.916Z',
+            statuscode: 'Not Started',
+            dcpActualenddate: null,
+            dcpActualstartdate: '2019-10-18T19:31:57.916Z',
+            dcpPlannedcompletiondate: null,
+            dcpPlannedstartdate: null,
+            id: '11',
+          }),
+          server.create('milestone', {
+            displayName: 'Community Board Review',
+            dcpMilestonesequence: 48,
+            milestonename: 'Community Board Review',
+            dcpMilestone: '923beec4-dad0-e711-8116-1458d04e2fb8',
+            milestoneLinks: [],
+            dcpMilestoneoutcome: null,
+            displayDate2: null,
+            displayDate: '2019-11-17T20:31:57.956Z',
+            statuscode: 'Not Started',
+            dcpActualenddate: null,
+            dcpActualstartdate: null,
+            dcpPlannedcompletiondate: null,
+            dcpPlannedstartdate: '2019-11-17T20:31:57.956Z',
+            id: '12',
+          }),
+          server.create('milestone', {
+            displayName: 'Borough Board Review',
+            dcpMilestonesequence: 50,
+            milestonename: 'Borough Board Review',
+            dcpMilestone: '963beec4-dad0-e711-8116-1458d04e2fb8',
+            milestoneLinks: [],
+            dcpMilestoneoutcome: null,
+            displayDate2: '2019-11-06T20:31:58.519Z',
+            displayDate: '2019-10-07T19:31:58.519Z',
+            statuscode: 'In Progress',
+            dcpActualenddate: '2019-11-06T20:31:58.519Z',
+            dcpActualstartdate: '2019-10-07T19:31:58.519Z',
+            dcpPlannedcompletiondate: null,
+            dcpPlannedstartdate: null,
+            id: '38',
+          }),
+        ],
+      }),
+    });
+
+    await visit('/my-projects/upcoming');
+
+    // make sure that milestones list on assignment card shows up
+    assert.ok(find('[data-test-milestone-id="12"]'), 'community board milestone');
+    assert.ok(find('[data-test-milestone-id="38"]'), 'borough board milestone');
+  });
 });


### PR DESCRIPTION
This is a temporary fix for Issue #895 

Because many of the values in the database for the field `dcpRecommendationsubmittedbyname` are `NULL`, `hearings-list-for-milestones-list` will often break when it tries to match this field with the corresponding milestone. 

This temporary fix is coupled with a backend change of adding `dcpRecommendationsubmittedbyname` as a field to dispositions in the API. 

New test written for the bug

To-Do: Figure out better way to fix this problem based on data we have