### PR TITLE
964, 918: hide timeline on upcoming and provide unknown date

### DIFF
--- a/app/templates/components/archive-project-card.hbs
+++ b/app/templates/components/archive-project-card.hbs
@@ -32,6 +32,7 @@
       <ul class="no-bullet no-margin">
         {{#each assignment.tabSpecificMilestones as |milestone|}}
           <ArchiveProjectMilestoneListItem
+            data-test-milestone-id="{{milestone.id}}"
             @project={{this.assignment.project}}
             @milestone={{milestone}}
           />

--- a/app/templates/components/to-review-project-card.hbs
+++ b/app/templates/components/to-review-project-card.hbs
@@ -45,7 +45,7 @@
               @route="my-projects.assignment.hearing.add"
               @model={{assignment}}
               class="button expanded tiny-margin-bottom"
-              data-test-button="submitHearing"
+              data-test-button-post-hearing="{{assignment.id}}"
             >
               {{fa-icon 'calendar' fixedWidth=true size="lg" transform="left-2"}}
               Post {{participant-type-label assignment.dcpLupteammemberrole}} Hearing Notice

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -37,6 +37,8 @@
             >
               {{#if (not (eq isMoreThanThirtyDaysBeforePublicReview null))}}
                 {{if isMoreThanThirtyDaysBeforePublicReview 'in more than 30 days' 'in fewer than 30 days'}}
+              {{else}}
+                unknown date
               {{/if}}
             </strong>
           </p>
@@ -55,7 +57,7 @@
                 @route="my-projects.assignment.hearing.add"
                 @model={{this.assignment}}
                 class="button expanded"
-                data-test-button="submitHearing"
+                data-test-button-post-hearing="{{this.assignment.id}}"
               >
                 {{fa-icon 'calendar' fixedWidth=true size="lg" transform="left-2"}}
                 Post {{participant-type-label this.assignment.dcpLupteammemberrole}} Hearing Notice
@@ -81,91 +83,64 @@
           {{/if}}
         {{/if}}
       {{/if}}
-      {{waive-hearings-popup assignment=this.assignment showPopup=showPopup}}
-      <ul class="no-bullet no-margin">
-        {{#each this.assignment.assigneeDisplayMilestones as |milestone idx|}}
-          {{#if (eq idx 1)}}
-            <li class="small-margin-bottom">
-              <LinkTo
-                @route='show-project'
-                @model={{milestone.project.id}}
-                data-test-button='submitHearing'
-              >
-                {{fa-icon 'ellipsis-v' fixedWidth=true class="tiny-margin-right"}}
-                <span class="text-tiny">VIEW FULL TIMELINE</span>
-              </LinkTo>
-            </li>
-          {{/if}}
-          <li class="grid-x small-margin-bottom" data-test-milestone-view="true" data-test-milestone-id={{milestone.id}} data-test-display-order={{idx}}>
-            <div class="cell shrink small-margin-right">
-              {{#if (eq milestone.statuscode "Completed")}}
-                {{fa-icon 'check' class='blue' fixedWidth=true}}
-              {{else if (eq milestone.statuscode "In Progress")}}
-                {{fa-icon 'hourglass-half' class='blue' fixedWidth=true}}
-              {{else if (eq milestone.statuscode "Overridden")}}
-                {{fa-icon 'times' class='red-muted' fixedWidth=true}}
-              {{else if (eq milestone.statuscode "Not Started")}}
-                <span data-test={{if (string-includes milestone.displayName "Review") "upcoming-indicator"}}>
-                  {{fa-icon 'calendar' class='light-gray' fixedWidth=true}}
-                </span>
-              {{/if}}
-            </div>
-            <div class="cell auto {{if (eq milestone.statuscode "Not Started") 'gray'}}">
-              <strong>{{milestone.displayName}}</strong>
-              {{#if milestone.dcpActualenddate}}
-                <small class="display-inline-block">
-                  <DateDisplay
-                    @date={{milestone.dcpActualenddate}}
-                  />
-                </small>
-              {{/if}}
-              {{#hearings-list-for-milestones-list milestone=milestone as |milestoneParticipants|}}
-                {{#each milestoneParticipants as |milestoneParticipant|}}
-                  {{#if milestoneParticipant.hearingsSubmitted}}
-                    <strong data-test-lup-full-name="{{milestoneParticipant.landUseParticipantFullName}}">
-                      {{milestoneParticipant.landUseParticipantFullName}} Public Hearing
+
+      {{#if assignment.hearingsSubmitted}}
+        {{#deduped-hearings-list dispositions=assignment.dispositions as |dedupedHearings|}}
+          <h6>{{participant-type-label assignment.dcpLupteammemberrole}} Hearings:</h6>
+              <ul class="no-bullet">
+              {{#each dedupedHearings as |hearing|}}
+                <li class="grid-x small-margin-bottom">
+                  <div class="cell shrink small-margin-right">
+                    {{#if (is-before hearing.disposition.dcpDateofpublichearing)}}
+                      {{fa-icon "calendar" class="light-gray" fixedWidth=true}}
+                    {{else}}
+                      {{fa-icon "check" class="blue" fixedWidth=true}}
+                    {{/if}}
+                  </div>
+                  <div class="cell auto">
+                    {{log "id" hearing.disposition.id}}
+                    <strong data-test-hearing-location="{{hearing.disposition.id}}" class="display-inline-block">
+                      {{~hearing.disposition.dcpPublichearinglocation~}}
                     </strong>
-                    {{#deduped-hearings-list dispositions=milestoneParticipant.userDispositions as |dedupedHearings|}}
-                      {{#each dedupedHearings as |hearing|}}
-                        <ul class="sub-milestones no-bullet">
-                          <li class="grid-x">
-                            <div class="cell shrink small-margin-right">
-                              {{#if (is-before hearing.disposition.dcpDateofpublichearing)}}
-                                {{fa-icon 'calendar' fixedWidth=true class='light-gray'}}
-                              {{else}}
-                                {{fa-icon 'check' fixedWidth=true class='blue-muted'}}
-                              {{/if}}
-                            </div>
-                            <div class="cell auto">
-                              <span data-test-hearing-location="{{hearing.disposition.id}}">{{hearing.disposition.dcpPublichearinglocation}}</span>
-                              <small class="display-inline-block" data-test-hearing-date="{{hearing.disposition.id}}">
-                                <DateDisplay
-                                  @date={{hearing.disposition.dcpDateofpublichearing}}
-                                  @outputFormat="LLL"
-                                />
-                              </small>
-                              <span class="display-inline-block text-tiny">
-                                {{#each hearing.hearingActions as |action index|}}
-                                  {{#if action.dcpName}}
-                                    <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-hearing-actions-list="{{hearing.disposition.id}}{{index}}">
-                                      {{action.dcpName}}
-                                      <small>{{action.dcpUlurpnumber}}</small>
-                                    </span>
-                                  {{/if}}
-                                {{/each}}
-                              </span>
-                            </div>
-                          </li>
-                        </ul>
-                      {{/each}}
-                    {{/deduped-hearings-list}}
-                  {{/if}}
-                {{/each}}
-              {{/hearings-list-for-milestones-list}}
-            </div>
-          </li>
-        {{/each}}
-      </ul>
+
+                    <span class="display-inline-block">
+                      <span data-test-hearing-date="{{hearing.disposition.id}}">
+                        <DateDisplay @date={{hearing.disposition.dcpDateofpublichearing}} />
+                      </span>
+                      <span class="light-gray">|</span>
+                      <span data-test-hearing-time="{{hearing.disposition.id}}">
+                        <DateDisplay @date={{hearing.disposition.dcpDateofpublichearing}} @outputFormat="h:mm A" />
+                      </span>
+                    </span>
+
+                    <small data-test-hearing-actions-list="{{hearing.disposition.id}}">
+                      {{#each hearing.hearingActions as |action index| ~}}
+                        {{#if action.dcpName}}
+                          <span class="label light-gray tiny-margin-bottom tiny-margin-right">
+                            {{action.dcpName}}
+                            <small>{{action.dcpUlurpnumber}}</small>
+                          </span>
+                        {{/if}}
+                      {{~/each}}
+                    </small>
+                  </div>
+                </li>
+              {{/each}}
+              </ul>
+        {{/deduped-hearings-list}}
+      {{/if}}
+
+      {{waive-hearings-popup assignment=this.assignment showPopup=showPopup}}
+      <p class="text-center">
+        <LinkTo
+          @route='show-project'
+          @model={{milestone.project.id}}
+          data-test-button='submitHearing'
+        >
+          {{fa-icon 'calendar-day' fixedWidth=true class="tiny-margin-right"}}
+          <span class="tiny-margin-bottom">VIEW FULL PROJECT TIMELINE</span>
+        </LinkTo>
+      </p>
     </div>
   </div>
 </div>

--- a/app/templates/my-projects.hbs
+++ b/app/templates/my-projects.hbs
@@ -1,12 +1,12 @@
   <div class="cell">
     <div class="grid-container medium-margin-top medium-margin-bottom">
       {{#if (not this.isInSubroute)}}
-        <ul 
+        <ul
           class="tabs medium-margin-bottom"
           data-test-dashboard-tab-links
         >
           <li class="tabs-title upcoming {{if (eq activeTab 'upcoming') 'is-active'}}">
-            {{#link-to 'my-projects.upcoming'}}Upcoming{{/link-to}}
+            {{#link-to 'my-projects.upcoming'}}<span data-test-tab-button="upcoming">Upcoming</span>{{/link-to}}
           </li>
           <li class="tabs-title to-review {{if (eq activeTab 'to-review') 'is-active'}}">
             {{#link-to 'my-projects.to-review'}}To Review{{/link-to}}

--- a/tests/acceptance/768-limit-reorder-milestones-upcoming-tab-test.js
+++ b/tests/acceptance/768-limit-reorder-milestones-upcoming-tab-test.js
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, skip } from 'qunit';
 import { visit, find } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -8,7 +8,8 @@ module('Acceptance | 768 limit reorder milestones upcoming tab', function(hooks)
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('visiting /768-limit-reorder-milestones-upcoming-tab', async function(assert) {
+  // skipping this for PR 964, 918: hide timeline on upcoming and provide unknown date
+  skip('visiting /768-limit-reorder-milestones-upcoming-tab', async function(assert) {
     this.server.create('user', {
       id: 1,
       email: 'qncb5@planning.nyc.gov',

--- a/tests/acceptance/hearings-list-for-milestones-list-shows-up-correctly-test.js
+++ b/tests/acceptance/hearings-list-for-milestones-list-shows-up-correctly-test.js
@@ -26,198 +26,6 @@ module('Acceptance | hearings list for milestones list shows up correctly', func
     await invalidateSession();
   });
 
-  test('hearings-list-for-milestones-list shows up on upcoming tab in complicated scenario', async function(assert) {
-    // ########## UPCOMING #################################################################
-    this.server.create('assignment', {
-      id: 5,
-      tab: 'upcoming',
-      user: server.create('user', {
-        name: 'Peter Pan',
-        landUseParticipant: 'QNBB',
-      }),
-      project: this.server.create('project', {
-        dispositions: [
-          server.create('disposition', {
-            id: 17,
-            dcpPublichearinglocation: '121 Bananas Avenue, Queens',
-            dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
-            fullname: 'QN BB',
-            action: server.create('action', { id: 1, dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
-          }),
-          server.create('disposition', {
-            id: 18,
-            dcpPublichearinglocation: '345 Purple Street, Manhattan',
-            dcpDateofpublichearing: new Date('2020-10-21T01:30:00'),
-            fullname: 'MN BB',
-            action: server.create('action', { id: 1, dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
-          }),
-          server.create('disposition', {
-            id: 19,
-            dcpPublichearinglocation: '567 Grapefruit Boulevard, Manhattan',
-            dcpDateofpublichearing: new Date('2021-04-14T20:30:00'),
-            fullname: 'MN BB',
-            action: server.create('action', { id: 3, dcpName: 'Change to City Map', dcpUlurpnumber: 'N19983dLUP' }),
-          }),
-          server.create('disposition', {
-            id: 20,
-            dcpPublichearinglocation: '908 Cherries Road, Queens',
-            dcpDateofpublichearing: new Date('2019-04-14T20:30:00'),
-            fullname: 'QN CB4',
-            action: server.create('action', { id: 1, dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
-          }),
-          // #### duplicate of 22 ############################################################
-          server.create('disposition', {
-            id: 21,
-            dcpPublichearinglocation: '239 Spaghetti Street, Queens',
-            dcpDateofpublichearing: new Date('2021-06-21T14:30:00'),
-            fullname: 'QN CB5',
-            action: server.create('action', { id: 3, dcpName: 'Change to City Map', dcpUlurpnumber: 'N19983dLUP' }),
-          }),
-          // #### duplicate of 21 ############################################################
-          server.create('disposition', {
-            id: 22,
-            dcpPublichearinglocation: '239 Spaghetti Street, Queens',
-            dcpDateofpublichearing: new Date('2021-06-21T14:30:00'),
-            fullname: 'QN CB5',
-            action: server.create('action', { id: 4, dcpName: 'Business Improvement District', dcpUlurpnumber: 'C780076TLK' }),
-          }),
-          // #### shouldn't show up ############################################################
-          server.create('disposition', {
-            id: 23,
-            dcpPublichearinglocation: '',
-            dcpDateofpublichearing: null,
-            fullname: 'BX CB2',
-            action: server.create('action', { id: 4, dcpName: 'Business Improvement District', dcpUlurpnumber: 'C780076TLK' }),
-          }),
-          // #### hearings waived ############################################################
-          server.create('disposition', {
-            id: 24,
-            dcpPublichearinglocation: 'waived',
-            dcpDateofpublichearing: null,
-            fullname: 'BK CB3',
-            action: server.create('action', { id: 4, dcpName: 'Business Improvement District', dcpUlurpnumber: 'C780076TLK' }),
-          }),
-        ],
-        milestones: [
-          server.create('milestone', {
-            displayName: 'Land Use Application Filed',
-            dcpMilestonesequence: 26,
-            milestonename: 'Land Use Application Filed',
-            dcpMilestone: '663beec4-dad0-e711-8116-1458d04e2fb8',
-            dcpMilestoneoutcome: null,
-            displayDate2: null,
-            displayDate: '2019-07-13T19:31:57.763Z',
-            statuscode: 'Completed',
-            dcpActualenddate: null,
-            dcpActualstartdate: '2019-07-13T19:31:57.763Z',
-            dcpPlannedcompletiondate: null,
-            dcpPlannedstartdate: null,
-            id: '1',
-          }),
-          server.create('milestone', {
-            displayName: 'Application Reviewed at City Planning Commission Review Session',
-            dcpMilestonesequence: 46,
-            milestonename: 'Application Reviewed at City Planning Commission Review Session',
-            dcpMilestone: '8e3beec4-dad0-e711-8116-1458d04e2fb8',
-            milestoneLinks: [],
-            dcpMilestoneoutcome: null,
-            displayDate2: null,
-            displayDate: '2019-10-18T19:31:57.916Z',
-            statuscode: 'Completed',
-            dcpActualenddate: null,
-            dcpActualstartdate: '2019-10-18T19:31:57.916Z',
-            dcpPlannedcompletiondate: null,
-            dcpPlannedstartdate: null,
-            id: '11',
-          }),
-          server.create('milestone', {
-            displayName: 'Community Board Review',
-            dcpMilestonesequence: 48,
-            milestonename: 'Community Board Review',
-            dcpMilestone: '923beec4-dad0-e711-8116-1458d04e2fb8',
-            milestoneLinks: [],
-            dcpMilestoneoutcome: null,
-            displayDate2: null,
-            displayDate: '2019-10-05T20:31:57.956Z',
-            statuscode: 'Completed',
-            dcpActualenddate: null,
-            dcpActualstartdate: null,
-            dcpPlannedcompletiondate: null,
-            dcpPlannedstartdate: '2019-10-05T20:31:57.956Z',
-            id: '12',
-          }),
-          server.create('milestone', {
-            displayName: 'Borough Board Review',
-            dcpMilestonesequence: 50,
-            milestonename: 'Borough Board Review',
-            dcpMilestone: '963beec4-dad0-e711-8116-1458d04e2fb8',
-            milestoneLinks: [],
-            dcpMilestoneoutcome: null,
-            displayDate2: '2019-11-06T20:31:58.519Z',
-            displayDate: '2019-10-07T19:31:58.519Z',
-            statuscode: 'In Progress',
-            dcpActualenddate: '2019-11-06T20:31:58.519Z',
-            dcpActualstartdate: '2019-10-07T19:31:58.519Z',
-            dcpPlannedcompletiondate: null,
-            dcpPlannedstartdate: null,
-            id: '38',
-          }),
-        ],
-      }),
-    });
-
-    await visit('/my-projects/upcoming');
-
-    // #### HEARING TITLE ############################################################
-    assert.ok(this.element.querySelector('[data-test-lup-full-name="Queens Borough Board"]').textContent.includes('Queens Borough Board Public Hearing'), 'QNBB');
-    assert.ok(this.element.querySelector('[data-test-lup-full-name="Manhattan Borough Board"]').textContent.includes('Manhattan Borough Board Public Hearing'), 'MNBB');
-    assert.ok(this.element.querySelector('[data-test-lup-full-name="Queens Community Board 5"]').textContent.includes('Queens Community Board 5 Public Hearing'), 'QNCB5');
-    assert.ok(this.element.querySelector('[data-test-lup-full-name="Queens Community Board 4"]').textContent.includes('Queens Community Board 4 Public Hearing'), 'QNCB4');
-    assert.notOk(find('[data-test-lup-full-name="Brooklyn Community Board 3"]'), 'BKCB3');
-    assert.notOk(find('[data-test-lup-full-name="Bronx Community Board 2"]'), 'BXCB2');
-
-    // #### HEARING LOCATION ############################################################
-    assert.ok(this.element.querySelector('[data-test-hearing-location="17"]').textContent.includes('121 Bananas Avenue, Queens'), 'location 17');
-    assert.ok(this.element.querySelector('[data-test-hearing-location="18"]').textContent.includes('345 Purple Street, Manhattan'), 'location 18');
-    assert.ok(this.element.querySelector('[data-test-hearing-location="19"]').textContent.includes('567 Grapefruit Boulevard, Manhattan'), 'location 19');
-    assert.ok(this.element.querySelector('[data-test-hearing-location="20"]').textContent.includes('908 Cherries Road, Queens'), 'location 20');
-    assert.ok(this.element.querySelector('[data-test-hearing-location="21"]').textContent.includes('239 Spaghetti Street, Queens'), 'location 21');
-    // duplicate
-    assert.notOk(find('[data-test-hearing-location="22"]'), 'location 22');
-    // not submitted yet
-    assert.notOk(find('[data-test-hearing-location="23"]'), 'location 23');
-    // waived
-    assert.notOk(find('[data-test-hearing-location="24"]'), 'location 24');
-
-    // #### HEARING DATE ############################################################
-    assert.ok(this.element.querySelector('[data-test-hearing-date="17"]').textContent.includes('October 21'), 'date 17');
-    assert.ok(this.element.querySelector('[data-test-hearing-date="18"]').textContent.includes('October 21'), 'date 18');
-    assert.ok(this.element.querySelector('[data-test-hearing-date="19"]').textContent.includes('April 14'), 'date 19');
-    assert.ok(this.element.querySelector('[data-test-hearing-date="20"]').textContent.includes('April 14'), 'date 20');
-    assert.ok(this.element.querySelector('[data-test-hearing-date="21"]').textContent.includes('June 21'), 'date 21');
-    // duplicate
-    assert.notOk(find('[data-test-hearing-date="22"]'), 'date 22');
-    // not submitted yet
-    assert.notOk(find('[data-test-hearing-date="23"]'), 'date 23');
-    // waived
-    assert.notOk(find('[data-test-hearing-date="24"]'), 'date 24');
-
-
-    // #### HEARING ACTIONS ############################################################
-    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="170"]').textContent.includes('Zoning Special Permit'), 'action 170');
-    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="180"]').textContent.includes('Zoning Special Permit'), 'action 180');
-    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="190"]').textContent.includes('Change to City Map'), 'action 190');
-    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="200"]').textContent.includes('Zoning Special Permit'), 'action 200');
-    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="210"]').textContent.includes('Change to City Map'), 'action 210');
-    assert.ok(this.element.querySelector('[data-test-hearing-actions-list="211"]').textContent.includes('Business Improvement District'), 'action 211 duplicate');
-    // duplicate
-    assert.notOk(find('[data-test-hearing-actions-list="220"]'), 'action 220');
-    // not submitted yet
-    assert.notOk(find('[data-test-hearing-actions-list="230"]'), 'action 230');
-    // waived
-    assert.notOk(find('[data-test-hearing-actions-list="240"]'), 'action 240');
-  });
-
   test('hearings-list-for-milestones-list shows up correctly on show-project', async function(assert) {
     // ########## UPCOMING #################################################################
     this.server.create('project', {
@@ -724,10 +532,10 @@ module('Acceptance | hearings list for milestones list shows up correctly', func
     assert.ok(this.element.querySelector('[data-test-hearing-date="18"]').textContent.includes('April 21'));
   });
 
-  test('hearings-list-for-milestones-list does not break when NULL value for fullname on upcoming tab', async function(assert) {
+  test('hearings-list-for-milestones-list does not break when NULL value for fullname on archive tab', async function(assert) {
     this.server.create('assignment', {
       id: 5,
-      tab: 'upcoming',
+      tab: 'archive',
       dispositions: [
         server.create('disposition', {
           id: 17,
@@ -815,7 +623,7 @@ module('Acceptance | hearings list for milestones list shows up correctly', func
       }),
     });
 
-    await visit('/my-projects/upcoming');
+    await visit('/my-projects/archive');
 
     // make sure that milestones list on assignment card shows up
     assert.ok(find('[data-test-milestone-id="12"]'), 'community board milestone');

--- a/tests/acceptance/user-can-waive-hearings-test.js
+++ b/tests/acceptance/user-can-waive-hearings-test.js
@@ -55,7 +55,7 @@ module('Acceptance | user can waive hearings', function(hooks) {
 
     await visit('/my-projects/to-review');
 
-    assert.ok('[data-test-button="submitHearing"]');
+    assert.ok('[data-test-button-post-hearing="4"]');
 
     assert.notOk(find('[data-test-button="onConfirmOptOutHearing"]'));
     assert.notOk(find('[data-test-button="closeOptOutHearingPopup"]'));
@@ -69,7 +69,7 @@ module('Acceptance | user can waive hearings', function(hooks) {
 
     assert.notOk(find('[data-test-button="onConfirmOptOutHearing"]'));
 
-    assert.ok(find('[data-test-hearings-waived-message]'));
+    assert.ok(find('[data-test-hearings-waived-message="4"]'));
     assert.ok(find('[data-test-button="submitRecommendation"]'));
 
     assert.equal(this.server.db.dispositions.firstObject.dcpIspublichearingrequired, 'No');
@@ -79,24 +79,6 @@ module('Acceptance | user can waive hearings', function(hooks) {
     assert.equal(currentURL(), '/my-projects/4/recommendations/add');
 
     assert.ok(find('[data-test-hearings-waived-message]'));
-  });
-
-  test('button for hearing submission does not show if there are no dispositions', async function(assert) {
-    this.server.create('assignment', {
-      id: 4,
-      tab: 'upcoming',
-      user: this.server.create('user'),
-      dispositions: [],
-      project: this.server.create('project', {
-        id: 4,
-      }),
-    });
-
-    await authenticateSession();
-
-    await visit('/my-projects/upcoming');
-
-    assert.notOk(find('[data-test-button="submitHearing"]'));
   });
 
   test('user can waive hearings on upcoming page', async function(assert) {
@@ -125,7 +107,7 @@ module('Acceptance | user can waive hearings', function(hooks) {
 
     await visit('/my-projects/upcoming');
 
-    assert.ok('[data-test-button="submitHearing"]');
+    assert.ok('[data-test-button-post-hearing="4"]');
 
     assert.notOk(find('[data-test-button="onConfirmOptOutHearing"]'));
     assert.notOk(find('[data-test-button="closeOptOutHearingPopup"]'));
@@ -140,6 +122,8 @@ module('Acceptance | user can waive hearings', function(hooks) {
     assert.notOk(find('[data-test-button="onConfirmOptOutHearing"]'));
 
     assert.notOk(find('[data-test-button="optOutHearingOpenPopup"]'));
+
+    assert.ok(find('[data-test-hearings-waived-message="4"]'));
 
     assert.equal(this.server.db._collections[2]._records[0].dcpIspublichearingrequired, 'No');
   });

--- a/tests/integration/components/hearings-list-for-milestones-list-test.js
+++ b/tests/integration/components/hearings-list-for-milestones-list-test.js
@@ -8,7 +8,7 @@ import EmberObject from '@ember/object';
 module('Integration | Component | hearings-list-for-milestones-list', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('check that hearings list renders when user has submitted hearings on upcoming tab', async function(assert) {
+  test('check that hearings list renders when user has submitted hearings on archive tab', async function(assert) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
@@ -16,7 +16,7 @@ module('Integration | Component | hearings-list-for-milestones-list', function(h
 
     const assignment = store.createRecord('assignment', {
       id: 5,
-      tab: 'upcoming',
+      tab: 'archive',
       publicReviewPlannedStartDate: new Date('2020-10-21T01:30:00'),
       user: store.createRecord('user', {
         name: 'Peter Pan',
@@ -149,12 +149,11 @@ module('Integration | Component | hearings-list-for-milestones-list', function(h
       }),
     });
 
-
     this.set('assignment', assignment);
 
     await render(hbs`
-      {{#upcoming-project-card assignment=assignment}}
-      {{/upcoming-project-card}}
+      {{#archive-project-card assignment=assignment}}
+      {{/archive-project-card}}
       <div id="reveal-modal-container"></div>
     `);
 


### PR DESCRIPTION
Closes #964 - hiding the milestone timeline on the upcoming tab until we can figure out the correct way to sort milestones

Closes #918 - providing "unknown date" when a project is missing a planned start date for community board review

This also fixes the issue of the LUP's submitted hearing details not showing up on the upcoming tab. It seems like something wasn't working correctly in the previous implementation with those nested within the milestone list.

Change hearings displayed on upcoming tab to be similar to to-review tab 

### Tests:
- Full test for submitting a hearing on the upcoming tab in `user-can-fill-out-hearing-form-test`
- Remove test for showing `hearings-list-for-milestones-list` on upcoming tab
