### PR TITLE
914: character limit for forms

### DIFF
--- a/app/templates/components/date-time-picker.hbs
+++ b/app/templates/components/date-time-picker.hbs
@@ -6,6 +6,7 @@
         <label class="date-time-picker--date {{if (and dateMissing checkIfMissing) 'is-invalid-label'}}">
           Hearing Date
           {{pikaday-input
+            readonly="readonly"
             placeholder='Select a date'
             value=this.date
             minDate=currentDate

--- a/app/templates/components/location-input.hbs
+++ b/app/templates/components/location-input.hbs
@@ -3,6 +3,7 @@
     {{input
       class=(if (and locationMissing checkIfMissing) "is-invalid-input")
       type="text"
+      maxlength=100
       placeholder="Add a location"
       autocomplete="off"
       data-test-allactions-input="location"

--- a/app/templates/my-projects/assignment/recommendations/add.hbs
+++ b/app/templates/my-projects/assignment/recommendations/add.hbs
@@ -404,6 +404,7 @@
                     </label>
                     <Textarea
                       @id={{concat "disposition-" (concat idx "-dcpConsideration")}}
+                      @maxlength=2000
                       @value={{dispositionChangesetPair.changeset.dcpConsideration}}
                       @placeholder="Add a Recommendation comment for this action here."
                       @rows="4"
@@ -438,6 +439,7 @@
                     <Input
                       @id="all-actions-vote-location"
                       @type="text"
+                      @maxlength=100
                       @placeholder="Add a location"
                       @autocomplete="off"
                       @value={{this.dispositionForAllActionsChangeset.dcpVotelocation}}
@@ -458,6 +460,7 @@
                     </label>
                     <PikadayInput
                       @id="all-actions-vote-date"
+                      @readonly="readonly"
                       @placeholder='Select a date'
                       @value={{this.dispositionForAllActionsChangeset.dcpDateofvote}}
                       @format='MM/DD/YYYY'
@@ -483,6 +486,7 @@
                 </label>
                 <Textarea
                   @id="all-actions-dcpConsideration"
+                  @maxlength=2000
                   @value={{this.dispositionForAllActionsChangeset.dcpConsideration}}
                   @placeholder="Add Recommendation comment for all actions here."
                   @rows="4"


### PR DESCRIPTION
- add character limits for 3 disposition form fields: `dcpPublichearinglocation`, `dcpConsideration`, and `dcpVoteLocation`
- make sure that users cannot type in the `pikaday` inputs and instead have to choose from the calendar to assure correct date format `readonly="readonly"`

Unfortunately it's not possible to put `maxlength` on inputs where the `type` is `number`, but there are other validations on the number inputs to make sure that a user cannot submit unless the numbers are in a range. 

Closes #914 <-- read issue to see where info on character limits came from