### PR TITLE
update tab header language

### DIFF
--- a/app/templates/my-projects/archive-loading.hbs
+++ b/app/templates/my-projects/archive-loading.hbs
@@ -1,4 +1,7 @@
-<h4>Archive of projects that you have reviewed which are no longer in the public review process</h4>
+<h4>
+  Archive:
+  <span class="text-weight-normal">Projects that you have reviewed which are no longer in the public review process</span>
+</h4>
 
 <div class="text-center large-margin-top large-padding-top" style="padding:3rem 0;">
   {{fa-icon 'spinner' spin="true" size="5x" class="light-gray"}}

--- a/app/templates/my-projects/archive.hbs
+++ b/app/templates/my-projects/archive.hbs
@@ -1,4 +1,7 @@
-<h4>Archive of projects that you have reviewed which are no longer in the public review process</h4>
+<h4>
+  Archive:
+  <span class="text-weight-normal">Projects that you have reviewed which are no longer in the public review process</span>
+</h4>
 
 {{#each sortedAssignments as |assignment|}}
   <ArchiveProjectCard @assignment={{assignment}} />

--- a/app/templates/my-projects/reviewed-loading.hbs
+++ b/app/templates/my-projects/reviewed-loading.hbs
@@ -1,4 +1,7 @@
-<h4>Projects that you have reviewed which are still in the public review process</h4>
+<h4>
+  Reviewed:
+  <span class="text-weight-normal">Projects that you have reviewed which are still in the public review process</span>
+</h4>
 
 <div class="text-center large-margin-top large-padding-top" style="padding:3rem 0;">
   {{fa-icon 'spinner' spin="true" size="5x" class="light-gray"}}

--- a/app/templates/my-projects/reviewed.hbs
+++ b/app/templates/my-projects/reviewed.hbs
@@ -1,4 +1,7 @@
-<h4>Projects that you have reviewed which are still in the public review process</h4>
+<h4>
+  Reviewed:
+  <span class="text-weight-normal">Projects that you have reviewed which are still in the public review process</span>
+</h4>
 
 {{#each sortedAssignments as |assignment|}}
   <ReviewedProjectCard @assignment={{assignment}} />

--- a/app/templates/my-projects/to-review-loading.hbs
+++ b/app/templates/my-projects/to-review-loading.hbs
@@ -1,4 +1,7 @@
-<h4>Projects that require you to submit your hearing dates and recommendations</h4>
+<h4>
+  To Review:
+  <span class="text-weight-normal">Projects subject to ULURP and/or referred out for your review</span>
+</h4>
 
 <div class="text-center large-margin-top large-padding-top" style="padding:3rem 0;">
   {{fa-icon 'spinner' spin="true" size="5x" class="light-gray"}}

--- a/app/templates/my-projects/to-review.hbs
+++ b/app/templates/my-projects/to-review.hbs
@@ -1,4 +1,7 @@
-<h4>Projects that require you to submit your hearing dates and recommendations</h4>
+<h4>
+  To Review:
+  <span class="text-weight-normal">Projects subject to ULURP and/or referred out for your review</span>
+</h4>
 
 {{#if this.model}}
   {{#each sortedProjects as |assignment|}}

--- a/app/templates/my-projects/upcoming-loading.hbs
+++ b/app/templates/my-projects/upcoming-loading.hbs
@@ -1,4 +1,7 @@
-<h4>Recently filed projects that you'll soon need to review</h4>
+<h4>
+  Upcoming: 
+  <span class="text-weight-normal">Projects that will be subject to ULURP and/or referred out for your review</span>
+</h4>
 
 <div class="text-center large-margin-top large-padding-top" style="padding:3rem 0;">
   {{fa-icon 'spinner' spin="true" size="5x" class="light-gray"}}

--- a/app/templates/my-projects/upcoming.hbs
+++ b/app/templates/my-projects/upcoming.hbs
@@ -1,4 +1,7 @@
-<h4>Recently filed projects that you'll soon need to review</h4>
+<h4>
+  Upcoming:
+  <span class="text-weight-normal">Projects that will be subject to ULURP and/or referred out for your review</span>
+</h4>
 
 {{#each sortedProjects as |assignment|}}
   {{upcoming-project-card assignment=assignment}}


### PR DESCRIPTION
This PR replaces the language in the tab headers to not use the words "require" or "soon." Substitutes some approved legalese. 😒

![image](https://user-images.githubusercontent.com/409279/68894594-97b1fd80-06f5-11ea-9110-6e5eb1d1c498.png)
![image](https://user-images.githubusercontent.com/409279/68894604-a00a3880-06f5-11ea-9a3c-72f4f7558455.png)
![image](https://user-images.githubusercontent.com/409279/68894630-a8fb0a00-06f5-11ea-853e-a6279c5858ce.png)
![image](https://user-images.githubusercontent.com/409279/68894649-b0221800-06f5-11ea-9382-bc76722834e4.png)
