### PR TITLE
only show action.dcpName labels if they exist

### DIFF
--- a/app/templates/components/archive-project-card.hbs
+++ b/app/templates/components/archive-project-card.hbs
@@ -62,10 +62,12 @@
                           </small>
                           <span class="display-inline-block text-tiny">
                             {{#each hearing.hearingActions as |action index|}}
-                              <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-hearing-actions-list="{{hearing.disposition.id}}{{index}}">
-                                {{action.dcpName}}
-                                <small>{{action.dcpUlurpnumber}}</small>
-                              </span>
+                              {{#if action.dcpName}}
+                                <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-hearing-actions-list="{{hearing.disposition.id}}{{index}}">
+                                  {{action.dcpName}}
+                                  <small>{{action.dcpUlurpnumber}}</small>
+                                </span>
+                              {{/if}}
                             {{/each}}
                           </span>
                         </div>

--- a/app/templates/components/project-milestone.hbs
+++ b/app/templates/components/project-milestone.hbs
@@ -95,10 +95,12 @@
                   </small>
                   <div class="text-tiny">
                     {{#each hearing.hearingActions as |action index|}}
-                      <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-hearing-actions-list="{{hearing.disposition.id}}{{index}}">
-                        {{action.dcpName}}
-                        <small>{{action.dcpUlurpnumber}}</small>
-                      </span>
+                      {{#if action.dcpName}}
+                        <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-hearing-actions-list="{{hearing.disposition.id}}{{index}}">
+                          {{action.dcpName}}
+                          <small>{{action.dcpUlurpnumber}}</small>
+                        </span>
+                      {{/if}}
                     {{/each}}
                   </div>
                 </div>
@@ -145,10 +147,12 @@
                   </small>
                   <div class="text-tiny">
                     {{#each vote.voteActions as |action index|}}
-                      <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-vote-actions-list="{{vote.disposition.id}}{{index}}">
-                        {{action.dcpName}}
-                        <small>{{action.dcpUlurpnumber}}</small>
-                      </span>
+                      {{#if action.dcpName}}
+                        <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-vote-actions-list="{{vote.disposition.id}}{{index}}">
+                          {{action.dcpName}}
+                          <small>{{action.dcpUlurpnumber}}</small>
+                        </span>
+                      {{/if}}
                     {{/each}}
                   </div>
                 </div>

--- a/app/templates/components/reviewed-project-card.hbs
+++ b/app/templates/components/reviewed-project-card.hbs
@@ -62,10 +62,12 @@
                             </small>
                             <span class="display-inline-block text-tiny">
                               {{#each hearing.hearingActions as |action index|}}
-                                <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-hearing-actions-list="{{hearing.disposition.id}}{{index}}">
-                                  {{action.dcpName}}
-                                  <small>{{action.dcpUlurpnumber}}</small>
-                                </span>
+                                {{#if action.dcpName}}
+                                  <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-hearing-actions-list="{{hearing.disposition.id}}{{index}}">
+                                    {{action.dcpName}}
+                                    <small>{{action.dcpUlurpnumber}}</small>
+                                  </span>
+                                {{/if}}
                               {{/each}}
                             </span>
                           </div>

--- a/app/templates/components/to-review-project-card.hbs
+++ b/app/templates/components/to-review-project-card.hbs
@@ -120,10 +120,12 @@
 
                     <small data-test-hearing-actions-list="{{hearing.disposition.id}}">
                       {{#each hearing.hearingActions as |action index| ~}}
-                        <span class="label light-gray tiny-margin-bottom tiny-margin-right">
-                          {{action.dcpName}}
-                          <small>{{action.dcpUlurpnumber}}</small>
-                        </span>
+                        {{#if action.dcpName}}
+                          <span class="label light-gray tiny-margin-bottom tiny-margin-right">
+                            {{action.dcpName}}
+                            <small>{{action.dcpUlurpnumber}}</small>
+                          </span>
+                        {{/if}}
                       {{~/each}}
                     </small>
                   </div>

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -146,10 +146,12 @@
                               </small>
                               <span class="display-inline-block text-tiny">
                                 {{#each hearing.hearingActions as |action index|}}
-                                  <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-hearing-actions-list="{{hearing.disposition.id}}{{index}}">
-                                    {{action.dcpName}}
-                                    <small>{{action.dcpUlurpnumber}}</small>
-                                  </span>
+                                  {{#if action.dcpName}}
+                                    <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-hearing-actions-list="{{hearing.disposition.id}}{{index}}">
+                                      {{action.dcpName}}
+                                      <small>{{action.dcpUlurpnumber}}</small>
+                                    </span>
+                                  {{/if}}
                                 {{/each}}
                               </span>
                             </div>

--- a/app/templates/my-projects/assignment/hearing/add.hbs
+++ b/app/templates/my-projects/assignment/hearing/add.hbs
@@ -153,10 +153,12 @@
 
                       <div class="text-tiny" data-test-hearing-actions-list="{{hearing.disposition.id}}">
                         {{#each hearing.hearingActions as |action index| ~}}
-                          <span class="label light-gray tiny-margin-bottom tiny-margin-right">
-                            {{action.dcpName}}
-                            <small>{{action.dcpUlurpnumber}}</small>
-                          </span>
+                          {{#if action.dcpName}}
+                            <span class="label light-gray tiny-margin-bottom tiny-margin-right">
+                              {{action.dcpName}}
+                              <small>{{action.dcpUlurpnumber}}</small>
+                            </span>
+                          {{/if}}
                         {{~/each}}
                       </div>
                     </div>


### PR DESCRIPTION
This PR prevents empty labels from appearing in the markup. 