### PR TITLE
Create disposition specific queues with copies of each file

### DIFF
--- a/app/components/document-upload-form.js
+++ b/app/components/document-upload-form.js
@@ -3,4 +3,6 @@ import Component from '@ember/component';
 export default class DocumentUploadForm extends Component {
   // name of the queue
   queueName = 'application'
+
+  onFileAdd = () => {};
 }

--- a/app/templates/components/document-upload-form.hbs
+++ b/app/templates/components/document-upload-form.hbs
@@ -15,6 +15,7 @@
         @name={{concat this.queueName}}
         @accept='*/*'
         @multiple=true
+        @onfileadd={{this.onFileAdd}}
         class="button gray no-margin"
       >
         {{fa-icon 'upload'}} Choose Files

--- a/app/templates/my-projects/assignment/recommendations/add.hbs
+++ b/app/templates/my-projects/assignment/recommendations/add.hbs
@@ -496,6 +496,7 @@
             {{/if}}
             <DocumentUploadForm
               @queueName={{this.queueName}}
+              @onFileAdd={{this.addFileToDispositionQueues}}
             />
             <hr>
             <fieldset class="medium-margin-bottom">

--- a/tests/unit/controllers/my-projects/assignment/recommendations/add-test.js
+++ b/tests/unit/controllers/my-projects/assignment/recommendations/add-test.js
@@ -17,12 +17,12 @@ module('Unit | Controller | my-projects/assignment/recommendations/add', functio
 
     // DISPOSITIONS THAT REPRESENT THE MODEL'S DISPOSITIONS ARRAY (project.dispositions)
     const disp1 = disp.create({
-      id: 1,
+      id: '1',
       dcpWasaquorumpresent: null,
     });
 
     const disp2 = disp.create({
-      id: 2,
+      id: '2',
       dcpWasaquorumpresent: null,
     });
 
@@ -42,15 +42,15 @@ module('Unit | Controller | my-projects/assignment/recommendations/add', functio
     // DISPOSITIONS THAT REPRESENT THE OBJECTS WITHIN THE dedupedHearings ARRAY
     // a dedupedHearing object that has 3 duplicate dispositions
     const dedupedHearing1 = disp.create({
-      id: 1,
+      id: '1',
       dcpWasaquorumpresent: null,
       duplicateDisps: [
         disp.create({
-          id: 1,
+          id: '1',
           dcpWasaquorumpresent: null,
         }),
         disp.create({
-          id: 2,
+          id: '2',
           dcpWasaquorumpresent: null,
         }),
         disp.create({
@@ -154,15 +154,20 @@ module('Unit | Controller | my-projects/assignment/recommendations/add', functio
 
     controller.transitionToRoute = function() { return true; };
 
-    controller.set('recommendationAddQueue', {
-      files: [],
+    controller.set('queuesByDisposition', {
+      1: {
+        files: [],
+      },
+      2: {
+        files: [],
+      },
     });
 
     controller.set('allActions', true);
 
     controller.set('model', { dcpLupteammemberrole: 'CB' });
 
-    controller.set('dispositions', [EmberObject.create(), EmberObject.create()]);
+    controller.set('dispositions', [EmberObject.create({ id: '1' }), EmberObject.create({ id: '2' })]);
 
     controller.dispositions[0].save = function() {
       return true;
@@ -207,15 +212,20 @@ module('Unit | Controller | my-projects/assignment/recommendations/add', functio
 
     controller.transitionToRoute = function() { return true; };
 
-    controller.set('recommendationAddQueue', {
-      files: [],
+    controller.set('queuesByDisposition', {
+      1: {
+        files: [],
+      },
+      2: {
+        files: [],
+      },
     });
 
     controller.set('allActions', false);
 
     controller.set('model', { dcpLupteammemberrole: 'CB' });
 
-    controller.set('dispositions', [EmberObject.create(), EmberObject.create()]);
+    controller.set('dispositions', [EmberObject.create({ id: '1' }), EmberObject.create({ id: '2' })]);
 
     controller.dispositions[0].save = function() {
       return true;
@@ -269,12 +279,12 @@ module('Unit | Controller | my-projects/assignment/recommendations/add', functio
     const modelObject = EmberObject.extend({});
 
     const disp1 = modelObject.create({
-      id: 1,
+      id: '1',
       statuscode: '',
     });
 
     const disp2 = modelObject.create({
-      id: 2,
+      id: '2',
       statuscode: '',
     });
 
@@ -285,8 +295,13 @@ module('Unit | Controller | my-projects/assignment/recommendations/add', functio
       assert.equal(route, 'my-projects/assignment/recommendations/done');
     };
 
-    controller.set('recommendationAddQueue', {
-      files: [],
+    controller.set('queuesByDisposition', {
+      1: {
+        files: [],
+      },
+      2: {
+        files: [],
+      },
     });
 
     controller.dispositions = dispositions;


### PR DESCRIPTION
This PR breaks out the universal file queue into queues for each disposition. 
 
Each disposition queue will have a copy of each file uploaded. This is necessary to prevent the file from being flushed from every one of its parent queues (and previously from the universal queue) after it is successfully uploaded once for the first disposition.

This may also help with the any future plans to upload different files to each disposition.

