### PR TITLE
show disabled assignment buttons

### DIFF
--- a/app/styles/modules/_m-forms.scss
+++ b/app/styles/modules/_m-forms.scss
@@ -85,3 +85,16 @@
     margin: 0;
   }
 }
+
+
+//
+// Hearing opt-out notice
+// --------------------------------------------------
+.opt-out-notice {
+  @include button(true, $off-white, $off-white, $black, solid);
+  cursor: default;
+
+  svg {
+    color: $gray;
+  }
+}

--- a/app/templates/components/to-review-project-card.hbs
+++ b/app/templates/components/to-review-project-card.hbs
@@ -37,6 +37,41 @@
       </div>
     </div>
     <div class="cell medium-8 large-auto">
+
+      {{#if assignment.hearingsNotSubmittedNotWaived}}
+        <div class="grid-x">
+          <div class="cell medium-auto">
+            <LinkTo
+              @route="my-projects.assignment.hearing.add"
+              @model={{assignment}}
+              class="button expanded tiny-margin-bottom"
+              data-test-button="submitHearing"
+            >
+              {{fa-icon 'calendar' fixedWidth=true size="lg" transform="left-2"}}
+              Post {{participant-type-label assignment.dcpLupteammemberrole}} Hearing Notice
+            </LinkTo>
+          </div>
+          <div class="cell medium-shrink">
+            <button
+              class="button expanded gray"
+              onClick={{action "openOptOutHearingPopup"}}
+              data-test-button="optOutHearingOpenPopup"
+            >
+              {{fa-icon 'calendar-times' size="lg" transform="shrink-5 down-1"}}
+              <small>Opt Out</small>
+            </button>
+            {{waive-hearings-popup assignment=assignment showPopup=showPopup}}
+          </div>
+        </div>
+      {{else}}
+        {{#if assignment.hearingsWaived}}
+          <span class="opt-out-notice" data-test-hearings-waived-message="{{assignment.project.id}}">
+            {{fa-icon 'calendar-times' size="lg" transform="left-2"}}
+            You've opted out of posting a hearing
+          </span>
+        {{/if}}
+      {{/if}}
+
       {{#if assignment.hearingsSubmittedOrWaived}}
         <LinkTo @route="my-projects.assignment.recommendations.add"
           @model={{assignment}}
@@ -47,9 +82,12 @@
           {{fa-icon 'thumbs-down' fixedWidth=true size="lg" transform="flip-h left-2"}}
           Submit {{participant-type-label assignment.dcpLupteammemberrole}} Recommendation
         </LinkTo>
-      {{/if}}
-      {{#if assignment.hearingsWaived}}
-        <span data-test-hearings-waived-message="{{assignment.project.id}}">You've opted out of noticing a public hearing.</span>
+      {{else}}
+        <a class="button expanded" disabled>
+          {{fa-icon 'thumbs-up' fixedWidth=true size="lg"}}
+          {{fa-icon 'thumbs-down' fixedWidth=true size="lg" transform="flip-h left-2"}}
+          Submit {{participant-type-label assignment.dcpLupteammemberrole}} Recommendation
+        </a>
       {{/if}}
 
       {{#if assignment.hearingsSubmitted}}
@@ -95,32 +133,6 @@
         {{/deduped-hearings-list}}
       {{/if}}
 
-      {{#if assignment.hearingsNotSubmittedNotWaived}}
-        <div class="grid-x">
-          <div class="cell medium-auto">
-            <LinkTo
-              @route="my-projects.assignment.hearing.add"
-              @model={{assignment}}
-              class="button expanded tiny-margin-bottom"
-              data-test-button="submitHearing"
-            >
-              {{fa-icon 'calendar' fixedWidth=true size="lg" transform="left-2"}}
-              Post {{participant-type-label assignment.dcpLupteammemberrole}} Hearing Notice
-            </LinkTo>
-          </div>
-          <div class="cell medium-shrink">
-            <button
-              class="button expanded gray"
-              onClick={{action "openOptOutHearingPopup"}}
-              data-test-button="optOutHearingOpenPopup"
-            >
-              {{fa-icon 'calendar-times' size="lg" transform="shrink-5 down-1"}}
-              <small>Opt Out</small>
-            </button>
-            {{waive-hearings-popup assignment=assignment showPopup=showPopup}}
-          </div>
-        </div>
-      {{/if}}
     </div>
   </div>
 </div>

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -69,10 +69,16 @@
               {{fa-icon 'calendar-times' size="lg" transform="shrink-5 down-1"}}
               <small>Opt Out</small>
             </button>
-
             {{waive-hearings-popup assignment=this.assignment showPopup=showPopup}}
           </div>
         </div>
+      {{else}}
+        {{#if assignment.hearingsWaived}}
+          <span class="opt-out-notice" data-test-hearings-waived-message="{{assignment.project.id}}">
+            {{fa-icon 'calendar-times' size="lg" transform="left-2"}}
+            You've opted out of posting a hearing
+          </span>
+        {{/if}}
       {{/if}}
       <ul class="no-bullet no-margin">
         {{#each this.assignment.assigneeDisplayMilestones as |milestone idx|}}

--- a/tests/integration/components/to-review-project-card-test.js
+++ b/tests/integration/components/to-review-project-card-test.js
@@ -158,7 +158,7 @@ module('Integration | Component | to-review-project-card', function(hooks) {
 
     const card = this.element.textContent.trim();
 
-    assert.ok(card.includes("You've opted out of noticing a public hearing."));
+    assert.ok(card.includes("You've opted out of posting a hearing"));
     assert.notOk(card.includes('Opt out'));
     assert.notOk(card.includes('Post Community Board Hearing Notice'));
   });


### PR DESCRIPTION
This PR updates the assignment cards layout to show the hearing/recommendation buttons as disabled until they can be used. This is in response to usability testing in which users were confused as to the button changing (per @papersix). 

**Default state:** 
Recommendation button disabled

![image](https://user-images.githubusercontent.com/409279/68798098-cb245780-0623-11ea-95c6-59d8d652ae88.png)

**Opted out:** 
Hearing button replaced by message, recommendation button active

![image](https://user-images.githubusercontent.com/409279/68798149-e0998180-0623-11ea-939a-b2d8fdc6f712.png)

**Hearing submitted:** 
Hearing button replaced by hearings list, recommendation button active

![image](https://user-images.githubusercontent.com/409279/68798217-fdce5000-0623-11ea-8f00-f1a6ed04f96a.png)
