### PR TITLE
1025: update design for votes on sub-milestones

### DIFF
--- a/app/components/recommendation-symbol.js
+++ b/app/components/recommendation-symbol.js
@@ -8,11 +8,11 @@ export default class RecommendationSymbol extends Component {
   @computed('participantRecommendation')
   get icon() {
     let icon = { style: '', color: 'light-gray' };
-    if ([717170000, 717170001].includes(this.participantRecommendation)) {
+    if (['Favorable', 'Conditional Favorable', 'Approved', 'Approved with Modifications/Conditions', 'No Objection'].includes(this.participantRecommendation)) {
       icon = { style: 'thumbs-up', color: 'green-muted' };
-    } else if ([717170002, 717170003].includes(this.participantRecommendation)) {
+    } else if (['Unfavorable', 'Conditional Unfavorable', 'Disapproved', 'Disapproved with Modifications/Conditions'].includes(this.participantRecommendation)) {
       icon = { style: 'thumbs-down', color: 'red-muted' };
-    } else if ([717170002, 717170006, 717170008].includes(this.participantRecommendation)) {
+    } else if (['Waiver of Recommendation', 'Received after Clock Expried', 'Vote Quorum Not Present', 'Non-Complying'].includes(this.participantRecommendation)) {
       icon = { style: 'comment-slash', color: 'light-gray' };
     }
     return icon;

--- a/app/models/disposition.js
+++ b/app/models/disposition.js
@@ -1,5 +1,6 @@
 import DS from 'ember-data';
 import { computed } from '@ember/object';
+import { RECOMMENDATION_OPTIONSET_BY_PARTICIPANT_TYPE_LOOKUP } from 'labs-zap-search/controllers/my-projects/assignment/recommendations/add';
 
 const {
   Model, attr, belongsTo,
@@ -17,6 +18,12 @@ export const STATECODES = [
   { Label: 'Active', Value: 0 },
   { Label: 'Inactive', Value: 1 },
 ];
+
+export const PARTICIPANT_TYPE_RECOMMENDATION_TYPE_LOOKUP = {
+  BP: 'dcpBoroughpresidentrecommendation',
+  BB: 'dcpBoroughboardrecommendation',
+  CB: 'dcpCommunityboardrecommendation',
+};
 
 // mirrors @attr but allows for computed a
 // value for serialization
@@ -198,5 +205,21 @@ export default class DispositionModel extends Model {
       return borough.concat(' ', participantType, ' ', cbNumber);
     }
     return borough.concat(' ', participantType);
+  }
+
+  // the recommendationLabel associated with the recommendation code
+  // e.g. for code `717170000` the recommendationLabel for BB would be `Favorable`
+  @computed('fullname', 'dcpCommunityboardrecommendation', 'dcpBoroughboardrecommendation', 'dcpBoroughpresidentrecommendation')
+  get recommendationLabel() {
+    // participantType e.g. `BB`
+    const participantType = this.fullname.substring(3, 5);
+    // recommendationCode e.g. `717170000`
+    const recommendationCode = this.get(PARTICIPANT_TYPE_RECOMMENDATION_TYPE_LOOKUP[participantType]);
+    // partTypeRecs e.g. array of objects with code and label values for a type of participant
+    const partTypeRecs = RECOMMENDATION_OPTIONSET_BY_PARTICIPANT_TYPE_LOOKUP[participantType];
+    // filter the partTypeRecs array of objects to match the `participantRecommendation`
+    const recLabels = partTypeRecs.filter(rec => rec.code === recommendationCode);
+
+    return recLabels.firstObject.label;
   }
 }

--- a/app/templates/components/project-milestone.hbs
+++ b/app/templates/components/project-milestone.hbs
@@ -115,22 +115,12 @@
             {{#each dedupedVotes as |vote|}}
               <li class="grid-x small-margin-bottom">
                 <div class="cell shrink small-margin-right">
-                  {{#if (eq milestoneParticipant.landUseParticipantType "CB")}}
-                    <span data-test-comm-board-rec="{{vote.disposition.id}}">
-                      {{recommendation-symbol participantRecommendation=vote.disposition.dcpCommunityboardrecommendation}}
-                    </span>
-                  {{else if (eq milestoneParticipant.landUseParticipantType "BB")}}
-                    <span data-test-borough-board-rec="{{vote.disposition.id}}">
-                      {{recommendation-symbol participantRecommendation=vote.disposition.dcpBoroughboardrecommendation}}
-                    </span>
-                  {{else if (eq milestoneParticipant.landUseParticipantType "BP")}}
-                    <span data-test-borough-pres-rec="{{vote.disposition.id}}">
-                      {{recommendation-symbol participantRecommendation=vote.disposition.dcpBoroughpresidentrecommendation}}
-                    </span>
-                  {{/if}}
+                  <span data-test-rec-symbol="{{vote.disposition.id}}">
+                    {{recommendation-symbol participantRecommendation=vote.disposition.recommendationLabel}}
+                  </span>
                 </div>
                 <div class="cell auto">
-                  <strong>Vote</strong>
+                  <strong data-test-rec-label="{{vote.disposition.id}}">{{vote.disposition.recommendationLabel}}</strong>
                   <small>
                     <span class="display-inline-block" data-test-voting-favor="{{vote.disposition.id}}">
                       {{vote.disposition.dcpVotinginfavorrecommendation}} In Favor,
@@ -143,7 +133,7 @@
                     </span>
                   </small>
                   <small class="display-inline-block" data-test-vote-date="{{vote.disposition.id}}">
-                    {{~moment-format vote.disposition.dcpDateofvote "LL"~}}
+                    Vote:&nbsp;{{~moment-format vote.disposition.dcpDateofvote "LL"~}}
                   </small>
                   <div class="text-tiny">
                     {{#each vote.voteActions as |action index|}}

--- a/tests/acceptance/hearings-list-for-milestones-list-shows-up-correctly-test.js
+++ b/tests/acceptance/hearings-list-for-milestones-list-shows-up-correctly-test.js
@@ -314,17 +314,26 @@ module('Acceptance | hearings list for milestones list shows up correctly', func
     assert.notOk(find('[data-test-vote-date="23"]'), 'date 23');
     // waived hearing but still submitted recommendation
     assert.ok(this.element.querySelector('[data-test-vote-date="24"]').textContent.includes('July 21'), 'date 24');
-    //
+
     // // #### VOTE RECOMMENDATION ############################################################
-    // index = number in a list of similar participant types (e.g. borough board)
-    assert.ok(find('[data-test-borough-board-rec="17"]'), 'QNBB thumb');
-    assert.ok(find('[data-test-borough-board-rec="18"]'), 'MNBB thumb');
-    assert.notOk(find('[data-test-borough-board-rec="19"]'), 'MNBB duplicate thumb'); // duplicate
-    assert.ok(find('[data-test-comm-board-rec="20"]'), 'QNCB4 thumb');
-    assert.ok(find('[data-test-comm-board-rec="21"]'), 'QNCB5 thumb');
-    assert.ok(find('[data-test-comm-board-rec="22"]'), 'QNCB5 thumb');
-    assert.ok(find('[data-test-comm-board-rec="24"]'), 'BKCB3 thumb'); // hearings waived but rec submitted
-    assert.notOk(find('[data-test-comm-board-rec="23"]'), 'BXCB2 thumb'); // not submitted yet
+    assert.ok(this.element.querySelector('[data-test-rec-label="17"]').textContent.includes('Waiver of Recommendation'), 'QNBB rec');
+    assert.ok(this.element.querySelector('[data-test-rec-label="18"]').textContent.includes('Favorable'), 'MNBB rec');
+    assert.notOk(find('[data-test-rec-label="19"]'), 'MNBB duplicate rec'); // duplicate
+    assert.ok(this.element.querySelector('[data-test-rec-label="20"]').textContent.includes('Approved with Modifications/Conditions'), 'QNCB4 rec');
+    assert.ok(this.element.querySelector('[data-test-rec-label="21"]').textContent.includes('Disapproved with Modifications/Conditions'), 'QNCB5 rec');
+    assert.ok(this.element.querySelector('[data-test-rec-label="22"]').textContent.includes('Waiver of Recommendation'), 'QNCB5 rec');
+    assert.ok(this.element.querySelector('[data-test-rec-label="24"]').textContent.includes('Disapproved'), 'BKCB3 rec'); // hearings waived but rec submitted
+    assert.notOk(find('[data-test-rec-label="23"]'), 'BXCB2 rec'); // not submitted yet
+
+    // // #### VOTE RECOMMENDATION SYMBOL ############################################################
+    assert.ok(find('[data-test-rec-symbol="17"]'), 'QNBB thumb');
+    assert.ok(find('[data-test-rec-symbol="18"]'), 'MNBB thumb');
+    assert.notOk(find('[data-test-rec-symbol="19"]'), 'MNBB duplicate thumb'); // duplicate
+    assert.ok(find('[data-test-rec-symbol="20"]'), 'QNCB4 thumb');
+    assert.ok(find('[data-test-rec-symbol="21"]'), 'QNCB5 thumb');
+    assert.ok(find('[data-test-rec-symbol="22"]'), 'QNCB5 thumb');
+    assert.ok(find('[data-test-rec-symbol="24"]'), 'BKCB3 thumb'); // hearings waived but rec submitted
+    assert.notOk(find('[data-test-rec-symbol="23"]'), 'BXCB2 thumb'); // not submitted yet
 
     // #### VOTE ACTIONS ############################################################
     assert.ok(this.element.querySelector('[data-test-vote-actions-list="170"]').textContent.includes('Zoning Special Permit'), 'action 170');


### PR DESCRIPTION
- updated "Vote" to say the actual recommendation value e.g. "Favorable"
- updated the date to have "Vote:" in front of it
- updated `recommendation-symbol` component to use labels instead of codes
- added one new computed property to `disposition` model called `recommendationLabel`

Closes #1025 