### PR TITLE
1029: use goal duration

### DIFF
--- a/app/components/reviewed-project-card.js
+++ b/app/components/reviewed-project-card.js
@@ -31,7 +31,7 @@ export default class ReviewedProjectCardComponent extends Component {
       return {
         displayName: firstInProgressMilestoneDates.displayName,
         estTimeRemaining: firstInProgressMilestoneDates.dcpRemainingplanneddayscalculated,
-        estTimeDuration: firstInProgressMilestoneDates.dcpActualdurationasoftoday,
+        estTimeDuration: firstInProgressMilestoneDates.dcpGoalduration,
         dcpPlannedcompletiondate: firstInProgressMilestoneDates.dcpPlannedcompletiondate,
       };
     }

--- a/app/models/assignment.js
+++ b/app/models/assignment.js
@@ -166,8 +166,8 @@ export default class AssignmentModel extends Model {
   @computed('tab', 'dcpLupteammemberrole', 'project.milestones')
   get toReviewMilestoneTimeDuration() {
     const participantMilestoneId = this.milestoneConstants.referralIdentifierByAcronymLookup[this.dcpLupteammemberrole];
-    const { dcpActualdurationasoftoday } = this.project.get('milestones').find(milestone => milestone.dcpMilestone === participantMilestoneId) || {};
-    return dcpActualdurationasoftoday;
+    const { dcpGoalduration } = this.project.get('milestones').find(milestone => milestone.dcpMilestone === participantMilestoneId) || {};
+    return dcpGoalduration;
   }
 
   // If `tab` is 'reviewed'...
@@ -185,7 +185,7 @@ export default class AssignmentModel extends Model {
       dcpActualstartdate: milestone.dcpActualstartdate,
       dcpPlannedcompletiondate: milestone.dcpPlannedcompletiondate,
       dcpRemainingplanneddayscalculated: milestone.dcpRemainingplanneddayscalculated,
-      dcpActualdurationasoftoday: milestone.dcpActualdurationasoftoday,
+      dcpGoalduration: milestone.dcpGoalduration,
     }));
   }
 }

--- a/app/models/milestone.js
+++ b/app/models/milestone.js
@@ -53,9 +53,9 @@ export default class MilestoneModel extends Model {
   // represents number of days e.g. `8`
   @attr('string') dcpRemainingplanneddayscalculated;
 
-  // field `dcp_actualdurationasoftoday` from table dcp_projectmilestone
+  // field `dcp_goalduration` from table dcp_projectmilestone
   // represents number of days e.g. `29`
-  @attr('string') dcpActualdurationasoftoday;
+  @attr('string') dcpGoalduration;
 
   // --> CRM:dcp_milestoneoutcome.dcp_name
   @attr('string') outcome;

--- a/tests/acceptance/reviewed-project-cards-renders-test.js
+++ b/tests/acceptance/reviewed-project-cards-renders-test.js
@@ -44,7 +44,7 @@ module('Acceptance | reviewed project cards renders', function(hooks) {
                 dcpPlannedcompletiondate: moment().add(15, 'days'),
                 displayDate2: null,
                 dcpRemainingplanneddayscalculated: 14,
-                dcpActualdurationasoftoday: 29,
+                dcpGoalduration: 29,
               }),
             ],
           }),
@@ -64,7 +64,7 @@ module('Acceptance | reviewed project cards renders', function(hooks) {
     assert.equal(timeDurationValue, 'of 29 estimated days remain', 'Estimated time duration displays 29');
   });
 
-  test('reviewed project card does not show "of" if dcpActualdurationasoftoday is null', async function(assert) {
+  test('reviewed project card does not show "of" if dcpGoalduration is null', async function(assert) {
     this.server.create('user', {
       id: 1,
       email: 'qncb5@planning.nyc.gov',
@@ -84,7 +84,7 @@ module('Acceptance | reviewed project cards renders', function(hooks) {
                 dcpPlannedcompletiondate: moment().add(15, 'days'),
                 displayDate2: null,
                 dcpRemainingplanneddayscalculated: 14,
-                dcpActualdurationasoftoday: null,
+                dcpGoalduration: null,
               }),
             ],
           }),
@@ -124,7 +124,7 @@ module('Acceptance | reviewed project cards renders', function(hooks) {
                 dcpPlannedcompletiondate: moment().add(15, 'days'),
                 displayDate2: null,
                 dcpRemainingplanneddayscalculated: null,
-                dcpActualdurationasoftoday: 29,
+                dcpGoalduration: 29,
               }),
             ],
           }),

--- a/tests/acceptance/to-review-project-cards-renders-test.js
+++ b/tests/acceptance/to-review-project-cards-renders-test.js
@@ -43,7 +43,7 @@ module('Acceptance | to review project cards renders', function(hooks) {
               dcpPlannedcompletiondate: moment().add(21, 'days'),
               displayDate2: moment().add(21, 'days'),
               dcpRemainingplanneddayscalculated: '20',
-              dcpActualdurationasoftoday: '59',
+              dcpGoalduration: '59',
             })],
           }),
         }),
@@ -62,7 +62,7 @@ module('Acceptance | to review project cards renders', function(hooks) {
     assert.equal(timeRemainingValue, '20', 'Time remaining displays 20');
   });
 
-  test('to-review project card does not show "of" if dcpActualdurationasoftoday is null', async function(assert) {
+  test('to-review project card does not show "of" if dcpGoalduration is null', async function(assert) {
     this.server.create('user', {
       id: 1,
       email: 'qncb5@planning.nyc.gov',
@@ -81,7 +81,7 @@ module('Acceptance | to review project cards renders', function(hooks) {
               dcpPlannedcompletiondate: moment().add(21, 'days'),
               displayDate2: moment().add(21, 'days'),
               dcpRemainingplanneddayscalculated: '20',
-              dcpActualdurationasoftoday: null,
+              dcpGoalduration: null,
             })],
           }),
         }),
@@ -119,7 +119,7 @@ module('Acceptance | to review project cards renders', function(hooks) {
               dcpPlannedcompletiondate: moment().add(21, 'days'),
               displayDate2: moment().add(21, 'days'),
               dcpRemainingplanneddayscalculated: null,
-              dcpActualdurationasoftoday: '59',
+              dcpGoalduration: '59',
             })],
           }),
         }),


### PR DESCRIPTION
Closes #1029
Related to https://github.com/NYCPlanning/zap-api/pull/65

Updates all references to `dcpActualdurationasoftoday` to use `dcpGoalduration` instead. Now our durations match with what's in CRM. Yay!

![image](https://user-images.githubusercontent.com/13967925/70346415-4ac0d300-182c-11ea-99ce-a7e21255f30b.png)

![image](https://user-images.githubusercontent.com/13967925/70346397-40063e00-182c-11ea-90d3-bf84ffdfb3ed.png)
