### PR TITLE
Only use assignment-specific dispositions

### DIFF
--- a/app/controllers/my-projects/assignment/hearing/add.js
+++ b/app/controllers/my-projects/assignment/hearing/add.js
@@ -48,7 +48,7 @@ export default class MyProjectsProjectHearingAddController extends Controller {
     // passed down to date-time-picker and location-input components
     this.set('checkIfMissing', true);
 
-    const { dispositions } = this.model;
+    const { dispositionsByRole: dispositions } = this.model;
     const dispositionForAllActions = this.get('dispositionForAllActions');
 
     let fieldsFilled;
@@ -85,7 +85,7 @@ export default class MyProjectsProjectHearingAddController extends Controller {
   // saves date and location to the disposition model
   @action
   async onConfirm() {
-    const { dispositions } = this.model;
+    const { dispositionsByRole: dispositions } = this.model;
     const allActions = this.get('allActions') || (dispositions.length <= 1);
 
     // if user is submitting ONE hearing for ALL actions
@@ -102,7 +102,7 @@ export default class MyProjectsProjectHearingAddController extends Controller {
       });
     }
 
-    dispositions.save().then(() => {
+    return Promise.all(dispositions.map(dispo => dispo.save())).then(() => {
       this.set('hearingSubmitted', false);
       this.set('checkIfMissing', false);
       this.set('modalOpen', false);

--- a/app/controllers/my-projects/assignment/recommendations/add.js
+++ b/app/controllers/my-projects/assignment/recommendations/add.js
@@ -353,7 +353,7 @@ export default class MyProjectsProjectRecommendationsAddController extends Contr
       });
 
       try {
-        await this.dispositions.save();
+        await Promise.all(this.dispositions.map(disposition => disposition.save()));
 
         this.dispositionForAllActions.setProperties({
           recommendation: null,

--- a/app/models/assignment.js
+++ b/app/models/assignment.js
@@ -6,6 +6,12 @@ const {
   Model, belongsTo, hasMany, attr,
 } = DS;
 
+export const participantRoles = [
+  { abbreviation: 'BP', label: 'Borough President' },
+  { abbreviation: 'BB', label: 'Borough Board' },
+  { abbreviation: 'CB', label: 'Community Board' },
+];
+
 export default class AssignmentModel extends Model {
   @service
   milestoneConstants;
@@ -17,6 +23,13 @@ export default class AssignmentModel extends Model {
   // ZAP-API will filter this to the set of lupteammember role's dispos
   // this could be computed through the project dispositions: project_dispositions
   @hasMany('disposition', { async: false }) dispositions;
+
+  @computed('dispositions')
+  get dispositionsByRole() {
+    const { label } = participantRoles.findBy('abbreviation', this.dcpLupteammemberrole);
+
+    return this.dispositions.filterBy('dcpRepresenting', label);
+  }
 
   @attr('string') dcpLupteammemberrole;
 

--- a/app/models/disposition.js
+++ b/app/models/disposition.js
@@ -50,6 +50,8 @@ export default class DispositionModel extends Model {
 
   @attr('string', { defaultValue: null }) dcpIspublichearingrequired;
 
+  @attr('string', { defaultValue: null }) dcpRepresenting;
+
   // sourced from dcp_dcpDateofpublichearing
   @attr('date', { defaultValue: null }) dcpDateofpublichearing;
 

--- a/app/routes/my-projects/assignment/recommendations/add.js
+++ b/app/routes/my-projects/assignment/recommendations/add.js
@@ -13,8 +13,8 @@ export default class MyProjectsProjectRecommendationsAddRoute extends Route {
 
   async setupController(controller, model) {
     super.setupController(controller, model);
-    controller.set('dispositions', model.dispositions);
-    controller.set('allActions', model.dispositions.length <= 1 ? true : null);
+    controller.set('dispositions', model.dispositionsByRole);
+    controller.set('allActions', model.dispositionsByRole.length <= 1 ? true : null);
   }
 
   @action

--- a/app/templates/components/to-review-project-card.hbs
+++ b/app/templates/components/to-review-project-card.hbs
@@ -91,7 +91,7 @@
       {{waive-hearings-popup assignment=assignment showPopup=showPopup}}
 
       {{#if assignment.hearingsSubmitted}}
-        {{#deduped-hearings-list dispositions=assignment.dispositions as |dedupedHearings|}}
+        {{#deduped-hearings-list dispositions=assignment.dispositionsByRole as |dedupedHearings|}}
           <h6>{{participant-type-label assignment.dcpLupteammemberrole}} Hearings:</h6>
               <ul class="no-bullet">
               {{#each dedupedHearings as |hearing|}}

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -51,7 +51,7 @@
       </div>
     </div>
     <div class="cell medium-auto">
-      {{#if this.assignment.dispositions}}
+      {{#if this.assignment.dispositionsByRole}}
         {{#if this.assignment.hearingsNotSubmittedNotWaived}}
           <div class="grid-x">
             <div class="cell medium-auto">
@@ -87,7 +87,7 @@
       {{/if}}
 
       {{#if assignment.hearingsSubmitted}}
-        {{#deduped-hearings-list dispositions=assignment.dispositions as |dedupedHearings|}}
+        {{#deduped-hearings-list dispositions=assignment.dispositionsByRole as |dedupedHearings|}}
           <h6>{{participant-type-label assignment.dcpLupteammemberrole}} Hearings:</h6>
               <ul class="no-bullet">
               {{#each dedupedHearings as |hearing|}}

--- a/app/templates/my-projects/assignment/hearing/add.hbs
+++ b/app/templates/my-projects/assignment/hearing/add.hbs
@@ -17,7 +17,7 @@
     </div>
   </div>
   <div class="large-7 cell">
-    {{#if (gt model.dispositions.length 1)}}
+    {{#if (gt model.dispositionsByRole.length 1)}}
       <fieldset class="medium-margin-bottom">
         <legend><strong>Would you like to submit a single hearing for all actions?</strong></legend>
         <input
@@ -45,13 +45,13 @@
       </fieldset>
     {{/if}}
 
-    {{#if (or allActions (lte model.dispositions.length 1))}}
+    {{#if (or allActions (lte model.dispositionsByRole.length 1))}}
       {{hearing-form
         disposition=dispositionForAllActions
         allActions=allActions
         checkIfMissing=checkIfMissing}}
     {{else if (eq allActions false)}}
-      {{#each model.dispositions as |disposition|}}
+      {{#each model.dispositionsByRole as |disposition|}}
         <h4>{{disposition.action.dcpName}}  <small class="dark-gray">{{disposition.action.dcpUlurpnumber}}</small></h4>
         {{hearing-form
           disposition=disposition
@@ -60,7 +60,7 @@
       {{/each}}
     {{/if}}
 
-    {{#if (or (not-eq allActions null) (lte model.dispositions.length 1))}}
+    {{#if (or (not-eq allActions null) (lte model.dispositionsByRole.length 1))}}
         <button
           class="button"
           data-test-button="checkHearing"
@@ -90,7 +90,7 @@
         {{else}}
           <h3 class="large-margin-right">Please confirm your hearing information.</h3>
 
-          {{#if (or allActions (lte model.dispositions.length 1))}}
+          {{#if (or allActions (lte model.dispositionsByRole.length 1))}}
             <ul class="no-bullet">
               <li class="grid-x small-margin-bottom">
                 <div class="cell shrink small-margin-right">
@@ -119,7 +119,7 @@
               </li>
             </ul>
           {{else}}
-            {{#deduped-hearings-list dispositions=model.dispositions as |dedupedHearings|}}
+            {{#deduped-hearings-list dispositions=model.dispositionsByRole as |dedupedHearings|}}
               <ul class="no-bullet">
                 {{#each dedupedHearings as |hearing|}}
                   <li class="grid-x small-margin-bottom">

--- a/app/templates/my-projects/assignment/recommendations/add.hbs
+++ b/app/templates/my-projects/assignment/recommendations/add.hbs
@@ -44,7 +44,7 @@
             <p class="help-text">
               A quorum requires the presence of 20% of appointed board members, and not fewer than seven members.
             </p>
-            {{#deduped-hearings-list dispositions=assignment.dispositions as |dedupedHearings|}}
+            {{#deduped-hearings-list dispositions=assignment.dispositionsByRole as |dedupedHearings|}}
               {{#each dedupedHearings as |hearing idx|}}
                 {{#if hearing.disposition.dcpDateofpublichearing}}
                   <div class="grid-x">
@@ -74,12 +74,12 @@
                         name={{concat idx '-quorum'}}
                         id={{concat idx '-quorum-yes'}}
                         checked={{if hearing.disposition.dcpWasaquorumpresent "checked"}}
-                        onClick={{action 'updateDispositionAttr' hearing assignment.dispositions 'dcpWasaquorumpresent' true}}
+                        onClick={{action 'updateDispositionAttr' hearing assignment.dispositionsByRole 'dcpWasaquorumpresent' true}}
                         data-test-quorum-yes="{{idx}}"
                       />
                       <label
                         for="{{concat idx '-quorum-yes'}}"
-                        {{action 'updateDispositionAttr' hearing assignment.dispositions 'dcpWasaquorumpresent' true}}
+                        {{action 'updateDispositionAttr' hearing assignment.dispositionsByRole 'dcpWasaquorumpresent' true}}
                       >
                         Yes
                       </label>
@@ -87,12 +87,12 @@
                         name={{concat idx '-quorum'}}
                         id={{concat idx '-quorum-no'}}
                         checked={{if (eq hearing.disposition.dcpWasaquorumpresent false) "checked"}}
-                        onClick={{action 'updateDispositionAttr' hearing assignment.dispositions 'dcpWasaquorumpresent' false}}
+                        onClick={{action 'updateDispositionAttr' hearing assignment.dispositionsByRole 'dcpWasaquorumpresent' false}}
                         data-test-quorum-no="{{idx}}"
                       />
                       <label
                         for="{{concat idx '-quorum-no'}}"
-                        {{action 'updateDispositionAttr' hearing assignment.dispositions 'dcpWasaquorumpresent' false}}
+                        {{action 'updateDispositionAttr' hearing assignment.dispositionsByRole 'dcpWasaquorumpresent' false}}
                       >
                         No
                       </label>
@@ -535,7 +535,7 @@
                   >
                     Was a Quorum Present at your Hearing(s)?
                   </h5>
-                  {{#deduped-hearings-list dispositions=assignment.dispositions as |dedupedHearings|}}
+                  {{#deduped-hearings-list dispositions=assignment.dispositionsByRole as |dedupedHearings|}}
                     {{#each dedupedHearings as |hearing idx|}}
                       <p class="grid-x">
                         <strong class="cell small-1"

--- a/mirage/factories/disposition.js
+++ b/mirage/factories/disposition.js
@@ -28,6 +28,9 @@ export default Factory.extend({
 
   dcpCommunityboardrecommendation: null,
 
+  // see afterCreate
+  dcpRepresenting: 'Borough Board',
+
   fullname(i) {
     return faker.list.random('QN BB', 'MN BP', 'BK CB14')(i);
   },

--- a/mirage/factories/project.js
+++ b/mirage/factories/project.js
@@ -199,6 +199,13 @@ export default Factory.extend({
     },
   }),
 
+  withActions: trait({
+    afterCreate(project, server) {
+      server
+        .createList('action', 2, { project });
+    },
+  }),
+
   withActionsAndDispositions: trait({
     afterCreate(project, server) {
       // server

--- a/tests/acceptance/1021-role-specific-dispos-test.js
+++ b/tests/acceptance/1021-role-specific-dispos-test.js
@@ -1,0 +1,89 @@
+import { module, test } from 'qunit';
+import {
+  visit,
+  click,
+  triggerEvent,
+  fillIn,
+} from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { Interactor as Pikaday } from 'ember-pikaday/test-support';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+import { selectChoose } from 'ember-power-select/test-support';
+
+module('Acceptance | 1021 role specific dispos', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('visiting /1021-role-specific-dispos', async function(assert) {
+    this.server.create('assignment', {
+      tab: 'to-review',
+      dcpLupteammemberrole: 'BB',
+      project: this.server.create('project', {
+        id: 4,
+        actions: [
+          this.server.create('action', { id: 1, dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+          this.server.create('action', { id: 2, dcpName: 'Zoning Text Amendment', dcpUlurpnumber: 'N860877TCM' }),
+        ],
+        dispositions: [
+          this.server.create('disposition', {
+            id: 1,
+            dcpRepresenting: 'Borough Board',
+            dcpPublichearinglocation: '',
+            dcpDateofpublichearing: null,
+            dcpProjectaction: 1,
+          }),
+          this.server.create('disposition', {
+            id: 2,
+            dcpRepresenting: 'Borough Board',
+            dcpPublichearinglocation: '',
+            dcpDateofpublichearing: null,
+            dcpProjectaction: 2,
+          }),
+          this.server.create('disposition', {
+            id: 3,
+            dcpRepresenting: 'Community Board',
+            dcpPublichearinglocation: '',
+            dcpDateofpublichearing: null,
+            dcpProjectaction: 2,
+          }),
+          this.server.create('disposition', {
+            id: 4,
+            dcpRepresenting: 'Community Board',
+            dcpPublichearinglocation: '',
+            dcpDateofpublichearing: null,
+            dcpProjectaction: 2,
+          }),
+        ],
+      }),
+      dispositions: this.server.schema.dispositions.all(),
+    });
+
+    await authenticateSession();
+
+    await visit('/my-projects/1/hearing/add');
+
+    const addressTestString = '121 Bananas Ave, Queens, NY';
+
+    await click('[data-test-radio="all-action-yes"]');
+    await fillIn('[data-test-allactions-input="location"]', addressTestString);
+    await triggerEvent('[data-test-allactions-input="location"]', 'keyup', { keyCode: 84 });
+    await click('[data-test-button="checkHearing"]');
+    await click('[data-test-allactions-input="date"]');
+    await Pikaday.selectDate(new Date('2020-10-21T00:00:00'));
+    await click('[data-test-button="checkHearing"]');
+    await fillIn('[data-test-allactions-input="hour"]', 6);
+    await click('[data-test-button="checkHearing"]');
+    await fillIn('[data-test-allactions-input="minute"]', 30);
+    await click('[data-test-button="checkHearing"]');
+    await selectChoose('[data-test-allactions-dropdown="timeOfDay"]', 'PM');
+    await click('[data-test-button="checkHearing"]');
+    await click('[data-test-button="confirmHearing"]');
+
+    const submittedDispos = this.server.schema.dispositions.where({
+      dcpPublichearinglocation: addressTestString,
+    });
+
+    assert.equal(submittedDispos.length, 2, 'Only affected dispositions are those for assigned role');
+  });
+});

--- a/tests/acceptance/542-document-upload-for-recommendation-test.js
+++ b/tests/acceptance/542-document-upload-for-recommendation-test.js
@@ -11,10 +11,13 @@ import { upload } from 'ember-file-upload/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { invalidateSession, authenticateSession } from 'ember-simple-auth/test-support';
+import { participantRoles } from 'labs-zap-search/models/assignment';
 import moment from 'moment';
 
 // Sets up assignment will have 3 dispos with hearings
 function setUpProjectAndDispos(server, participantType) {
+  const { label } = participantRoles.findBy('abbreviation', participantType);
+
   server.create('user', {
     id: 1,
     // These two fields don't matter to these tests
@@ -27,16 +30,19 @@ function setUpProjectAndDispos(server, participantType) {
         dcpLupteammemberrole: participantType,
         dispositions: [
           server.create('disposition', {
+            dcpRepresenting: label,
             dcpPublichearinglocation: 'Canal street',
             dcpDateofpublichearing: moment().subtract(22, 'days'),
             action: server.create('action'),
           }),
           server.create('disposition', {
+            dcpRepresenting: label,
             dcpPublichearinglocation: 'Canal street',
             dcpDateofpublichearing: moment().subtract(22, 'days'),
             action: server.create('action'),
           }),
           server.create('disposition', {
+            dcpRepresenting: label,
             dcpPublichearinglocation: 'Hudson Yards',
             dcpDateofpublichearing: moment().subtract(28, 'days'),
             action: server.create('action'),

--- a/tests/acceptance/930-recommendation-action-dropdown-bug-test.js
+++ b/tests/acceptance/930-recommendation-action-dropdown-bug-test.js
@@ -11,12 +11,16 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { authenticateSession } from 'ember-simple-auth/test-support';
 import { RECOMMENDATION_OPTIONSET_BY_PARTICIPANT_TYPE_LOOKUP } from 'labs-zap-search/controllers/my-projects/assignment/recommendations/add';
 import moment from 'moment';
+import { participantRoles } from 'labs-zap-search/models/assignment';
 
 module('Acceptance | 930 recommendation action dropdown bug', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
   test('Participant can submit a different recommendation for each action', async function(assert) {
+    const participantType = 'BP';
+    const { label } = participantRoles.findBy('abbreviation', participantType);
+
     server.create('user', {
       id: 1,
       // These two fields don't matter to these tests
@@ -26,19 +30,22 @@ module('Acceptance | 930 recommendation action dropdown bug', function(hooks) {
         server.create('assignment', {
           id: 1,
           tab: 'to-review',
-          dcpLupteammemberrole: 'BP',
+          dcpLupteammemberrole: participantType,
           dispositions: [
             server.create('disposition', {
+              dcpRepresenting: label,
               dcpPublichearinglocation: 'Canal street',
               dcpDateofpublichearing: moment().subtract(22, 'days'),
               action: server.create('action'),
             }),
             server.create('disposition', {
+              dcpRepresenting: label,
               dcpPublichearinglocation: 'Canal street',
               dcpDateofpublichearing: moment().subtract(22, 'days'),
               action: server.create('action'),
             }),
             server.create('disposition', {
+              dcpRepresenting: label,
               dcpPublichearinglocation: 'Hudson Yards',
               dcpDateofpublichearing: moment().subtract(28, 'days'),
               action: server.create('action'),
@@ -52,10 +59,11 @@ module('Acceptance | 930 recommendation action dropdown bug', function(hooks) {
         server.create('assignment', {
           id: 2,
           tab: 'to-review',
-          dcpLupteammemberrole: 'BP',
+          dcpLupteammemberrole: participantType,
           dispositions: [
             server.create('disposition', {
               id: 5,
+              dcpRepresenting: label,
               dcpIspublichearingrequired: 'No',
               dcpPublichearinglocation: null,
               dcpDateofpublichearing: null,

--- a/tests/acceptance/user-can-submit-recommendation-form-test.js
+++ b/tests/acceptance/user-can-submit-recommendation-form-test.js
@@ -10,10 +10,13 @@ import { selectChoose } from 'ember-power-select/test-support';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { invalidateSession, authenticateSession } from 'ember-simple-auth/test-support';
+import { participantRoles } from 'labs-zap-search/models/assignment';
 import moment from 'moment';
 
 // First assignment will have 3 dispos with hearings, second assignment will have 1 dispo without hearing
 function setUpProjectAndDispos(server, participantType) {
+  const { label: dcpRepresenting } = participantRoles.findBy('abbreviation', participantType);
+
   server.create('user', {
     id: 1,
     // These two fields don't matter to these tests
@@ -27,6 +30,7 @@ function setUpProjectAndDispos(server, participantType) {
         dispositions: [
           server.create('disposition', {
             id: 1,
+            dcpRepresenting,
             dcpPublichearinglocation: 'Canal street',
             dcpDateofpublichearing: moment().subtract(22, 'days'),
             dcpProjectaction: '1',
@@ -34,6 +38,7 @@ function setUpProjectAndDispos(server, participantType) {
           }),
           server.create('disposition', {
             id: 2,
+            dcpRepresenting,
             dcpPublichearinglocation: 'Canal street',
             dcpDateofpublichearing: moment().subtract(22, 'days'),
             dcpProjectaction: '2',
@@ -41,6 +46,7 @@ function setUpProjectAndDispos(server, participantType) {
           }),
           server.create('disposition', {
             id: 3,
+            dcpRepresenting,
             dcpPublichearinglocation: 'Hudson Yards',
             dcpDateofpublichearing: moment().subtract(28, 'days'),
             dcpProjectaction: '3',
@@ -56,6 +62,7 @@ function setUpProjectAndDispos(server, participantType) {
           dispositions: [
             server.create('disposition', {
               id: 1,
+              dcpRepresenting,
               dcpPublichearinglocation: 'Canal street',
               dcpDateofpublichearing: moment().subtract(22, 'days'),
               dcpProjectaction: '1',
@@ -63,6 +70,7 @@ function setUpProjectAndDispos(server, participantType) {
             }),
             server.create('disposition', {
               id: 2,
+              dcpRepresenting,
               dcpPublichearinglocation: 'Canal street',
               dcpDateofpublichearing: moment().subtract(22, 'days'),
               dcpProjectaction: '2',
@@ -70,6 +78,7 @@ function setUpProjectAndDispos(server, participantType) {
             }),
             server.create('disposition', {
               id: 3,
+              dcpRepresenting,
               dcpPublichearinglocation: 'Hudson Yards',
               dcpDateofpublichearing: moment().subtract(28, 'days'),
               dcpProjectaction: '3',
@@ -85,6 +94,7 @@ function setUpProjectAndDispos(server, participantType) {
         dispositions: [
           server.create('disposition', {
             id: 5,
+            dcpRepresenting,
             dcpIspublichearingrequired: 'No',
             dcpPublichearinglocation: null,
             dcpDateofpublichearing: null,
@@ -99,6 +109,7 @@ function setUpProjectAndDispos(server, participantType) {
           dispositions: [
             server.create('disposition', {
               id: 5,
+              dcpRepresenting,
               dcpIspublichearingrequired: 'No',
               dcpPublichearinglocation: null,
               dcpDateofpublichearing: null,


### PR DESCRIPTION
Closes #1021 

Filters dispositions to be assignment-specific.

Warning: Depends heavily on computed property on the assignment. 