### PR TITLE
1003: use new fields for milestone duration and time remaining

### DIFF
--- a/app/components/reviewed-project-card.js
+++ b/app/components/reviewed-project-card.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
-import moment from 'moment';
 
 export default class ReviewedProjectCardComponent extends Component {
   @service
@@ -31,8 +30,8 @@ export default class ReviewedProjectCardComponent extends Component {
     if (firstInProgressMilestoneDates.displayName && firstInProgressMilestoneDates.dcpActualstartdate && firstInProgressMilestoneDates.dcpPlannedcompletiondate) {
       return {
         displayName: firstInProgressMilestoneDates.displayName,
-        estTimeRemaining: moment(firstInProgressMilestoneDates.dcpPlannedcompletiondate).diff(moment(), 'days'),
-        estTimeDuration: moment(firstInProgressMilestoneDates.dcpPlannedcompletiondate).diff(moment(firstInProgressMilestoneDates.dcpActualstartdate), 'days'),
+        estTimeRemaining: firstInProgressMilestoneDates.dcpRemainingplanneddayscalculated,
+        estTimeDuration: firstInProgressMilestoneDates.dcpActualdurationasoftoday,
         dcpPlannedcompletiondate: firstInProgressMilestoneDates.dcpPlannedcompletiondate,
       };
     }

--- a/app/components/to-review-project-card.js
+++ b/app/components/to-review-project-card.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
-import { computed, action } from '@ember/object';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import moment from 'moment';
 
 export default class ToReviewProjectCardComponent extends Component {
   @service
@@ -10,16 +9,6 @@ export default class ToReviewProjectCardComponent extends Component {
   showPopup = false;
 
   assignment = {};
-
-  @computed('assignment.toReviewMilestonePlannedCompletionDate')
-  get timeRemaining() {
-    return moment(this.assignment.toReviewMilestonePlannedCompletionDate).diff(moment(), 'days');
-  }
-
-  @computed('assignment.{toReviewMilestoneActualStartDate,toReviewMilestonePlannedCompletionDate}')
-  get timeDuration() {
-    return moment(this.assignment.toReviewMilestonePlannedCompletionDate).diff(moment(this.assignment.toReviewMilestoneActualStartDate), 'days');
-  }
 
   @action
   openOptOutHearingPopup() {

--- a/app/models/assignment.js
+++ b/app/models/assignment.js
@@ -153,6 +153,20 @@ export default class AssignmentModel extends Model {
     return dcpPlannedcompletiondate;
   }
 
+  @computed('tab', 'dcpLupteammemberrole', 'project.milestones')
+  get toReviewMilestoneTimeRemaining() {
+    const participantMilestoneId = this.milestoneConstants.referralIdentifierByAcronymLookup[this.dcpLupteammemberrole];
+    const { dcpRemainingplanneddayscalculated } = this.project.get('milestones').find(milestone => milestone.dcpMilestone === participantMilestoneId) || {};
+    return dcpRemainingplanneddayscalculated;
+  }
+
+  @computed('tab', 'dcpLupteammemberrole', 'project.milestones')
+  get toReviewMilestoneTimeDuration() {
+    const participantMilestoneId = this.milestoneConstants.referralIdentifierByAcronymLookup[this.dcpLupteammemberrole];
+    const { dcpActualdurationasoftoday } = this.project.get('milestones').find(milestone => milestone.dcpMilestone === participantMilestoneId) || {};
+    return dcpActualdurationasoftoday;
+  }
+
   // If `tab` is 'reviewed'...
   //   - these start/end dates come from the current In Progress milestone
   //   - an array of milestone dates is returned
@@ -167,6 +181,8 @@ export default class AssignmentModel extends Model {
       displayName: milestone.displayName,
       dcpActualstartdate: milestone.dcpActualstartdate,
       dcpPlannedcompletiondate: milestone.dcpPlannedcompletiondate,
+      dcpRemainingplanneddayscalculated: milestone.dcpRemainingplanneddayscalculated,
+      dcpActualdurationasoftoday: milestone.dcpActualdurationasoftoday,
     }));
   }
 }

--- a/app/models/milestone.js
+++ b/app/models/milestone.js
@@ -49,6 +49,14 @@ export default class MilestoneModel extends Model {
   // --> CRM:display_date_2 | e.g. null
   @attr('string') displayDate2;
 
+  // field `dcp_remainingplanneddayscalculated` from table dcp_projectmilestone
+  // represents number of days e.g. `8`
+  @attr('string') dcpRemainingplanneddayscalculated;
+
+  // field `dcp_actualdurationasoftoday` from table dcp_projectmilestone
+  // represents number of days e.g. `29`
+  @attr('string') dcpActualdurationasoftoday;
+
   // --> CRM:dcp_milestoneoutcome
   @attr('string') dcpMilestoneoutcome;
 

--- a/app/templates/components/reviewed-project-card.hbs
+++ b/app/templates/components/reviewed-project-card.hbs
@@ -14,14 +14,24 @@
       <div class="cell medium-4 large-3 xlarge-2">
         <div class="text-center medium-margin-right medium-margin-left">
           {{#if timeDisplayLabel}}
-            <p class="tiny-margin-bottom">{{timeDisplayLabel}}</p>
-            <p>
-              <strong
-                class="stat"
-                data-test-estimated-time-remaining
-              >{{plannedTimeDisplay.estTimeRemaining}}</strong>
-              <strong class="display-block">of {{plannedTimeDisplay.estTimeDuration}} estimated days remain</strong>
-            </p>
+            <p class="tiny-margin-bottom" data-test-time-display-label="{{assignment.id}}">{{timeDisplayLabel}}</p>
+            {{#if plannedTimeDisplay.estTimeRemaining}}
+              <p>
+                <strong
+                  class="stat"
+                  data-test-estimated-time-remaining="{{assignment.id}}"
+                >{{plannedTimeDisplay.estTimeRemaining}}</strong>
+                {{#if plannedTimeDisplay.estTimeDuration}}
+                  <strong class="display-block" data-test-estimated-time-duration="{{assignment.id}}">
+                    of {{plannedTimeDisplay.estTimeDuration}} estimated days remain
+                  </strong>
+                {{else}}
+                  <strong class="display-block" data-test-estimated-no-time-duration-message="{{assignment.id}}">
+                    estimated days remain
+                  </strong>
+                {{/if}}
+              </p>
+            {{/if}}
             <p class="text-tiny">
               Estimated End <DateDisplay @date={{plannedTimeDisplay.dcpPlannedcompletiondate}} outputFormat="M/D/YYYY" />
             </p>

--- a/app/templates/components/to-review-project-card.hbs
+++ b/app/templates/components/to-review-project-card.hbs
@@ -13,16 +13,22 @@
     </div>
     <div class="cell medium-4 large-3 xlarge-2">
       <div class="text-center medium-margin-right medium-margin-left">
-        <p class="tiny-margin-bottom">{{participant-type-label assignment.dcpLupteammemberrole}} Review</p>
+        <p class="tiny-margin-bottom" data-test-milestone-label="{{assignment.id}}">{{participant-type-label assignment.dcpLupteammemberrole}} Review</p>
         {{#if assignment.toReviewMilestonePlannedCompletionDate}}
-          <p>
-            <strong class="stat"
-              data-test-time-remaining
-            >
-              {{timeRemaining}}
-            </strong>
-            <strong class="display-block">of {{timeDuration}} days remain</strong>
-          </p>
+          {{#if assignment.toReviewMilestoneTimeRemaining}}
+            <p>
+              <strong class="stat"
+                data-test-time-remaining="{{assignment.id}}"
+              >
+                {{assignment.toReviewMilestoneTimeRemaining}}
+              </strong>
+              {{#if assignment.toReviewMilestoneTimeDuration}}
+                <strong class="display-block" data-test-time-duration="{{assignment.id}}">of {{assignment.toReviewMilestoneTimeDuration}} days remain</strong>
+              {{else}}
+                <strong class="display-block" data-test-no-time-duration-message="{{assignment.id}}">days remain</strong>
+              {{/if}}
+            </p>
+          {{/if}}
           <p class="text-tiny">
             Ends <DateDisplay @date={{assignment.toReviewMilestonePlannedCompletionDate}} @outputFormat="M/D/YYYY" />
           </p>

--- a/tests/acceptance/reviewed-project-cards-renders-test.js
+++ b/tests/acceptance/reviewed-project-cards-renders-test.js
@@ -43,6 +43,8 @@ module('Acceptance | reviewed project cards renders', function(hooks) {
                 displayDate: moment().subtract(9, 'days'),
                 dcpPlannedcompletiondate: moment().add(15, 'days'),
                 displayDate2: null,
+                dcpRemainingplanneddayscalculated: 14,
+                dcpActualdurationasoftoday: 29,
               }),
             ],
           }),
@@ -56,8 +58,90 @@ module('Acceptance | reviewed project cards renders', function(hooks) {
 
     await visit('/my-projects/reviewed');
 
-    const timeRemainingValue = find('[data-test-estimated-time-remaining]').textContent.trim();
+    const timeRemainingValue = find('[data-test-estimated-time-remaining="1"]').textContent.trim();
+    const timeDurationValue = find('[data-test-estimated-time-duration="1"]').textContent.trim();
     assert.equal(timeRemainingValue, '14', 'Estimated time remaining displays 14');
+    assert.equal(timeDurationValue, 'of 29 estimated days remain', 'Estimated time duration displays 29');
+  });
+
+  test('reviewed project card does not show "of" if dcpActualdurationasoftoday is null', async function(assert) {
+    this.server.create('user', {
+      id: 1,
+      email: 'qncb5@planning.nyc.gov',
+      landUseParticipant: 'QNCB',
+      assignments: [
+        this.server.create('assignment', {
+          id: 1,
+          tab: 'reviewed',
+          dcpLupteammemberrole: 'CB',
+          dispositions: [],
+          project: this.server.create('project', {
+            milestones: [
+              this.server.create('milestone', 'boroughPresidentReview', {
+                statuscode: 'In Progress',
+                dcpActualstartdate: moment().subtract(9, 'days'),
+                displayDate: moment().subtract(9, 'days'),
+                dcpPlannedcompletiondate: moment().add(15, 'days'),
+                displayDate2: null,
+                dcpRemainingplanneddayscalculated: 14,
+                dcpActualdurationasoftoday: null,
+              }),
+            ],
+          }),
+        }),
+      ],
+    });
+
+    await authenticateSession({
+      id: 1,
+    });
+
+    await visit('/my-projects/reviewed');
+
+    const timeRemainingValue = find('[data-test-estimated-time-remaining="1"]').textContent.trim();
+    const noTimeDurationMessage = find('[data-test-estimated-no-time-duration-message="1"]').textContent.trim();
+    assert.equal(timeRemainingValue, '14', 'Estimated time remaining displays 14');
+    assert.equal(noTimeDurationMessage, 'estimated days remain', 'no estimated duration time');
+  });
+
+  test('reviewed project card does not date information if dcpRemainingplanneddayscalculated is null', async function(assert) {
+    this.server.create('user', {
+      id: 1,
+      email: 'qncb5@planning.nyc.gov',
+      landUseParticipant: 'QNCB',
+      assignments: [
+        this.server.create('assignment', {
+          id: 1,
+          tab: 'reviewed',
+          dcpLupteammemberrole: 'CB',
+          dispositions: [],
+          project: this.server.create('project', {
+            milestones: [
+              this.server.create('milestone', 'boroughPresidentReview', {
+                statuscode: 'In Progress',
+                dcpActualstartdate: moment().subtract(9, 'days'),
+                displayDate: moment().subtract(9, 'days'),
+                dcpPlannedcompletiondate: moment().add(15, 'days'),
+                displayDate2: null,
+                dcpRemainingplanneddayscalculated: null,
+                dcpActualdurationasoftoday: 29,
+              }),
+            ],
+          }),
+        }),
+      ],
+    });
+
+    await authenticateSession({
+      id: 1,
+    });
+
+    await visit('/my-projects/reviewed');
+
+    assert.ok(find('[data-test-time-display-label="1"]'));
+    assert.notOk(find('[data-test-estimated-time-remaining="1"]'));
+    assert.notOk(find('[data-test-estimated-time-duration="1"]'));
+    assert.notOk(find('[data-test-estimated-no-time-duration-message="1"]'));
   });
 
   test('reviewed project card displays recommendation dcpActualenddate', async function(assert) {

--- a/tests/acceptance/to-review-project-cards-renders-test.js
+++ b/tests/acceptance/to-review-project-cards-renders-test.js
@@ -42,6 +42,8 @@ module('Acceptance | to review project cards renders', function(hooks) {
               displayDate: moment().subtract(9, 'days'),
               dcpPlannedcompletiondate: moment().add(21, 'days'),
               displayDate2: moment().add(21, 'days'),
+              dcpRemainingplanneddayscalculated: '20',
+              dcpActualdurationasoftoday: '59',
             })],
           }),
         }),
@@ -54,8 +56,86 @@ module('Acceptance | to review project cards renders', function(hooks) {
 
     await visit('/my-projects/to-review');
 
-    const timeRemainingValue = find('[data-test-time-remaining]').textContent.trim();
+    const timeRemainingValue = find('[data-test-time-remaining="1"]').textContent.trim();
+    const timeDurationValue = find('[data-test-time-duration="1"]').textContent.trim();
+    assert.equal(timeDurationValue, 'of 59 days remain', 'time duration displays 59');
     assert.equal(timeRemainingValue, '20', 'Time remaining displays 20');
+  });
+
+  test('to-review project card does not show "of" if dcpActualdurationasoftoday is null', async function(assert) {
+    this.server.create('user', {
+      id: 1,
+      email: 'qncb5@planning.nyc.gov',
+      landUseParticipant: 'QNBP',
+      assignments: [
+        this.server.create('assignment', {
+          id: 1,
+          tab: 'to-review',
+          dcpLupteammemberrole: 'BP',
+          dispositions: [],
+          project: this.server.create('project', {
+            milestones: [this.server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'In Progress',
+              dcpActualstartdate: moment().subtract(9, 'days'),
+              displayDate: moment().subtract(9, 'days'),
+              dcpPlannedcompletiondate: moment().add(21, 'days'),
+              displayDate2: moment().add(21, 'days'),
+              dcpRemainingplanneddayscalculated: '20',
+              dcpActualdurationasoftoday: null,
+            })],
+          }),
+        }),
+      ],
+    });
+
+    await authenticateSession({
+      id: 1,
+    });
+
+    await visit('/my-projects/to-review');
+
+    const timeRemainingValue = find('[data-test-time-remaining="1"]').textContent.trim();
+    const noTimeDurationMessage = find('[data-test-no-time-duration-message="1"]').textContent.trim();
+    assert.equal(timeRemainingValue, '20', 'Estimated time remaining displays 20');
+    assert.equal(noTimeDurationMessage, 'days remain', 'no estimated duration time');
+  });
+
+  test('to-review project card does not date information if dcpRemainingplanneddayscalculated is null', async function(assert) {
+    this.server.create('user', {
+      id: 1,
+      email: 'qncb5@planning.nyc.gov',
+      landUseParticipant: 'QNBP',
+      assignments: [
+        this.server.create('assignment', {
+          id: 1,
+          tab: 'to-review',
+          dcpLupteammemberrole: 'BP',
+          dispositions: [],
+          project: this.server.create('project', {
+            milestones: [this.server.create('milestone', 'boroughPresidentReview', {
+              statuscode: 'In Progress',
+              dcpActualstartdate: moment().subtract(9, 'days'),
+              displayDate: moment().subtract(9, 'days'),
+              dcpPlannedcompletiondate: moment().add(21, 'days'),
+              displayDate2: moment().add(21, 'days'),
+              dcpRemainingplanneddayscalculated: null,
+              dcpActualdurationasoftoday: '59',
+            })],
+          }),
+        }),
+      ],
+    });
+
+    await authenticateSession({
+      id: 1,
+    });
+
+    await visit('/my-projects/to-review');
+
+    assert.ok(find('[data-test-milestone-label="1"]'));
+    assert.notOk(find('[data-test-estimated-time-remaining="1"]'));
+    assert.notOk(find('[data-test-estimated-time-duration="1"]'));
+    assert.notOk(find('[data-test-estimated-no-time-duration-message="1"]'));
   });
 
   test('to-review project card renders a "contact DCP" message if milestone dates are invalid', async function(assert) {


### PR DESCRIPTION
- add new fields `dcpRemainingplanneddayscalculated` and `dcpActualdurationasoftoday`
- update `to-review` and `reviewed` tabs to use the new these new fields
- update display logic in case one of these fields is NULL
- add new acceptance tests

Closes #1003 with backend changes PR https://github.com/NYCPlanning/zap-api/pull/55