### PR TITLE
873: replace lastmilestonedate with dcpLastmilestonedate

### DIFF
--- a/app/models/project.js
+++ b/app/models/project.js
@@ -101,7 +101,7 @@ export default class ProjectModel extends Model {
 
   @attr() center;
 
-  @attr() lastmilestonedate;
+  @attr() dcpLastmilestonedate;
 
   @attr() videoLinks;
 

--- a/app/templates/components/project-list-item.hbs
+++ b/app/templates/components/project-list-item.hbs
@@ -12,11 +12,11 @@
     <span class="label publicstatus-label">{{unless (eq project.dcpPublicstatusSimp 'Unknown') project.dcpPublicstatusSimp "Unknown Status"}}</span>
   </div>
   <div class="cell auto">
-    {{#if project.lastmilestonedate}}
+    {{#if project.dcpLastmilestonedate}}
       <span class="date dark-gray projects-list-result--date">
         {{icon-tooltip icon='calendar' tip='Latest Milestone'}}
         <DateDisplay
-          @date={{project.lastmilestonedate}}
+          @date={{project.dcpLastmilestonedate}}
           @outputFormat="MMMM D, YYYY"
         />
       </span>

--- a/app/templates/components/projects-map-data.hbs
+++ b/app/templates/components/projects-map-data.hbs
@@ -12,7 +12,7 @@
 
   {{#if highlightedFeature}}
     <div class='map-tooltip' style="top:{{tooltipPoint.y}}px;left:{{tooltipPoint.x}}px;">
-      {{highlightedFeature.properties.dcp_projectname}} (<DateDisplay @date={{highlightedFeature.properties.lastmilestonedate}} @outputFormat="MMMM, YYYY" />)
+      {{highlightedFeature.properties.dcp_projectname}} (<DateDisplay @date={{highlightedFeature.properties.dcpLastmilestonedate}} @outputFormat="MMMM, YYYY" />)
     </div>
   {{/if}}
 


### PR DESCRIPTION
Related to backend changes where, instead of calculating `lastmilestonedate` ourselves in the API, we're just grabbing this value from a CRM field `dcp_lastmilestonedate`

Related to backend PR [#60](https://github.com/NYCPlanning/zap-api/pull/60)

Addresses #873 