### PR TITLE
877: fix broken ceqr link on show-project page

### DIFF
--- a/app/helpers/build-url.js
+++ b/app/helpers/build-url.js
@@ -1,5 +1,4 @@
 import { helper } from '@ember/component/helper';
-import ENV from 'labs-zap-search/config/environment';
 
 function pad(string, size) {
   while (string.length < (size || 2)) { string = `0${string}`; }
@@ -57,10 +56,6 @@ function acris(bbl) {
   return `http://a836-acris.nyc.gov/bblsearch/bblsearch.asp?borough=${boro}&block=${block}&lot=${lot}`;
 }
 
-function ceqraccess(ceqrnumber) {
-  return `${ENV.host}/ceqr/${ceqrnumber}`;
-}
-
 function LowerCaseBorough(borough) {
   const boroText = borough.replace(/\s/g, '-');
   return boroText.toLowerCase();
@@ -77,7 +72,6 @@ export function buildUrl([type, value, option]) {
   if (type === 'bisweb') return bisweb(value);
   if (type === 'cpcReport') return cpcReport(value);
   if (type === 'acris') return acris(value);
-  if (type === 'ceqraccess') return ceqraccess(value);
   if (type === 'CommProfiles') return CommProfiles(value, option);
 
 

--- a/app/templates/show-project.hbs
+++ b/app/templates/show-project.hbs
@@ -206,13 +206,13 @@
 
         <div class="project-meta">
 
-{{!--           {{#if (or model.dcpCeqrtype model.dcpCeqrnumber)}}
+          {{#if (or model.dcpCeqrtype model.dcpCeqrnumber)}}
             <p class="text-small label-group">
               <strong>CEQR<sup class="dark-gray">{{icon-tooltip tip='City Environmental Quality Review. Only certain minor actions, known as Type II actions, are exempt from environmental review.'}}</sup>:</strong>
               {{#if model.dcpCeqrtype}}<span class="label light-gray">{{model.dcpCeqrtype}}</span>{{/if~}}
-              {{#if model.dcpCeqrnumber}}<span class="label light-gray"><a href="{{build-url "ceqraccess" model.dcpCeqrnumber}}" target="_blank">{{model.dcpCeqrnumber}} {{fa-icon 'external-link-alt'}}</a></span>{{/if~}}
+              {{#if model.dcpCeqrnumber}}<span class="label light-gray"><a href="https://a002-ceqraccess.nyc.gov/ceqr/" target="_blank">{{model.dcpCeqrnumber}} {{fa-icon 'external-link-alt'}}</a></span>{{/if~}}
             </p>
-          {{/if}} --}}
+          {{/if}}
 
           <p class="text-small label-group">
             <strong>Keywords:</strong>


### PR DESCRIPTION
Originally, CEQR link on show-project page was going to a broken link. This PR just replaces that link with the generic CEQR search page https://a002-ceqraccess.nyc.gov/ceqr/

Closes #877 