### PR TITLE
900: fix waive hearings by adding .save()

### DIFF
--- a/app/components/waive-hearings-popup.js
+++ b/app/components/waive-hearings-popup.js
@@ -1,25 +1,28 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
 
-// set property in each object of the array to same value
-export function updateEachObjectInArray(records = [], prop, newVal) {
-  records.setEach(prop, newVal);
-}
-
 export default class WaiveHearingsPopupComponent extends Component {
   showPopup = false;
 
   // run function updateEachObjectInArray on dispositions array
   // occurs when a user chooses to opt out of hearings for their project
   @action
-  onConfirmOptOutHearing(dispositions) {
-    updateEachObjectInArray(dispositions, 'dcpIspublichearingrequired', 'No');
-    this.set('showPopup', false);
+  async onConfirmOptOutHearing(assignment) {
+    const { dispositions } = assignment;
+    dispositions.setEach('dcpIspublichearingrequired', 'No');
+
+    try {
+      await dispositions.save();
+      this.set('showPopup', false);
+    } catch (e) {
+      dispositions.setEach('dcpIspublichearingrequired', '');
+      this.set('error', e);
+    }
   }
 
   // when a user clicks "cancel" button on opt out of hearings confirmation popup
   @action
-  closeOptOutHearingPopup() {
+  closeModal() {
     this.set('showPopup', false);
   }
 }

--- a/app/templates/components/to-review-project-card.hbs
+++ b/app/templates/components/to-review-project-card.hbs
@@ -60,7 +60,6 @@
               {{fa-icon 'calendar-times' size="lg" transform="shrink-5 down-1"}}
               <small>Opt Out</small>
             </button>
-            {{waive-hearings-popup assignment=assignment showPopup=showPopup}}
           </div>
         </div>
       {{else}}
@@ -89,6 +88,7 @@
           Submit {{participant-type-label assignment.dcpLupteammemberrole}} Recommendation
         </a>
       {{/if}}
+      {{waive-hearings-popup assignment=assignment showPopup=showPopup}}
 
       {{#if assignment.hearingsSubmitted}}
         {{#deduped-hearings-list dispositions=assignment.dispositions as |dedupedHearings|}}

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -70,7 +70,6 @@
                 {{fa-icon 'calendar-times' size="lg" transform="shrink-5 down-1"}}
                 <small>Opt Out</small>
               </button>
-              {{waive-hearings-popup assignment=this.assignment showPopup=showPopup}}
             </div>
           </div>
         {{else}}
@@ -82,6 +81,7 @@
           {{/if}}
         {{/if}}
       {{/if}}
+      {{waive-hearings-popup assignment=this.assignment showPopup=showPopup}}
       <ul class="no-bullet no-margin">
         {{#each this.assignment.assigneeDisplayMilestones as |milestone idx|}}
           {{#if (eq idx 1)}}

--- a/app/templates/components/waive-hearings-popup.hbs
+++ b/app/templates/components/waive-hearings-popup.hbs
@@ -1,28 +1,43 @@
 {{#ember-wormhole to="reveal-modal-container"}}
   {{#confirmation-modal open=showPopup}}
-    <h3>
-      <small class="display-inline-block">Opt out of noticing a public hearing for:</small>
-      <span class="display-inline-block">{{assignment.project.dcpProjectname}}</span>
-    </h3>
-    <p>Without proper notice of a public hearing, the {{participant-type-label assignment.dcpLupteammemberrole}}'s recommendation does not comply with City Charter requirements.
-    NYC Planning will still accept a recommendation, but a disapproval will not trigger an automatic City Council call up.</p>
-    <p><strong>Are you sure you want to opt out of noticing a public hearing?</strong></p>
-    <button
-      class="button small"
-      data-test-button="onConfirmOptOutHearing"
-      type="button"
-      onClick={{action "onConfirmOptOutHearing" assignment.dispositions}}
-    >
-      Opt Out
-    </button>
-    <button
-      class="button small clear"
-      data-test-button="closeOptOutHearingPopup"
-      type="button"
-      onClick={{action "closeOptOutHearingPopup"}}
-    >
-      Cancel
-    </button>
-
+    {{#if error}}
+      <div class="cell auto">
+        <span data-test-error-alert-message>
+          Oops something went wrong, can you try again?
+        </span>
+      </div>
+      <button
+        class="button clear"
+        data-test-button="backToMyProjectsAfterError"
+        type="button"
+        onClick={{action "closeModal"}}
+      >
+        Back to My Projects
+      </button>
+    {{else}}
+      <h3>
+        <small class="display-inline-block">Opt out of noticing a public hearing for:</small>
+        <span class="display-inline-block">{{assignment.project.dcpProjectname}}</span>
+      </h3>
+      <p>Without proper notice of a public hearing, the {{participant-type-label assignment.dcpLupteammemberrole}}'s recommendation does not comply with City Charter requirements.
+      NYC Planning will still accept a recommendation, but a disapproval will not trigger an automatic City Council call up.</p>
+      <p><strong>Are you sure you want to opt out of noticing a public hearing?</strong></p>
+      <button
+        class="button small"
+        data-test-button="onConfirmOptOutHearing"
+        type="button"
+        onClick={{action "onConfirmOptOutHearing" assignment}}
+      >
+        Opt Out
+      </button>
+      <button
+        class="button small clear"
+        data-test-button="closeOptOutHearingPopup"
+        type="button"
+        onClick={{action "closeModal"}}
+      >
+        Cancel
+      </button>
+    {{/if}}
   {{/confirmation-modal}}
 {{/ember-wormhole}}

--- a/tests/acceptance/user-can-waive-hearings-test.js
+++ b/tests/acceptance/user-can-waive-hearings-test.js
@@ -25,6 +25,10 @@ module('Acceptance | user can waive hearings', function(hooks) {
     await invalidateSession();
   });
 
+  hooks.beforeEach(async function() {
+    await authenticateSession();
+  });
+
   test('user can waive hearings on to-review page', async function(assert) {
     this.server.create('assignment', {
       id: 4,
@@ -49,8 +53,6 @@ module('Acceptance | user can waive hearings', function(hooks) {
       }),
     });
 
-    await authenticateSession();
-
     await visit('/my-projects/to-review');
 
     assert.ok('[data-test-button="submitHearing"]');
@@ -69,6 +71,8 @@ module('Acceptance | user can waive hearings', function(hooks) {
 
     assert.ok(find('[data-test-hearings-waived-message]'));
     assert.ok(find('[data-test-button="submitRecommendation"]'));
+
+    assert.equal(this.server.db._collections[2]._records[0].dcpIspublichearingrequired, 'No');
 
     await click('[data-test-button="submitRecommendation"]');
 
@@ -93,5 +97,134 @@ module('Acceptance | user can waive hearings', function(hooks) {
     await visit('/my-projects/upcoming');
 
     assert.notOk(find('[data-test-button="submitHearing"]'));
+  });
+
+  test('user can waive hearings on upcoming page', async function(assert) {
+    this.server.create('assignment', {
+      id: 4,
+      tab: 'upcoming',
+      user: this.server.create('user'),
+      dispositions: [
+        this.server.create('disposition', {
+          dcpIspublichearingrequired: '',
+          dcpDateofpublichearing: null,
+          dcpPublichearinglocation: '',
+          action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+        }),
+        this.server.create('disposition', {
+          dcpIspublichearingrequired: '',
+          dcpDateofpublichearing: null,
+          dcpPublichearinglocation: '',
+          action: server.create('action', { dcpName: 'Zoning Text Amendment', dcpUlurpnumber: 'C780076TLK' }),
+        }),
+      ],
+      project: this.server.create('project', {
+        id: 4,
+      }),
+    });
+
+    await visit('/my-projects/upcoming');
+
+    assert.ok('[data-test-button="submitHearing"]');
+
+    assert.notOk(find('[data-test-button="onConfirmOptOutHearing"]'));
+    assert.notOk(find('[data-test-button="closeOptOutHearingPopup"]'));
+
+    await click('[data-test-button="optOutHearingOpenPopup"]');
+
+    assert.ok(find('[data-test-button="onConfirmOptOutHearing"]'));
+    assert.ok(find('[data-test-button="closeOptOutHearingPopup"]'));
+
+    await click('[data-test-button="onConfirmOptOutHearing"]');
+
+    assert.notOk(find('[data-test-button="onConfirmOptOutHearing"]'));
+
+    assert.notOk(find('[data-test-button="optOutHearingOpenPopup"]'));
+
+    assert.equal(this.server.db._collections[2]._records[0].dcpIspublichearingrequired, 'No');
+  });
+
+  test('if there is a server error when running .save(), user will see error message on to-review tab', async function(assert) {
+    this.server.create('assignment', {
+      id: 4,
+      tab: 'to-review',
+      dispositions: [
+        server.create('disposition', {
+          dcpPublichearinglocation: '',
+          dcpDateofpublichearing: null,
+          dcpIspublichearingrequired: '',
+        }),
+        server.create('disposition', {
+          dcpPublichearinglocation: '',
+          dcpDateofpublichearing: null,
+          dcpIspublichearingrequired: '',
+        }),
+      ],
+      project: this.server.create('project', {
+        id: 4,
+      }),
+    });
+
+    this.server.patch('/dispositions/:id', { errors: ['server problem'] }, 500); // force mirage to error
+
+    await visit('/my-projects/to-review');
+
+    assert.ok(find('[data-test-button="optOutHearingOpenPopup"]'));
+
+    await click('[data-test-button="optOutHearingOpenPopup"]');
+
+    assert.ok(find('[data-test-button="onConfirmOptOutHearing"]'));
+
+    await click('[data-test-button="onConfirmOptOutHearing"]');
+
+    assert.equal(this.server.db._collections[2]._records[0].dcpIspublichearingrequired, '');
+
+    assert.ok(find('[data-test-error-alert-message]'));
+
+    await click('[data-test-button="backToMyProjectsAfterError"]');
+
+    assert.ok(find('[data-test-button="optOutHearingOpenPopup"]'));
+  });
+
+  test('if there is a server error when running .save(), user will see error message on upcoming tab', async function(assert) {
+    this.server.create('assignment', {
+      id: 4,
+      tab: 'upcoming',
+      dispositions: [
+        server.create('disposition', {
+          dcpPublichearinglocation: '',
+          dcpDateofpublichearing: null,
+          dcpIspublichearingrequired: '',
+        }),
+        server.create('disposition', {
+          dcpPublichearinglocation: '',
+          dcpDateofpublichearing: null,
+          dcpIspublichearingrequired: '',
+        }),
+      ],
+      project: this.server.create('project', {
+        id: 4,
+      }),
+    });
+
+    this.server.patch('/dispositions/:id', { errors: ['server problem'] }, 500); // force mirage to error
+
+    await visit('/my-projects/upcoming');
+
+    assert.ok(find('[data-test-button="optOutHearingOpenPopup"]'));
+
+    await click('[data-test-button="optOutHearingOpenPopup"]');
+
+    assert.ok(find('[data-test-button="onConfirmOptOutHearing"]'));
+
+    await click('[data-test-button="onConfirmOptOutHearing"]');
+
+    assert.equal(this.server.db._collections[2]._records[0].dcpIspublichearingrequired, '');
+
+    assert.ok(find('[data-test-error-alert-message]'));
+
+    await click('[data-test-button="backToMyProjectsAfterError"]');
+
+    assert.ok(find('[data-test-button="optOutHearingOpenPopup"]'));
   });
 });

--- a/tests/integration/components/deduped-hearings-list-test.js
+++ b/tests/integration/components/deduped-hearings-list-test.js
@@ -93,6 +93,7 @@ module('Integration | Component | deduped-hearings-list', function(hooks) {
     await render(hbs`
       {{#to-review-project-card assignment=assignment}}
       {{/to-review-project-card}}
+      <div id="reveal-modal-container"></div>
     `);
 
     const list = this.element.textContent.trim();

--- a/tests/integration/components/waive-hearings-popup-test.js
+++ b/tests/integration/components/waive-hearings-popup-test.js
@@ -2,8 +2,6 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { updateEachObjectInArray } from 'labs-zap-search/components/waive-hearings-popup';
-import EmberObject from '@ember/object';
 
 module('Integration | Component | waive-hearings-popup', function(hooks) {
   setupRenderingTest(hooks);
@@ -25,43 +23,5 @@ module('Integration | Component | waive-hearings-popup', function(hooks) {
     const messageVisible = waiveHearingsMessageOnPopup.includes('Are you sure you want to opt out of noticing a public hearing?');
 
     assert.ok(messageVisible);
-  });
-
-  test('updateEachObjectInArray function works', function(assert) {
-    const ourDisps = EmberObject.extend({});
-
-    const disp1 = ourDisps.create({
-      id: 1,
-      dcpPublichearinglocation: '',
-      dcpDateofpublichearing: null,
-    });
-
-    const disp2 = ourDisps.create({
-      id: 2,
-      dcpPublichearinglocation: '',
-      dcpDateofpublichearing: null,
-    });
-
-    const disp3 = ourDisps.create({
-      id: 3,
-      dcpPublichearinglocation: '',
-      dcpDateofpublichearing: null,
-    });
-
-    const disp4 = ourDisps.create({
-      id: 4,
-      dcpPublichearinglocation: '',
-      dcpDateofpublichearing: null,
-    });
-
-    // mimics each project's array of dispositions
-    const dispositions = [disp1, disp2, disp3, disp4];
-
-    // run the updateEachObjectInArray function, which...
-    updateEachObjectInArray(dispositions, 'dcpPublichearinglocation', 'waived');
-
-    const eachLocation = dispositions.map(disp => disp.dcpPublichearinglocation);
-
-    assert.equal(eachLocation.join(','), 'waived,waived,waived,waived');
   });
 });


### PR DESCRIPTION
- update the function that sets hearings to waived (`dcpIspublichearingrequired` = `No`) to include `.save()` instead of just setting the new value
- update tests to check for error handling
- move `waive-hearings-popup` to outside of the if statements on the project cards so that the component is not torn down before a user has submitted their info
- when tests forced an error, for some reason the `disposition.dcpIspublichearingrequired` values were still getting set to `No`, so the error function also resets this value so that the four computeds that check for hearings waived/submitted on the assignments model are not incorrect

Am open to fixes to this! Might require a bigger refactor in the future.

Closes #900 