### PR TITLE
952: add acceptance test for rec date submitted on reviewed

### DIFF
--- a/app/templates/components/reviewed-project-milestone-list-item.hbs
+++ b/app/templates/components/reviewed-project-milestone-list-item.hbs
@@ -28,7 +28,7 @@
           />
         {{/each}}
         <br>
-        <small class="display-block">
+        <small data-test-cb-recommendation-submitted-date="{{this.milestone.id}}" class="display-block">
           Recommendation submitted&nbsp;<DateDisplay @date={{this.anyCommunityBoardDispositionDateReceived}} />
         </small>
       {{else if (eq this.milestone.dcpMilestone this.milestoneConstants.BOROUGH_BOARD_REFERRAL)}}
@@ -39,7 +39,7 @@
           />
         {{/each}}
         <br>
-        <small class="display-block">
+        <small data-test-bb-recommendation-submitted-date="{{this.milestone.id}}" class="display-block">
           Recommendation submitted&nbsp;<DateDisplay @date={{this.anyBoroughBoardDispositionDateReceived}} />
         </small>
       {{else if (eq this.milestone.dcpMilestone this.milestoneConstants.BOROUGH_PRESIDENT_REFERRAL)}}

--- a/tests/acceptance/reviewed-project-cards-renders-test.js
+++ b/tests/acceptance/reviewed-project-cards-renders-test.js
@@ -57,4 +57,92 @@ module('Acceptance | reviewed project cards renders', function(hooks) {
     const timeRemainingValue = find('[data-test-estimated-time-remaining]').textContent.trim();
     assert.equal(timeRemainingValue, '14', 'Estimated time remaining displays 14');
   });
+
+  test('reviewed project card displays recommendation date submitted', async function(assert) {
+    this.server.create('user', {
+      id: 1,
+      email: 'qnbb@planning.nyc.gov',
+      landUseParticipant: 'QNBB',
+      assignments: [
+        this.server.create('assignment', {
+          id: 1,
+          tab: 'reviewed',
+          dcpLupteammemberrole: 'BB',
+          project: server.create('project', {
+            dispositions: [
+              server.create('disposition', {
+                id: 1,
+                dcpPublichearinglocation: '121 Bananas Ave',
+                dcpDateofpublichearing: new Date('2020-10-21T00:00:00'),
+                dcpDatereceived: new Date('2020-12-15T00:00:00'),
+                action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+                dcpDateofvote: new Date('2020-11-12T00:00:00'),
+                dcpBoroughboardrecommendation: '717170002',
+                dcpVotingagainstrecommendation: 1,
+                dcpVotinginfavorrecommendation: 2,
+                dcpVotingabstainingonrecommendation: 3,
+                fullname: 'QN BB',
+              }),
+              server.create('disposition', {
+                id: 2,
+                dcpPublichearinglocation: '445 Peach St',
+                dcpDateofpublichearing: new Date('2020-11-21T00:00:00'),
+                dcpDatereceived: new Date('2020-12-20T00:00:00'),
+                action: server.create('action', { dcpName: 'Zoning Text Amendment', dcpUlurpnumber: 'N860877TCM' }),
+                dcpDateofvote: new Date('2020-11-30T00:00:00'),
+                dcpCommunityboardrecommendation: '717170002',
+                dcpVotingagainstrecommendation: 1,
+                dcpVotinginfavorrecommendation: 2,
+                dcpVotingabstainingonrecommendation: 3,
+                fullname: 'QN CB5',
+              }),
+            ],
+            milestones: [
+              server.create('milestone', {
+                displayName: 'Community Board Review',
+                dcpMilestonesequence: 48,
+                milestonename: 'Community Board Review',
+                dcpMilestone: '923beec4-dad0-e711-8116-1458d04e2fb8',
+                milestoneLinks: [],
+                dcpMilestoneoutcome: null,
+                displayDate2: null,
+                displayDate: '2019-10-05T20:31:57.956Z',
+                statuscode: 'Completed',
+                dcpActualenddate: null,
+                dcpActualstartdate: null,
+                dcpPlannedcompletiondate: null,
+                dcpPlannedstartdate: '2019-10-05T20:31:57.956Z',
+                id: '12',
+              }),
+              server.create('milestone', {
+                displayName: 'Borough Board Review',
+                dcpMilestonesequence: 50,
+                milestonename: 'Borough Board Review',
+                dcpMilestone: '963beec4-dad0-e711-8116-1458d04e2fb8',
+                milestoneLinks: [],
+                dcpMilestoneoutcome: null,
+                displayDate2: '2019-11-06T20:31:58.519Z',
+                displayDate: '2019-10-07T19:31:58.519Z',
+                statuscode: 'In Progress',
+                dcpActualenddate: '2019-11-06T20:31:58.519Z',
+                dcpActualstartdate: '2019-10-07T19:31:58.519Z',
+                dcpPlannedcompletiondate: null,
+                dcpPlannedstartdate: null,
+                id: '38',
+              }),
+            ],
+          }),
+        }),
+      ],
+    });
+
+    await authenticateSession({
+      id: 1,
+    });
+
+    await visit('/my-projects/reviewed');
+
+    assert.ok(this.element.querySelector('[data-test-bb-recommendation-submitted-date="38"]').textContent.includes('12/15/2020'), 'date submitted borough board');
+    assert.ok(this.element.querySelector('[data-test-cb-recommendation-submitted-date="12"]').textContent.includes('12/20/2020'), 'date submitted community board');
+  });
 });


### PR DESCRIPTION
Add acceptance test for displaying recommendation date submitted on `reviewed` tab. Bug associated with #952 is still present in staging but this rules out a frontend problem. 

Fix bug in another PR

Addresses frontend testing of #952 
