### PR TITLE
1057 allow retry

### DIFF
--- a/app/controllers/my-projects/assignment/hearing/add.js
+++ b/app/controllers/my-projects/assignment/hearing/add.js
@@ -47,6 +47,7 @@ export default class MyProjectsProjectHearingAddController extends Controller {
     // set to true for a visual display of which inputs are invalid
     // passed down to date-time-picker and location-input components
     this.set('checkIfMissing', true);
+    this.set('error', null);
 
     const { dispositionsByRole: dispositions } = this.model;
     const dispositionForAllActions = this.get('dispositionForAllActions');
@@ -86,6 +87,8 @@ export default class MyProjectsProjectHearingAddController extends Controller {
   @action
   async onConfirm() {
     const { dispositionsByRole: dispositions } = this.model;
+    this.set('error', null);
+
     const allActions = this.get('allActions') || (dispositions.length <= 1);
 
     // if user is submitting ONE hearing for ALL actions
@@ -108,6 +111,7 @@ export default class MyProjectsProjectHearingAddController extends Controller {
       this.set('modalOpen', false);
       this.transitionToRoute('my-projects.assignment.hearing.done');
     }, (e) => {
+      console.log('is true error state');
       this.set('error', e);
       console.log('server error', e);
     });

--- a/app/controllers/my-projects/assignment/recommendations/add.js
+++ b/app/controllers/my-projects/assignment/recommendations/add.js
@@ -321,17 +321,10 @@ export default class MyProjectsProjectRecommendationsAddController extends Contr
     // had files successfully uploaded to it
     const uploadResults = [];
 
-    const assignmentQueueOriginalLength = this.assignmentQueue.files.length;
-
     try {
       // copy files from assignmentQueue to each disposition queue
       for (let i = 0; i < this.assignmentQueue.files.length; i += 1) {
         await this.addFileToDispositionQueues(this.assignmentQueue.files[i]); // eslint-disable-line
-      }
-
-      // flush assignment queue after copying is complete
-      while (this.assignmentQueue.files.length > 0) {
-        this.assignmentQueue.remove(this.assignmentQueue.files[0]);
       }
 
       // upload files across dispositions queues
@@ -352,7 +345,7 @@ export default class MyProjectsProjectRecommendationsAddController extends Contr
         const fileUploadResponses = await Promise.all(fileUploadPromises); // eslint-disable-line
 
         // The check for matching fileUploadResponse length and assignmentQueueOriginalLength supports acceptance tests
-        const filesUploadedToDispo = fileUploadResponses.every(res => res.status === 200) && fileUploadResponses.length === assignmentQueueOriginalLength;
+        const filesUploadedToDispo = fileUploadResponses.every(res => res.status === 200);
 
         uploadResults.push(filesUploadedToDispo);
       }
@@ -365,6 +358,11 @@ export default class MyProjectsProjectRecommendationsAddController extends Contr
     // Only proceed if all files were uploaded to all dispositions
     // The check for matching uploadResults and dispositions length supports acceptance tests
     if (uploadResults.every(res => res === true) && (uploadResults.length === this.dispositions.length) && !this.submitError) {
+      // flush assignment queue after copying is complete
+      while (this.assignmentQueue.files.length > 0) {
+        this.assignmentQueue.remove(this.assignmentQueue.files[0]);
+      }
+
       const { participantType } = this;
       const targetField = RECOMMENDATION_FIELD_BY_PARTICIPANT_TYPE_LOOKUP[participantType];
       this.dispositionForAllActionsChangeset.execute();

--- a/app/controllers/my-projects/assignment/recommendations/add.js
+++ b/app/controllers/my-projects/assignment/recommendations/add.js
@@ -105,6 +105,8 @@ export default class MyProjectsProjectRecommendationsAddController extends Contr
 
   submitError = false;
 
+  errorBody = null;
+
   @computed('assignment')
   get assignmentQueueName() {
     const parsedAssignmentId = this.assignment.id.replace(/-/g, '');
@@ -313,6 +315,7 @@ export default class MyProjectsProjectRecommendationsAddController extends Contr
   @action
   async submitRecommendations() {
     this.set('isSubmitting', true);
+    this.set('submitError', false);
 
     // array of true/false values each representing whether a disposition
     // had files successfully uploaded to it

--- a/app/templates/my-projects/assignment/hearing/add.hbs
+++ b/app/templates/my-projects/assignment/hearing/add.hbs
@@ -79,6 +79,13 @@
               Oops something went wrong, can you try again?
             </span>
           </div>
+          <div class="cell auto">
+            {{#each error.errors as |errorObject idx|}}
+              {{#each-in errorObject as |key value|}}
+                <span>{{idx}}: {{key}}: {{value}}</span>
+              {{/each-in}}
+            {{/each}}
+          </div>
           <button
             class="button clear"
             data-test-button="backToHearingFormAfterError"

--- a/app/templates/my-projects/assignment/recommendations/add.hbs
+++ b/app/templates/my-projects/assignment/recommendations/add.hbs
@@ -708,11 +708,21 @@
                 {{#if this.submitError}}
                   <p class="red-muted">Sorry, there was an error submitting your disposition.</p>
                   <p class="red-muted">Please contact City Planning at <a href="mailto:ZAP_feedback_DL@planning.nyc.gov">ZAP_feedback_DL@planning.nyc.gov</a> or 212-720-3300.</p>
+
+                  {{#each this.dispositions as |disposition|}}
+                    {{#each disposition.adapterError.errors as |error|}}
+                      <p class="red-muted">{{disposition.action.dcpName}}</p>
+                      {{#each-in error as |key value|}}
+                        <p class="red-muted">
+                          <span>{{key}}: {{value}}</span>
+                        </p>
+                      {{/each-in}}
+                    {{/each}}
+                  {{/each}}
                 {{/if}}
               {{/if}} {{!-- end if submitting --}}
             {{/confirmation-modal}}
           {{/ember-wormhole}}
-
         </div>
       </div>
     </div>

--- a/tests/acceptance/542-document-upload-for-recommendation-test.js
+++ b/tests/acceptance/542-document-upload-for-recommendation-test.js
@@ -12,6 +12,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import { invalidateSession, authenticateSession } from 'ember-simple-auth/test-support';
 import { participantRoles } from 'labs-zap-search/models/assignment';
+import { Response } from 'ember-cli-mirage';
 import moment from 'moment';
 
 // Sets up assignment will have 3 dispos with hearings
@@ -265,13 +266,65 @@ module('Acceptance | 542 document upload for recommendation', function (hooks) {
 
     assert.equal(find('[data-test-confirmation-file-name="foo.txt"]').textContent.replace(/\s/g, ''), 'foo.txt(text/plain)');
 
-    this.server.patch('/dispositions/:id', { errors: [{ default: 'server problem' }] }, 500);
+    this.server.patch('/dispositions/:id', { errors: [{ detail: 'server problem' }] }, 500);
 
     await click('[data-test-submit]');
 
     const requestCount1 = this.server.pretender.handledRequests.length;
 
     await this.server.patch('/dispositions/:id');
+
+    await click('[data-test-submit]');
+
+    const requestCount2 = this.server.pretender.handledRequests.length;
+
+    assert.ok(requestCount2 > requestCount1);
+
+    assert.equal(currentURL(), '/my-projects/1/recommendations/done');
+  });
+
+  test('User can upload, receive failure from doc upload, and retry', async function (assert) {
+    setUpProjectAndDispos(server, 'CB');
+
+    await authenticateSession();
+
+    // Fill in all form fields except for documents
+    await visit('/my-projects/1/recommendations/add');
+    await click('[data-test-quorum-yes="0"]');
+    await click('[data-test-quorum-no="1"]');
+    await click('[data-test-all-actions-yes]');
+    await find('[data-test-all-actions-recommendation-select]');
+    await selectChoose('[data-test-all-actions-recommendation]', 'Disapproved');
+    await fillIn('[data-test-all-actions-dcpVotinginfavorrecommendation]', 1);
+    await fillIn('[data-test-all-actions-dcpVotingagainstrecommendation]', 2);
+    await fillIn('[data-test-all-actions-dcpVotingabstainingonrecommendation]', 3);
+    await fillIn('[data-test-all-actions-dcpTotalmembersappointedtotheboard]', 4);
+    await fillIn('[data-test-all-actions-dcpVotelocation]', 'Smith Street');
+    await fillIn('[data-test-all-actions-dcpDateofvote]', '10/17/2019');
+    await fillIn('[data-test-all-actions-dcpConsideration]', 'My All Actions Comment');
+
+    const file = new File(['foo'], 'foo.txt', { type: 'text/plain' });
+
+    // https://github.com/adopted-ember-addons/ember-file-upload/blob/master/addon-test-support/index.js
+    await upload('#assign1FileUpload > input', file);
+
+    await click('[data-test-continue]');
+
+    assert.equal(find('[data-test-confirmation-file-name="foo.txt"]').textContent.replace(/\s/g, ''), 'foo.txt(text/plain)');
+
+    this.server.post('/document', { errors: [{ detail: 'server problem' }] }, 500);
+
+    await click('[data-test-submit]');
+
+    const requestCount1 = this.server.pretender.handledRequests.length;
+
+    // copied from mirage/config
+    this.server.post('/document', function(schema, request) {
+      // requestBody should be a FormData object
+      const { requestBody } = request;
+      const success = requestBody.get('instanceId') && requestBody.get('entityName') && requestBody.get('file');
+      return success ? new Response(200) : new Response(400, {}, { errors: ['Bad Parameters'] });
+    });
 
     await click('[data-test-submit]');
 

--- a/tests/acceptance/user-can-fill-out-hearing-form-test.js
+++ b/tests/acceptance/user-can-fill-out-hearing-form-test.js
@@ -685,7 +685,7 @@ module('Acceptance | user can fill out hearing form', function(hooks) {
       }),
     });
 
-    this.server.patch('/dispositions/:id', { errors: ['server problem'] }, 500); // force mirage to error
+    this.server.patch('/dispositions/:id', { errors: [{ message: 'server problem' }] }, 500); // force mirage to error
 
     await visit('/my-projects/4/hearing/add');
 
@@ -716,7 +716,17 @@ module('Acceptance | user can fill out hearing form', function(hooks) {
 
     await click('[data-test-button="confirmHearing"]');
 
+    this.server.patch('/dispositions/:id');
+
     assert.ok(find('[data-test-error-alert-message]'));
+
+    await click('[data-test-button="backToHearingFormAfterError"]');
+
+    await click('[data-test-button="checkHearing"]');
+
+    await click('[data-test-button="confirmHearing"]');
+
+    assert.equal(currentURL(), '/my-projects/4/hearing/done');
   });
 
   test('single disposition hearing form with NULL dcpDateofpublichearing works, triggers modal', async function(assert) {


### PR DESCRIPTION
Handle errors and allow retries on error responses from server.

This likely duplicates some documents in the upload process but nevertheless allows upload retries.

Closes #1020, but we should refactor as soon as humanly possible.