### PR TITLE
885: tabindex disabled for AmPm selection on hearing form, user has to select manually

### DIFF
--- a/app/templates/components/date-time-picker.hbs
+++ b/app/templates/components/date-time-picker.hbs
@@ -78,6 +78,7 @@
             {{#power-select
               triggerClass="timeofday-dropdown"
               supportsDataTestProperties=true
+              tabindex="-1"
               searchEnabled=false
               selected=this.timeOfDay
               options=timeOfDayOption


### PR DESCRIPTION
When a user tabs to the `timeOfDay` dropdown on the hearing form and types in "P", `PM` value will show up in the power-select box but this value will not be saved to the model. This is because it is necessary for an `onclose` event to occur on the power-select to run the `setHearingDate` action. When a user types but does not select manually, this action is not run. 

Setting the `tabindex="-1"` will make it so that a user cannot tab to this power-select box, removing the possibility that they'll type in the value and then expect it to be saved. Instead they'll always have to click on the box, which will open the dropdown, and then will trigger the `onclose` event when they select an option. 

Closes #885 