### PR TITLE
Unknown Date Text

### DIFF
--- a/app/templates/components/date-display.hbs
+++ b/app/templates/components/date-display.hbs
@@ -1,7 +1,7 @@
 {{#if this.date}}
   {{~moment-format this.date this.outputFormat this.inputFormat~}}
 {{else}}
-  <small class="light-gray">
+  <span class="light-gray">
     {{this.errorMessage}}
-  </small>
+  </span>
 {{/if}}

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -41,7 +41,9 @@
               {{#if (not (eq isMoreThanThirtyDaysBeforePublicReview null))}}
                 {{if isMoreThanThirtyDaysBeforePublicReview 'in more than 30 days' 'in fewer than 30 days'}}
               {{else}}
-                Date Unknown
+                <span class="light-gray">
+                  Date Unknown
+                </span>
               {{/if}}
             </strong>
           </p>

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -27,6 +27,9 @@
               />
             </strong>
           </p>
+          <p class="text-center text-tiny">
+            (Estimated Start Date)
+          </p>
         {{else}}
           <p class="tiny-margin-bottom">
             Public Review Begins
@@ -38,14 +41,9 @@
               {{#if (not (eq isMoreThanThirtyDaysBeforePublicReview null))}}
                 {{if isMoreThanThirtyDaysBeforePublicReview 'in more than 30 days' 'in fewer than 30 days'}}
               {{else}}
-                unknown date
+                Date Unknown
               {{/if}}
             </strong>
-          </p>
-        {{/if}}
-        {{#if (eq isMoreThanThirtyDaysBeforePublicReview null)}}
-          <p class="text-center text-tiny">
-            (Estimated Start Date)
           </p>
         {{/if}}
       </div>


### PR DESCRIPTION
This PR makes the "unknown date" text consistent in the Upcoming tab. It also fixes the broken logic for displaying "(Estimated Start Date)" when we're actually showing dates. 