### PR TITLE
improve the contact info message at the bottom of the tabs

### DIFF
--- a/app/templates/my-projects/archive.hbs
+++ b/app/templates/my-projects/archive.hbs
@@ -8,17 +8,17 @@
     <ArchiveProjectCard @assignment={{assignment}} />
   {{/each}}
 {{else}}
-  <div class="grid-container">
-    <div class="grid-x grid-padding-x grid-padding-y align-middle" style="min-height: 50vh">
-      <div class="cell large-10 large-offset-1 xlarge-8 xlarge-offset-2  text-center">
-        <h2 class="charcoal">You currently have no archived&nbsp;projects.</h2>
-        <p class="lead">If something has gone wrong, or you believe projects are missing from this&nbsp;list, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or 212-720-3300.</p>
-      </div>
+  <div class="grid-x grid-padding-x grid-padding-y align-bottom" style="min-height: 20vh">
+    <div class="cell large-10 large-offset-1 xlarge-8 xlarge-offset-2  text-center">
+      <h2 class="charcoal">You currently have no archived&nbsp;projects.</h2>
     </div>
   </div>
 {{/if}}
 
+<div class="grid-x grid-padding-x grid-padding-y">
+  <div class="cell large-10 large-offset-1 xlarge-8 xlarge-offset-2  text-center">
+    <p class="">If something has gone wrong, or you believe projects are missing from this&nbsp;list, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or 212-720-3300.</p>
+  </div>
+</div>
+
 {{outlet}}
-
-
- ZAP_feedback_DL@planning.nyc.gov or 212-720-3300

--- a/app/templates/my-projects/reviewed.hbs
+++ b/app/templates/my-projects/reviewed.hbs
@@ -8,14 +8,17 @@
     <ReviewedProjectCard @assignment={{assignment}} />
   {{/each}}
 {{else}}
-  <div class="grid-container">
-    <div class="grid-x grid-padding-x grid-padding-y align-middle" style="min-height: 50vh">
-      <div class="cell large-10 large-offset-1 xlarge-8 xlarge-offset-2  text-center">
-        <h2 class="charcoal">You currently have no reviewed&nbsp;projects.</h2>
-        <p class="lead">If something has gone wrong, or you believe projects are missing from this&nbsp;list, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or 212-720-3300.</p>
-      </div>
+  <div class="grid-x grid-padding-x grid-padding-y align-bottom" style="min-height: 20vh">
+    <div class="cell large-10 large-offset-1 xlarge-8 xlarge-offset-2  text-center">
+      <h2 class="charcoal">You currently have no reviewed&nbsp;projects.</h2>
     </div>
   </div>
 {{/if}}
+
+<div class="grid-x grid-padding-x grid-padding-y">
+  <div class="cell large-10 large-offset-1 xlarge-8 xlarge-offset-2  text-center">
+    <p class="">If something has gone wrong, or you believe projects are missing from this&nbsp;list, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or 212-720-3300.</p>
+  </div>
+</div>
 
 {{outlet}}

--- a/app/templates/my-projects/to-review.hbs
+++ b/app/templates/my-projects/to-review.hbs
@@ -8,14 +8,17 @@
     {{to-review-project-card assignment=assignment}}
   {{/each}}
 {{else}}
-  <div class="grid-container">
-    <div class="grid-x grid-padding-x grid-padding-y align-middle" style="min-height: 50vh">
-      <div class="cell large-10 large-offset-1 xlarge-8 xlarge-offset-2  text-center">
-        <h2 class="charcoal">You currently have no projects to&nbsp;review.</h2>
-        <p class="lead">If something has gone wrong, or you believe projects are missing from this&nbsp;list, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or 212-720-3300.</p>
-      </div>
+  <div class="grid-x grid-padding-x grid-padding-y align-bottom" style="min-height: 20vh">
+    <div class="cell large-10 large-offset-1 xlarge-8 xlarge-offset-2  text-center">
+      <h2 class="charcoal">You currently have no projects to&nbsp;review.</h2>
     </div>
   </div>
 {{/if}}
+
+<div class="grid-x grid-padding-x grid-padding-y">
+  <div class="cell large-10 large-offset-1 xlarge-8 xlarge-offset-2  text-center">
+    <p class="">If something has gone wrong, or you believe projects are missing from this&nbsp;list, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or 212-720-3300.</p>
+  </div>
+</div>
 
 {{outlet}}

--- a/app/templates/my-projects/upcoming.hbs
+++ b/app/templates/my-projects/upcoming.hbs
@@ -8,14 +8,17 @@
     {{upcoming-project-card assignment=assignment}}
   {{/each}}
 {{else}}
-  <div class="grid-container">
-    <div class="grid-x grid-padding-x grid-padding-y align-middle" style="min-height: 50vh">
-      <div class="cell large-10 large-offset-1 xlarge-8 xlarge-offset-2  text-center">
-        <h2 class="charcoal">You currently have no upcoming&nbsp;projects.</h2>
-        <p class="lead">If something has gone wrong, or you believe projects are missing from this&nbsp;list, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or 212-720-3300.</p>
-      </div>
+  <div class="grid-x grid-padding-x grid-padding-y align-bottom" style="min-height: 20vh">
+    <div class="cell large-10 large-offset-1 xlarge-8 xlarge-offset-2  text-center">
+      <h2 class="charcoal">You currently have no upcoming&nbsp;projects.</h2>
     </div>
   </div>
 {{/if}}
+
+<div class="grid-x grid-padding-x grid-padding-y">
+  <div class="cell large-10 large-offset-1 xlarge-8 xlarge-offset-2  text-center">
+    <p class="">If something has gone wrong, or you believe projects are missing from this&nbsp;list, please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or 212-720-3300.</p>
+  </div>
+</div>
 
 {{outlet}}


### PR DESCRIPTION
This PR puts the contact info at the bottom of every tab, regardless of if there's a "nor projects" message.

![image](https://user-images.githubusercontent.com/409279/68954765-ad293500-0792-11ea-8430-e09abc7492a6.png)
 

_* inspired by an accidentally pasted cruft on the Archive tab_ 

![image](https://user-images.githubusercontent.com/409279/68954818-c29e5f00-0792-11ea-8b02-3c5e32da2d76.png)
