### PR TITLE
1041: display but disable post hearings button if there are no disps

### DIFF
--- a/app/templates/components/to-review-project-card.hbs
+++ b/app/templates/components/to-review-project-card.hbs
@@ -43,38 +43,38 @@
       </div>
     </div>
     <div class="cell medium-8 large-auto">
-      {{#if this.assignment.dispositionsByRole}}
-        {{#if assignment.hearingsNotSubmittedNotWaived}}
-          <div class="grid-x">
-            <div class="cell medium-auto">
-              <LinkTo
-                @route="my-projects.assignment.hearing.add"
-                @model={{assignment}}
-                class="button expanded tiny-margin-bottom"
-                data-test-button-post-hearing="{{assignment.id}}"
-              >
-                {{fa-icon 'calendar' fixedWidth=true size="lg" transform="left-2"}}
-                Post {{participant-type-label assignment.dcpLupteammemberrole}} Hearing Notice
-              </LinkTo>
-            </div>
-            <div class="cell medium-shrink">
-              <button
-                class="button expanded gray"
-                onClick={{action "openOptOutHearingPopup"}}
-                data-test-button="optOutHearingOpenPopup"
-              >
-                {{fa-icon 'calendar-times' size="lg" transform="shrink-5 down-1"}}
-                <small>Opt Out</small>
-              </button>
-            </div>
+      {{#if assignment.hearingsNotSubmittedNotWaived}}
+        <div class="grid-x">
+          <div class="cell medium-auto">
+            <LinkTo
+              @route={{if this.assignment.dispositionsByRole "my-projects.assignment.hearing.add"}}
+              @model={{if this.assignment.dispositionsByRole this.assignment}}
+              class="button expanded tiny-margin-bottom"
+              disabled={{not this.assignment.dispositionsByRole}}
+              data-test-button-post-hearing="{{assignment.id}}"
+            >
+              {{fa-icon 'calendar' fixedWidth=true size="lg" transform="left-2"}}
+              Post {{participant-type-label assignment.dcpLupteammemberrole}} Hearing Notice
+            </LinkTo>
           </div>
-        {{else}}
-          {{#if assignment.hearingsWaived}}
-            <span class="opt-out-notice" data-test-hearings-waived-message="{{assignment.project.id}}">
-              {{fa-icon 'calendar-times' size="lg" transform="left-2"}}
-              You've opted out of posting a hearing
-            </span>
-          {{/if}}
+          <div class="cell medium-shrink">
+            <button
+              class="button expanded gray"
+              onClick={{action "openOptOutHearingPopup"}}
+              disabled={{not this.assignment.dispositions}}
+              data-test-button-opt-out-hearing-popup="{{this.assignment.id}}"
+            >
+              {{fa-icon 'calendar-times' size="lg" transform="shrink-5 down-1"}}
+              <small>Opt Out</small>
+            </button>
+          </div>
+        </div>
+      {{else}}
+        {{#if assignment.hearingsWaived}}
+          <span class="opt-out-notice" data-test-hearings-waived-message="{{assignment.project.id}}">
+            {{fa-icon 'calendar-times' size="lg" transform="left-2"}}
+            You've opted out of posting a hearing
+          </span>
         {{/if}}
       {{/if}}
 

--- a/app/templates/components/upcoming-project-card.hbs
+++ b/app/templates/components/upcoming-project-card.hbs
@@ -51,38 +51,38 @@
       </div>
     </div>
     <div class="cell medium-auto">
-      {{#if this.assignment.dispositionsByRole}}
-        {{#if this.assignment.hearingsNotSubmittedNotWaived}}
-          <div class="grid-x">
-            <div class="cell medium-auto">
-              <LinkTo
-                @route="my-projects.assignment.hearing.add"
-                @model={{this.assignment}}
-                class="button expanded"
-                data-test-button-post-hearing="{{this.assignment.id}}"
-              >
-                {{fa-icon 'calendar' fixedWidth=true size="lg" transform="left-2"}}
-                Post {{participant-type-label this.assignment.dcpLupteammemberrole}} Hearing Notice
-              </LinkTo>
-            </div>
-            <div class="cell medium-shrink">
-              <button
-                class="button expanded gray"
-                onClick={{action "openOptOutHearingPopup"}}
-                data-test-button="optOutHearingOpenPopup"
-              >
-                {{fa-icon 'calendar-times' size="lg" transform="shrink-5 down-1"}}
-                <small>Opt Out</small>
-              </button>
-            </div>
+      {{#if this.assignment.hearingsNotSubmittedNotWaived}}
+        <div class="grid-x">
+          <div class="cell medium-auto">
+            <LinkTo
+              @route={{if this.assignment.dispositionsByRole "my-projects.assignment.hearing.add"}}
+              @model={{if this.assignment.dispositionsByRole this.assignment}}
+              class="button expanded"
+              disabled={{not this.assignment.dispositionsByRole}}
+              data-test-button-post-hearing="{{this.assignment.id}}"
+            >
+              {{fa-icon 'calendar' fixedWidth=true size="lg" transform="left-2"}}
+              Post {{participant-type-label this.assignment.dcpLupteammemberrole}} Hearing Notice
+            </LinkTo>
           </div>
-        {{else}}
-          {{#if assignment.hearingsWaived}}
-            <span class="opt-out-notice" data-test-hearings-waived-message="{{assignment.project.id}}">
-              {{fa-icon 'calendar-times' size="lg" transform="left-2"}}
-              You've opted out of posting a hearing
-            </span>
-          {{/if}}
+          <div class="cell medium-shrink">
+            <button
+              class="button expanded gray"
+              onClick={{action "openOptOutHearingPopup"}}
+              disabled={{not this.assignment.dispositionsByRole}}
+              data-test-button-opt-out-hearing-popup="{{this.assignment.id}}"
+            >
+              {{fa-icon 'calendar-times' size="lg" transform="shrink-5 down-1"}}
+              <small>Opt Out</small>
+            </button>
+          </div>
+        </div>
+      {{else}}
+        {{#if assignment.hearingsWaived}}
+          <span class="opt-out-notice" data-test-hearings-waived-message="{{assignment.project.id}}">
+            {{fa-icon 'calendar-times' size="lg" transform="left-2"}}
+            You've opted out of posting a hearing
+          </span>
         {{/if}}
       {{/if}}
 

--- a/app/templates/my-projects.hbs
+++ b/app/templates/my-projects.hbs
@@ -9,7 +9,7 @@
             {{#link-to 'my-projects.upcoming'}}<span data-test-tab-button="upcoming">Upcoming</span>{{/link-to}}
           </li>
           <li class="tabs-title to-review {{if (eq activeTab 'to-review') 'is-active'}}">
-            {{#link-to 'my-projects.to-review'}}To Review{{/link-to}}
+            {{#link-to 'my-projects.to-review'}}<span data-test-tab-button="to-review">To Review</span>{{/link-to}}
           </li>
           <li class="tabs-title reviewed {{if (eq activeTab 'reviewed') 'is-active'}}">
             {{#link-to 'my-projects.reviewed'}}Reviewed{{/link-to}}

--- a/tests/acceptance/user-can-fill-out-hearing-form-test.js
+++ b/tests/acceptance/user-can-fill-out-hearing-form-test.js
@@ -883,7 +883,7 @@ module('Acceptance | user can fill out hearing form', function(hooks) {
       tab: 'upcoming',
       dispositions: [],
       project: this.server.create('project', {
-        id: 4,
+        id: 31,
         actions: [
           server.create('action', { id: '32a6b44c-8c0c-ea11-a9a8-001dd830804f', dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
         ],
@@ -891,9 +891,71 @@ module('Acceptance | user can fill out hearing form', function(hooks) {
       }),
     });
 
+    this.server.create('assignment', {
+      id: 5,
+      tab: 'upcoming',
+      dispositions: [
+        server.create('disposition', {
+          id: 1,
+          dcpPublichearinglocation: '',
+          dcpDateofpublichearing: null,
+          dcpProjectaction: '32a6b44c-8c0c-ea11-a9a8-001dd830804f',
+          // action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+        }),
+      ],
+      project: this.server.create('project', {
+        id: 30,
+        actions: [
+          server.create('action', { id: '32a6b44c-8c0c-ea11-a9a8-001dd830804f', dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+        ],
+        dispositions: [
+          server.create('disposition', {
+            id: 1,
+            dcpPublichearinglocation: '',
+            dcpDateofpublichearing: null,
+            dcpProjectaction: '32a6b44c-8c0c-ea11-a9a8-001dd830804f',
+            // action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+          }),
+        ],
+      }),
+    });
+
     await visit('/my-projects/upcoming');
 
-    assert.notOk(find('[data-test-button-post-hearing="4"]'));
+    // ############ ASSIGNMENT 4 ################################################
+    // Assignment 4 DOES NOT have dispositions, so hearing buttons should be disabled
+
+    // button should display, but should be disabled
+    assert.ok(find('[data-test-button-post-hearing="4"]'));
+
+    // clicking on the post hearing button should NOT change the route
+    await click('[data-test-button-post-hearing="4"]');
+
+    assert.equal(currentURL(), '/my-projects/upcoming');
+
+    // clicking on the opt out of hearings button should NOT open the modal
+    await click('[data-test-button-opt-out-hearing-popup="4"]');
+
+    // check that button on the "opt out of hearings" modal is not displaying
+    assert.notOk(find('[data-test-button="onConfirmOptOutHearing"]'));
+
+    // ############ ASSIGNMENT 5 ################################################
+    // Assignment 5 DOES have a disposition, so hearing buttons should be clickable
+
+    // clicking the post hearings button should change the route
+    await click('[data-test-button-post-hearing="5"]');
+
+    assert.equal(currentURL(), '/my-projects/5/hearing/add');
+
+    // return to the UPCOMING tab
+    await click('[data-test-my-projects-button]');
+    await click('[data-test-tab-button="upcoming"]');
+
+    // clicking on the "opt out of hearings" button should open the modal
+    await click('[data-test-button-opt-out-hearing-popup="5"]');
+
+    // check that the button on the modal is displaying
+    assert.ok(find('[data-test-button="onConfirmOptOutHearing"]'));
   });
 
   test('button for TO-REVIEW hearing submission does not show if there are no dispositions', async function(assert) {
@@ -902,7 +964,7 @@ module('Acceptance | user can fill out hearing form', function(hooks) {
       tab: 'to-review',
       dispositions: [],
       project: this.server.create('project', {
-        id: 4,
+        id: 31,
         actions: [
           server.create('action', { id: '32a6b44c-8c0c-ea11-a9a8-001dd830804f', dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
         ],
@@ -910,9 +972,71 @@ module('Acceptance | user can fill out hearing form', function(hooks) {
       }),
     });
 
+    this.server.create('assignment', {
+      id: 5,
+      tab: 'to-review',
+      dispositions: [
+        server.create('disposition', {
+          id: 1,
+          dcpPublichearinglocation: '',
+          dcpDateofpublichearing: null,
+          dcpProjectaction: '32a6b44c-8c0c-ea11-a9a8-001dd830804f',
+          // action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+        }),
+      ],
+      project: this.server.create('project', {
+        id: 30,
+        actions: [
+          server.create('action', { id: '32a6b44c-8c0c-ea11-a9a8-001dd830804f', dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+        ],
+        dispositions: [
+          server.create('disposition', {
+            id: 1,
+            dcpPublichearinglocation: '',
+            dcpDateofpublichearing: null,
+            dcpProjectaction: '32a6b44c-8c0c-ea11-a9a8-001dd830804f',
+            // action: server.create('action', { dcpName: 'Zoning Special Permit', dcpUlurpnumber: 'C780076TLK' }),
+          }),
+        ],
+      }),
+    });
+
     await visit('/my-projects/to-review');
 
-    assert.notOk(find('[data-test-button-post-hearing="4"]'));
+    // ############ ASSIGNMENT 4 ################################################
+    // Assignment 4 DOES NOT have dispositions, so hearing buttons should be disabled
+
+    // button should display, but should be disabled
+    assert.ok(find('[data-test-button-post-hearing="4"]'));
+
+    // clicking on the post hearing button should NOT change the route
+    await click('[data-test-button-post-hearing="4"]');
+
+    assert.equal(currentURL(), '/my-projects/to-review');
+
+    // clicking on the opt out of hearings button should open NOT the modal
+    await click('[data-test-button-opt-out-hearing-popup="4"]');
+
+    // check that button on the "opt out of hearings" modal is not displaying
+    assert.notOk(find('[data-test-button="onConfirmOptOutHearing"]'));
+
+    // ############ ASSIGNMENT 5 ################################################
+    // Assignment 5 DOES have a disposition, so hearing buttons should be clickable
+
+    // clicking the post hearings button should change the route
+    await click('[data-test-button-post-hearing="5"]');
+
+    assert.equal(currentURL(), '/my-projects/5/hearing/add');
+
+    // return to the to-review tab
+    await click('[data-test-my-projects-button]');
+    await click('[data-test-tab-button="to-review"]');
+
+    // clicking on the "opt out of hearings" button should open the modal
+    await click('[data-test-button-opt-out-hearing-popup="5"]');
+
+    // check that the button on the modal is displaying
+    assert.ok(find('[data-test-button="onConfirmOptOutHearing"]'));
   });
 
   test('modal does not open if user deletes hour or minute input', async function(assert) {

--- a/tests/acceptance/user-can-waive-hearings-test.js
+++ b/tests/acceptance/user-can-waive-hearings-test.js
@@ -81,7 +81,7 @@ module('Acceptance | user can waive hearings', function(hooks) {
     assert.notOk(find('[data-test-button="onConfirmOptOutHearing"]'));
     assert.notOk(find('[data-test-button="closeOptOutHearingPopup"]'));
 
-    await click('[data-test-button="optOutHearingOpenPopup"]');
+    await click('[data-test-button-opt-out-hearing-popup="4"]');
 
     assert.ok(find('[data-test-button="onConfirmOptOutHearing"]'));
     assert.ok(find('[data-test-button="closeOptOutHearingPopup"]'));
@@ -154,7 +154,7 @@ module('Acceptance | user can waive hearings', function(hooks) {
     assert.notOk(find('[data-test-button="onConfirmOptOutHearing"]'));
     assert.notOk(find('[data-test-button="closeOptOutHearingPopup"]'));
 
-    await click('[data-test-button="optOutHearingOpenPopup"]');
+    await click('[data-test-button-opt-out-hearing-popup="4"]');
 
     assert.ok(find('[data-test-button="onConfirmOptOutHearing"]'));
     assert.ok(find('[data-test-button="closeOptOutHearingPopup"]'));
@@ -163,7 +163,7 @@ module('Acceptance | user can waive hearings', function(hooks) {
 
     assert.notOk(find('[data-test-button="onConfirmOptOutHearing"]'));
 
-    assert.notOk(find('[data-test-button="optOutHearingOpenPopup"]'));
+    assert.notOk(find('[data-test-button-opt-out-hearing-popup="4"]'));
 
     assert.ok(find('[data-test-hearings-waived-message="4"]'));
 
@@ -219,9 +219,9 @@ module('Acceptance | user can waive hearings', function(hooks) {
 
     await visit('/my-projects/to-review');
 
-    assert.ok(find('[data-test-button="optOutHearingOpenPopup"]'));
+    assert.ok(find('[data-test-button-opt-out-hearing-popup="4"]'));
 
-    await click('[data-test-button="optOutHearingOpenPopup"]');
+    await click('[data-test-button-opt-out-hearing-popup="4"]');
 
     assert.ok(find('[data-test-button="onConfirmOptOutHearing"]'));
 
@@ -231,7 +231,7 @@ module('Acceptance | user can waive hearings', function(hooks) {
 
     await click('[data-test-button="backToMyProjectsAfterError"]');
 
-    assert.ok(find('[data-test-button="optOutHearingOpenPopup"]'));
+    assert.ok(find('[data-test-button-opt-out-hearing-popup="4"]'));
   });
 
   test('if there is a server error when running .save(), user will see error message on upcoming tab', async function(assert) {
@@ -283,9 +283,9 @@ module('Acceptance | user can waive hearings', function(hooks) {
 
     await visit('/my-projects/upcoming');
 
-    assert.ok(find('[data-test-button="optOutHearingOpenPopup"]'));
+    assert.ok(find('[data-test-button-opt-out-hearing-popup="4"]'));
 
-    await click('[data-test-button="optOutHearingOpenPopup"]');
+    await click('[data-test-button-opt-out-hearing-popup="4"]');
 
     assert.ok(find('[data-test-button="onConfirmOptOutHearing"]'));
 
@@ -295,6 +295,6 @@ module('Acceptance | user can waive hearings', function(hooks) {
 
     await click('[data-test-button="backToMyProjectsAfterError"]');
 
-    assert.ok(find('[data-test-button="optOutHearingOpenPopup"]'));
+    assert.ok(find('[data-test-button-opt-out-hearing-popup="4"]'));
   });
 });


### PR DESCRIPTION
### Changes
- Previously on `upcoming` and `to-review` tabs, we were NOT displaying the hearing button if an assignment had NO dispositions `{{#if this.assignment.dispositionsByRole}}`
- This PR removes the conditional shown above and now DISPLAYS the post hearings button if there are NO dispositions, but the button will be DISABLED

``` 
<LinkTo
   @route={{if this.assignment.dispositionsByRole "my-projects.assignment.hearing.add"}}
   @model={{if this.assignment.dispositionsByRole this.assignment}}
   disabled={{not this.assignment.dispositionsByRole}}
  >
```

- The `LinkTo` `disabled` attribute only changes the look of the button but does not actually disable its functionality, so I put conditionals in the `@route` tag of the `LinkTo` and `@model` tag of the `LinkTo` to prevent transitioning to a route if there were no dispositions for that assignment. 

### Tests
- two acceptance tests to check this behavior, one for the `upcoming` tab and one for the `to-review` tab
- updated test selector names

Closes #1041 