### PR TITLE
Change status when hearing submitted

### DIFF
--- a/app/models/disposition.js
+++ b/app/models/disposition.js
@@ -42,7 +42,7 @@ export default class DispositionModel extends Model {
   @attr('string', { defaultValue: '' }) fullname;
 
   // sourced from dcp_dcpPublichearinglocation
-  @attr('string', { defaultValue: '' }) dcpPublichearinglocation;
+  @attr('string', { defaultValue: null }) dcpPublichearinglocation;
 
   @attr('string', { defaultValue: null }) dcpIspublichearingrequired;
 
@@ -96,7 +96,18 @@ export default class DispositionModel extends Model {
   // Label: 'Submitted', 'Value': 2
   // Label: 'Deactivated', 'Value': 717170001
   // Label: 'Not Submitted', 'Value': 717170002
-  @attrComputed('dcpDateofvote', 'dcpBoroughpresidentrecommendation', 'dcpBoroughboardrecommendation', 'dcpCommunityboardrecommendation', 'dcpIspublichearingrequired')
+  @attrComputed(
+    // recommendations
+    'dcpDateofvote',
+    'dcpBoroughpresidentrecommendation',
+    'dcpBoroughboardrecommendation',
+    'dcpCommunityboardrecommendation',
+    'dcpIspublichearingrequired',
+
+    // hearings
+    'dcpPublichearinglocation',
+    'dcpDateofpublichearing',
+  )
   get statuscode() {
     if (this.dcpBoroughpresidentrecommendation !== null
       || this.dcpBoroughboardrecommendation !== null
@@ -105,6 +116,10 @@ export default class DispositionModel extends Model {
 
     if (
       this.dcpIspublichearingrequired !== null
+    ) return STATUSCODES.findBy('Label', 'Saved').Value;
+
+    if (this.dcpPublichearinglocation
+      || this.dcpDateofpublichearing
     ) return STATUSCODES.findBy('Label', 'Saved').Value;
 
     return STATUSCODES.findBy('Label', 'Draft').Value;

--- a/tests/unit/models/disposition-test.js
+++ b/tests/unit/models/disposition-test.js
@@ -42,6 +42,9 @@ module('Unit | Model | disposition', function(hooks) {
   test('when statuscode is draft or saved, statecode is "active"', async function(assert) {
     const store = this.owner.lookup('service:store');
     const model = store.createRecord('disposition', {
+      dcpPublichearinglocation: 'foo',
+      dcpDateofpublichearing: 'bar',
+
       dcpBoroughpresidentrecommendation: null,
       dcpBoroughboardrecommendation: null,
       dcpCommunityboardrecommendation: null,
@@ -49,5 +52,21 @@ module('Unit | Model | disposition', function(hooks) {
     });
 
     assert.equal(model.statecode, STATECODES.findBy('Label', 'Active').Value);
+  });
+
+  test('when hearing info is submitted, but nothing else, statecode is "active"', async function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('disposition', {
+      dcpDateofvote: null,
+      dcpBoroughpresidentrecommendation: null,
+      dcpBoroughboardrecommendation: null,
+      dcpCommunityboardrecommendation: null,
+      dcpIspublichearingrequired: null,
+
+      dcpPublichearinglocation: 'foo',
+      dcpDateofpublichearing: 'bar',
+    });
+
+    assert.equal(model.statuscode, STATUSCODES.findBy('Label', 'Saved').Value);
   });
 });


### PR DESCRIPTION
Adds logic to shift statuscode to Saved when required hearing information is provided

Closes https://github.com/NYCPlanning/zap-api/issues/45