### PR TITLE
1002: use dcpActualenddate instead of dcpDatereceived for review milestones in list

### DIFF
--- a/app/components/archive-project-milestone-list-item.js
+++ b/app/components/archive-project-milestone-list-item.js
@@ -15,33 +15,13 @@ export default class ArchiveProjectMilestoneListItemComponent extends Component 
     return this.project.dispositions.filter(disposition => disposition.dcpCommunityboardrecommendation);
   }
 
-  // Since all CB dispositions should have the same "dcpDatereceived", get the first one that's defined.
-  // TODO: Later, if we break out review outcomes by community board (for projects with multiple CBs),
-  // we should also get community board dispositions dcpDatereceived per community board.
-  @computed('communityBoardDispositions')
-  get anyCommunityBoardDispositionDateReceived() {
-    return this.communityBoardDispositions.map(disposition => disposition.dcpDatereceived).find(dcpDatereceived => !!dcpDatereceived);
-  }
-
   @computed('project.dispositions')
   get boroughBoardDispositions() {
     return this.project.dispositions.filter(disposition => disposition.dcpBoroughboardrecommendation);
   }
 
-  // The comment for anyCommunityBoardDispositionDateReceived applies here as well.
-  @computed('boroughBoardDispositions')
-  get anyBoroughBoardDispositionDateReceived() {
-    return this.boroughBoardDispositions.map(disposition => disposition.dcpDatereceived).find(dcpDatereceived => !!dcpDatereceived);
-  }
-
   @computed('project.dispositions')
   get boroughPresidentDispositions() {
     return this.project.dispositions.filter(disposition => disposition.dcpBoroughpresidentrecommendation);
-  }
-
-  // The comment for anyCommunityBoardDispositionDateReceived applies here as well.
-  @computed('boroughPresidentDispositions')
-  get anyBoroughPresidentDispositionDateReceived() {
-    return this.boroughPresidentDispositions.map(disposition => disposition.dcpDatereceived).find(dcpDatereceived => !!dcpDatereceived);
   }
 }

--- a/app/components/reviewed-project-milestone-list-item.js
+++ b/app/components/reviewed-project-milestone-list-item.js
@@ -15,33 +15,13 @@ export default class ReviewedProjectMilestoneListItemComponent extends Component
     return this.project.dispositions.filter(disposition => disposition.dcpCommunityboardrecommendation);
   }
 
-  // Since all CB dispositions should have the same "dcpDatereceived", get the first one that's defined.
-  // TODO: Later, if we break out review outcomes by community board (for projects with multiple CBs),
-  // we should also get community board dispositions dcpDatereceived per community board.
-  @computed('communityBoardDispositions')
-  get anyCommunityBoardDispositionDateReceived() {
-    return this.communityBoardDispositions.map(disposition => disposition.dcpDatereceived).find(dcpDatereceived => !!dcpDatereceived);
-  }
-
   @computed('project.dispositions')
   get boroughBoardDispositions() {
     return this.project.dispositions.filter(disposition => disposition.dcpBoroughboardrecommendation);
   }
 
-  // The comment for anyCommunityBoardDispositionDateReceived applies here as well.
-  @computed('boroughBoardDispositions')
-  get anyBoroughBoardDispositionDateReceived() {
-    return this.boroughBoardDispositions.map(disposition => disposition.dcpDatereceived).find(dcpDatereceived => !!dcpDatereceived);
-  }
-
   @computed('project.dispositions')
   get boroughPresidentDispositions() {
     return this.project.dispositions.filter(disposition => disposition.dcpBoroughpresidentrecommendation);
-  }
-
-  // The comment for anyCommunityBoardDispositionDateReceived applies here as well.
-  @computed('boroughPresidentDispositions')
-  get anyBoroughPresidentDispositionDateReceived() {
-    return this.boroughPresidentDispositions.map(disposition => disposition.dcpDatereceived).find(dcpDatereceived => !!dcpDatereceived);
   }
 }

--- a/app/templates/components/archive-project-milestone-list-item.hbs
+++ b/app/templates/components/archive-project-milestone-list-item.hbs
@@ -25,11 +25,6 @@
           @action={{disposition.action}}
         />
       {{/each}}
-      <br>
-      <small class="display-block">
-        {{#if this.anyCommunityBoardDispositionDateReceived}}<span data-test-cb-disposition-date-received>Recommendation submitted</span>&nbsp;{{/if~}}
-        <DateDisplay @date={{this.anyCommunityBoardDispositionDateReceived}} />
-      </small>
     {{else if (eq this.milestone.dcpMilestone this.milestoneConstants.BOROUGH_BOARD_REFERRAL)}}
       {{#each this.boroughBoardDispositions as |disposition|}}
         <RecommendationResultIcon
@@ -37,11 +32,6 @@
           @action={{disposition.action}}
         />
       {{/each}}
-      <br>
-      <small class="display-block">
-        {{#if this.anyBoroughBoardDispositionDateReceived}}<span data-test-bb-disposition-date-received>Recommendation submitted</span>&nbsp;{{/if~}}
-        <DateDisplay @date={{this.anyBoroughBoardDispositionDateReceived}} />
-      </small>
     {{else if (eq this.milestone.dcpMilestone this.milestoneConstants.BOROUGH_PRESIDENT_REFERRAL)}}
       {{#each this.boroughPresidentDispositions as |disposition|}}
         <RecommendationResultIcon
@@ -49,20 +39,14 @@
           @action={{disposition.action}}
         />
       {{/each}}
+    {{/if}}
+    {{#if this.milestone.dcpActualenddate}}
       <br>
-      <small class="display-block">
-        {{#if this.anyBoroughPresidentDispositionDateReceived}}<span data-test-bp-disposition-date-received>Recommendation submitted</span>&nbsp;{{/if~}}
-        <DateDisplay @date={{this.anyBoroughPresidentDispositionDateReceived}} />
+      <small class="display-block" data-test-actual-end-date="{{milestone.id}}">
+        <DateDisplay
+          @date={{this.milestone.dcpActualenddate}}
+        />
       </small>
-    {{else}}
-      <br>
-      {{#if this.milestone.dcpActualenddate}}
-        <small class="display-block">
-          <DateDisplay
-            @date={{this.milestone.dcpActualenddate}}
-          />
-        </small>
-      {{/if}}
     {{/if}}
   </div>
 </li>

--- a/app/templates/components/reviewed-project-milestone-list-item.hbs
+++ b/app/templates/components/reviewed-project-milestone-list-item.hbs
@@ -20,18 +20,12 @@
         {{this.milestone.displayName}}
       </strong>
       {{#if (eq this.milestone.dcpMilestone this.milestoneConstants.COMMUNITY_BOARD_REFERRAL)}}
-
         {{#each this.communityBoardDispositions as |disposition|}}
           <RecommendationResultIcon
             @recommendation={{disposition.dcpCommunityboardrecommendation}}
             @action={{disposition.action}}
           />
         {{/each}}
-        <br>
-        <small data-test-cb-recommendation-submitted-date="{{this.milestone.id}}" class="display-block">
-          {{#if this.anyCommunityBoardDispositionDateReceived}}<span data-test-cb-disposition-date-received>Recommendation submitted&nbsp;</span>{{/if~}}
-          <DateDisplay @date={{this.anyCommunityBoardDispositionDateReceived}} />
-        </small>
       {{else if (eq this.milestone.dcpMilestone this.milestoneConstants.BOROUGH_BOARD_REFERRAL)}}
         {{#each this.boroughBoardDispositions as |disposition|}}
           <RecommendationResultIcon
@@ -39,11 +33,6 @@
             @action={{disposition.action}}
           />
         {{/each}}
-        <br>
-        <small data-test-bb-recommendation-submitted-date="{{this.milestone.id}}" class="display-block">
-          {{#if this.anyBoroughBoardDispositionDateReceived}}<span data-test-bb-disposition-date-received>Recommendation submitted&nbsp;</span>{{/if~}}
-          <DateDisplay @date={{this.anyBoroughBoardDispositionDateReceived}} />
-        </small>
       {{else if (eq this.milestone.dcpMilestone this.milestoneConstants.BOROUGH_PRESIDENT_REFERRAL)}}
         {{#each this.boroughPresidentDispositions as |disposition|}}
           <RecommendationResultIcon
@@ -51,18 +40,12 @@
             @action={{disposition.action}}
           />
         {{/each}}
+      {{/if}}
+      {{#if this.milestone.dcpActualenddate}}
         <br>
-        <small class="display-block">
-          {{#if this.anyBoroughPresidentDispositionDateReceived}}<span data-test-bp-disposition-date-received>Recommendation submitted&nbsp;</span>{{/if~}}
-          <DateDisplay @date={{this.anyBoroughPresidentDispositionDateReceived}} />
+        <small class="display-block" data-test-actual-end-date="{{milestone.id}}">
+          <DateDisplay @date={{this.milestone.dcpActualenddate}} />
         </small>
-      {{else}}
-        <br>
-        {{#if this.milestone.dcpActualenddate}}
-          <small class="display-block">
-            <DateDisplay @date={{this.milestone.dcpActualenddate}} />
-          </small>
-        {{/if}}
       {{/if}}
     </p>
   </div>

--- a/tests/acceptance/archive-project-card-renders-test.js
+++ b/tests/acceptance/archive-project-card-renders-test.js
@@ -1,14 +1,12 @@
 import { module, test } from 'qunit';
 import {
   visit,
-  find,
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { invalidateSession, authenticateSession } from 'ember-simple-auth/test-support';
-import moment from 'moment';
 
-module('Acceptance | reviewed project cards renders', function(hooks) {
+module('Acceptance | archive project card renders', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
@@ -24,43 +22,7 @@ module('Acceptance | reviewed project cards renders', function(hooks) {
     await invalidateSession();
   });
 
-  test('reviewed project card renders an estimated time remaining if planned end date is valid', async function(assert) {
-    this.server.create('user', {
-      id: 1,
-      email: 'qncb5@planning.nyc.gov',
-      landUseParticipant: 'QNCB',
-      assignments: [
-        this.server.create('assignment', {
-          id: 1,
-          tab: 'reviewed',
-          dcpLupteammemberrole: 'CB',
-          dispositions: [],
-          project: this.server.create('project', {
-            milestones: [
-              this.server.create('milestone', 'boroughPresidentReview', {
-                statuscode: 'In Progress',
-                dcpActualstartdate: moment().subtract(9, 'days'),
-                displayDate: moment().subtract(9, 'days'),
-                dcpPlannedcompletiondate: moment().add(15, 'days'),
-                displayDate2: null,
-              }),
-            ],
-          }),
-        }),
-      ],
-    });
-
-    await authenticateSession({
-      id: 1,
-    });
-
-    await visit('/my-projects/reviewed');
-
-    const timeRemainingValue = find('[data-test-estimated-time-remaining]').textContent.trim();
-    assert.equal(timeRemainingValue, '14', 'Estimated time remaining displays 14');
-  });
-
-  test('reviewed project card displays recommendation dcpActualenddate', async function(assert) {
+  test('archive project card displays recommendation dcpActualenddate', async function(assert) {
     this.server.create('user', {
       id: 1,
       email: 'qnbb@planning.nyc.gov',
@@ -68,7 +30,7 @@ module('Acceptance | reviewed project cards renders', function(hooks) {
       assignments: [
         this.server.create('assignment', {
           id: 1,
-          tab: 'reviewed',
+          tab: 'archive',
           dcpLupteammemberrole: 'BB',
           project: server.create('project', {
             dispositions: [
@@ -142,7 +104,7 @@ module('Acceptance | reviewed project cards renders', function(hooks) {
       id: 1,
     });
 
-    await visit('/my-projects/reviewed');
+    await visit('/my-projects/archive');
 
     assert.ok(this.element.querySelector('[data-test-actual-end-date="38"]').textContent.includes('10/21/2020'), 'actual end date borough board');
     assert.ok(this.element.querySelector('[data-test-actual-end-date="12"]').textContent.includes('10/23/2020'), 'actual end date community board');

--- a/tests/integration/components/archive-project-milestone-list-item-test.js
+++ b/tests/integration/components/archive-project-milestone-list-item-test.js
@@ -1,73 +1,15 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { find, render } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 module('Integration | Component | archive-project-milestone-list-item', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it does not display "Recommendation Submitted" when there are no dispos', async function(assert) {
-    this.set('project', { dispositions: [] });
-
-    this.set('milestone', {});
-
-    await render(hbs`<ArchiveProjectMilestoneListItem @project={{this.project}} @milestone={{this.milestone}}/>`);
-
-    assert.notOk(find('[data-test-cb-disposition-date-received]'));
-  });
-
-
-  test('it does not display "Recommendation Submitted" date when there is no recommendation', async function(assert) {
-    this.set(
-      'project',
-      {
-        dispositions: [
-          EmberObject.create({
-            dcpCommunityboardrecommendation: '',
-            dcpDatereceived: null,
-          }),
-        ],
-      },
-    );
-
-    this.set('milestone', {});
-
-    await render(hbs`<ArchiveProjectMilestoneListItem @project={{this.project}} @milestone={{this.milestone}}/>`);
-
-    assert.notOk(find('[data-test-cb-disposition-date-received]'));
-  });
-
-
-  test('it does not display "Recommendation Submitted" date when there is a recommendation but there is no date received', async function(assert) {
-    this.set(
-      'project',
-      {
-        dispositions: [
-          EmberObject.create({
-            dcpCommunityboardrecommendation: 'foo',
-            dcpDatereceived: null,
-          }),
-        ],
-      },
-    );
-
-    this.set('milestone', {});
-
-    await render(hbs`<ArchiveProjectMilestoneListItem @project={{this.project}} @milestone={{this.milestone}}/>`);
-
-    assert.notOk(find('[data-test-cb-disposition-date-received]'));
-  });
-
-
   test('it displays a Community Board recommendation date', async function(assert) {
     this.set('project', {
-      dispositions: [
-        EmberObject.create({
-          dcpCommunityboardrecommendation: 'foo',
-          dcpDatereceived: new Date(),
-        }),
-      ],
+      dispositions: [],
     });
 
     this.set(
@@ -82,7 +24,7 @@ module('Integration | Component | archive-project-milestone-list-item', function
         displayDate2: null,
         displayDate: '2019-10-05T20:31:57.956Z',
         statuscode: 'Completed',
-        dcpActualenddate: null,
+        dcpActualenddate: new Date('2020-12-15T00:00:00'),
         dcpActualstartdate: null,
         dcpPlannedcompletiondate: null,
         dcpPlannedstartdate: '2019-10-05T20:31:57.956Z',
@@ -92,6 +34,7 @@ module('Integration | Component | archive-project-milestone-list-item', function
 
     await render(hbs`<ArchiveProjectMilestoneListItem @project={{this.project}} @milestone={{this.milestone}}/>`);
 
-    assert.ok(find('[data-test-cb-disposition-date-received]'));
+    assert.ok(this.element.textContent.includes('Community Board Review'));
+    assert.ok(this.element.textContent.includes('12/15/2020'));
   });
 });

--- a/tests/integration/components/reviewed-project-milestone-list-item-test.js
+++ b/tests/integration/components/reviewed-project-milestone-list-item-test.js
@@ -1,73 +1,15 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { find, render } from '@ember/test-helpers';
+import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import EmberObject from '@ember/object';
 
 module('Integration | Component | reviewed-project-milestone-list-item', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it does not display "Recommendation Submitted" when there are no dispos', async function(assert) {
-    this.set('project', { dispositions: [] });
-
-    this.set('milestone', {});
-
-    await render(hbs`<ReviewedProjectMilestoneListItem @project={{this.project}} @milestone={{this.milestone}}/>`);
-
-    assert.notOk(find('[data-test-cb-disposition-date-received]'));
-  });
-
-
-  test('it does not display "Recommendation Submitted" date when there is no recommendation', async function(assert) {
-    this.set(
-      'project',
-      {
-        dispositions: [
-          EmberObject.create({
-            dcpCommunityboardrecommendation: '',
-            dcpDatereceived: null,
-          }),
-        ],
-      },
-    );
-
-    this.set('milestone', {});
-
-    await render(hbs`<ReviewedProjectMilestoneListItem @project={{this.project}} @milestone={{this.milestone}}/>`);
-
-    assert.notOk(find('[data-test-cb-disposition-date-received]'));
-  });
-
-
-  test('it does not display "Recommendation Submitted" date when there is a recommendation but there is no date received', async function(assert) {
-    this.set(
-      'project',
-      {
-        dispositions: [
-          EmberObject.create({
-            dcpCommunityboardrecommendation: 'foo',
-            dcpDatereceived: null,
-          }),
-        ],
-      },
-    );
-
-    this.set('milestone', {});
-
-    await render(hbs`<ReviewedProjectMilestoneListItem @project={{this.project}} @milestone={{this.milestone}}/>`);
-
-    assert.notOk(find('[data-test-cb-disposition-date-received]'));
-  });
-
-
   test('it displays a Community Board recommendation date', async function(assert) {
     this.set('project', {
-      dispositions: [
-        EmberObject.create({
-          dcpCommunityboardrecommendation: 'foo',
-          dcpDatereceived: new Date(),
-        }),
-      ],
+      dispositions: [],
     });
 
     this.set(
@@ -82,7 +24,7 @@ module('Integration | Component | reviewed-project-milestone-list-item', functio
         displayDate2: null,
         displayDate: '2019-10-05T20:31:57.956Z',
         statuscode: 'Completed',
-        dcpActualenddate: null,
+        dcpActualenddate: new Date('2020-12-15T00:00:00'),
         dcpActualstartdate: null,
         dcpPlannedcompletiondate: null,
         dcpPlannedstartdate: '2019-10-05T20:31:57.956Z',
@@ -92,6 +34,7 @@ module('Integration | Component | reviewed-project-milestone-list-item', functio
 
     await render(hbs`<ReviewedProjectMilestoneListItem @project={{this.project}} @milestone={{this.milestone}}/>`);
 
-    assert.ok(find('[data-test-cb-disposition-date-received]'));
+    assert.ok(this.element.textContent.includes('Community Board Review'));
+    assert.ok(this.element.textContent.includes('12/15/2020'));
   });
 });


### PR DESCRIPTION
Replace `dcpDatereceived` with `dcpActualenddate` as the date displayed in the milestones list on the reviewed and archive tabs.

Closes #1002 