### PR TITLE
Pass QP to server if available

### DIFF
--- a/app/controllers/my-projects.js
+++ b/app/controllers/my-projects.js
@@ -5,6 +5,8 @@ import { inject as service } from '@ember/service';
 export default class MyProjectsController extends Controller {
   @service router;
 
+  queryParams = ['email'];
+
   @computed('router.currentRouteName')
   get activeTab() {
     const route = this.get('router.currentRouteName').split('.')[1];

--- a/app/routes/my-projects.js
+++ b/app/routes/my-projects.js
@@ -3,13 +3,4 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 
 const AuthenticatedRoute = Route.extend(AuthenticatedRouteMixin);
 
-export default class MyProjectsRoute extends AuthenticatedRoute {
-  // async model() {
-  //   return this.store.query('assignment', {
-  //     tab: 'to-review',
-  //     include: 'project.milestones,project.dispositions,project.actions',
-  //   }, {
-  //     reload: false,
-  //   });
-  // }
-}
+export default class MyProjectsRoute extends AuthenticatedRoute {}

--- a/app/routes/my-projects.js
+++ b/app/routes/my-projects.js
@@ -4,12 +4,12 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 const AuthenticatedRoute = Route.extend(AuthenticatedRouteMixin);
 
 export default class MyProjectsRoute extends AuthenticatedRoute {
-  async model() {
-    return this.store.query('assignment', {
-      tab: 'to-review',
-      include: 'project.milestones,project.dispositions,project.actions',
-    }, {
-      reload: false,
-    });
-  }
+  // async model() {
+  //   return this.store.query('assignment', {
+  //     tab: 'to-review',
+  //     include: 'project.milestones,project.dispositions,project.actions',
+  //   }, {
+  //     reload: false,
+  //   });
+  // }
 }

--- a/app/routes/my-projects/archive.js
+++ b/app/routes/my-projects/archive.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { get } from '@ember/object';
 
 export default class MyProjectsArchiveRoute extends Route {
   @service
@@ -8,10 +9,13 @@ export default class MyProjectsArchiveRoute extends Route {
   @service
   store;
 
-  async model() {
+  async model(model, transition) {
+    const email = get(transition, 'to.queryParams.email');
+
     // Use this endpoint for now. This will need to be updated when the backend is finalized.
     return this.store.query('assignment', {
       tab: 'archive',
+      ...(email ? { email } : {}),
       include: 'project.milestones,project.dispositions,project.actions,project.dispositions.action,dispositions,dispositions.action',
     }, {
       reload: true,

--- a/app/routes/my-projects/reviewed.js
+++ b/app/routes/my-projects/reviewed.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { get } from '@ember/object';
 
 export default class MyProjectsReviewedRoute extends Route {
   @service
@@ -8,9 +9,12 @@ export default class MyProjectsReviewedRoute extends Route {
   @service
   store;
 
-  async model() {
+  async model(model, transition) {
+    const email = get(transition, 'to.queryParams.email');
+
     return this.store.query('assignment', {
       tab: 'reviewed',
+      ...(email ? { email } : {}),
       include: 'project.milestones,project.dispositions,project.actions,project.dispositions.action,dispositions,dispositions.action',
     }, {
       reload: true,

--- a/app/routes/my-projects/to-review.js
+++ b/app/routes/my-projects/to-review.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { get } from '@ember/object';
 
 export default class MyProjectsToReviewRoute extends Route {
   @service
@@ -8,9 +9,12 @@ export default class MyProjectsToReviewRoute extends Route {
   @service
   store;
 
-  async model() {
+  async model(model, transition) {
+    const email = get(transition, 'to.queryParams.email');
+
     return this.store.query('assignment', {
       tab: 'to-review',
+      ...(email ? { email } : {}),
       include: 'project.milestones,project.dispositions,project.actions,dispositions,dispositions.action',
     }, {
       reload: true,

--- a/app/routes/my-projects/upcoming.js
+++ b/app/routes/my-projects/upcoming.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import { get } from '@ember/object';
 
 export default class MyProjectsUpcomingRoute extends Route {
   @service
@@ -8,9 +9,12 @@ export default class MyProjectsUpcomingRoute extends Route {
   @service
   store;
 
-  async model() {
+  async model(model, transition) {
+    const email = get(transition, 'to.queryParams.email');
+
     return this.store.query('assignment', {
       tab: 'upcoming',
+      ...(email ? { email } : {}),
       include: 'project.milestones,project.dispositions,project.actions,project.dispositions.action,dispositions,dispositions.action',
     }, {
       reload: true,

--- a/tests/acceptance/pass-optional-email-param-test.js
+++ b/tests/acceptance/pass-optional-email-param-test.js
@@ -1,0 +1,39 @@
+import { module, test } from 'qunit';
+import { visit, click } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+import { authenticateSession } from 'ember-simple-auth/test-support';
+
+module('Acceptance | pass optional email param', function(hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('my projects passes optional email params', async function(assert) {
+    await authenticateSession();
+    await visit('/my-projects/to-review?email=test@test.com');
+
+    const [req] = this.server.pretender.handledRequests;
+
+    assert.equal(req.queryParams.email, 'test@test.com');
+  });
+
+  test('my projects passes optional email params to upcoming', async function(assert) {
+    await authenticateSession();
+    await visit('/my-projects/upcoming?email=test@test.com');
+
+    const [req] = this.server.pretender.handledRequests;
+
+    assert.equal(req.queryParams.email, 'test@test.com');
+  });
+
+  test('tab through with param', async function(assert) {
+    await authenticateSession();
+    await visit('/my-projects/to-review?email=test@test.com');
+    await click('[data-test-tab-button="upcoming"]');
+
+    const [req, req2] = this.server.pretender.handledRequests;
+
+    assert.equal(req.queryParams.email, 'test@test.com');
+    assert.equal(req2.queryParams.email, 'test@test.com');
+  });
+});


### PR DESCRIPTION
FE changes for https://github.com/NYCPlanning/zap-api/pull/56 (not dependent on merging).

Allows passage of optional `email` qp to backend.

Closes #843 