### PR TITLE
42: add Prefiled option to project stage checkboxes

### DIFF
--- a/app/components/structural/project-list-map.js
+++ b/app/components/structural/project-list-map.js
@@ -6,6 +6,7 @@ const PROJECT_STATUS_COLOR_RAMP_CONFIG = {
   property: 'dcp_publicstatus_simp',
   type: 'categorical',
   stops: [
+    ['Prefiled', '#d6d426'],
     ['Filed', '#78D271'],
     ['In Public Review', '#0979C3'],
     ['Completed', '#a6cee3'],

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -83,6 +83,7 @@ $fieldset-border: $callout-border;
 //
 // Custom app modules and styles
 // --------------------------------------------------
+$prefiled-color: #d6d426;
 $filed-color: #78D271;
 $in-public-review-color: #0979C3;
 $completed-color: #a6cee3;

--- a/app/styles/modules/_m-categorical-colors.scss
+++ b/app/styles/modules/_m-categorical-colors.scss
@@ -3,6 +3,10 @@
 // --------------------------------------------------
 
 .label {
+  .publicstatus-prefiled & {
+    background: $prefiled-color;
+    color: $black;
+  }
   .publicstatus-filed & {
     background: $filed-color;
     color: $black;
@@ -22,6 +26,9 @@
 }
 
 .fa-map-marker-alt {
+  .publicstatus-prefiled & {
+    color: $prefiled-color;
+  }
   .publicstatus-filed & {
     color: $filed-color;
   }
@@ -35,6 +42,7 @@
     color: $dark-gray;
   }
 
+  .publicstatus-prefiled .button:hover &,
   .publicstatus-filed .button:hover &,
   .publicstatus-in-public-review .button:hover &,
   .publicstatus-completed .button:hover &,

--- a/app/styles/modules/_m-map-info-box.scss
+++ b/app/styles/modules/_m-map-info-box.scss
@@ -34,6 +34,9 @@
     .white {
       color: #fff;
     }
+    .stage-prefiled {
+      color: $prefiled-color;
+    }
     .stage-filed {
       color: $filed-color;
     }

--- a/app/templates/components/map-info-box.hbs
+++ b/app/templates/components/map-info-box.hbs
@@ -3,6 +3,12 @@
     <li>
       <span class="fa-layers fa-fw">
         {{fa-icon 'circle' class="white" transform="shrink-2"}}
+        {{fa-icon 'circle' class="stage-prefiled" transform="shrink-6"}}
+      </span>Prefiled
+    </li>
+    <li>
+      <span class="fa-layers fa-fw">
+        {{fa-icon 'circle' class="white" transform="shrink-2"}}
         {{fa-icon 'circle' class="stage-filed" transform="shrink-6"}}
       </span>Filed
     </li>

--- a/app/templates/show-geography.hbs
+++ b/app/templates/show-geography.hbs
@@ -100,9 +100,9 @@
         as |section|}}
         {{#section.filter-wrapper
           filterTitle=(get-label-for 'filters.dcp_publicstatus')
-          tooltip='These checkboxes filter projects by their stage in the application process. “Filed” refers to applications that have been submitted but have not yet started the public review process. “In Public Review” refers to applications that have graduated to the public review process. “Completed” refers to applications that have been Approved, Disapproved, Withdrawn or Terminated.'}}
+          tooltip='These checkboxes filter projects by their stage in the application process. "Prefiled" refers to applications that are likely to be filed or enter public review in the next 30 days. “Filed” refers to applications that have been submitted but have not yet started the public review process. “In Public Review” refers to applications that have graduated to the public review process. “Completed” refers to applications that have been Approved, Disapproved, Withdrawn or Terminated.'}}
           <ul class="menu vertical medium-horizontal stage-checkboxes">
-            {{#each (array 'Filed' 'In Public Review' 'Completed' 'Unknown') as |type|}}
+            {{#each (array 'Prefiled' 'Filed' 'In Public Review' 'Completed' 'Unknown') as |type|}}
               <li {{action section.delegate-mutation (action 'mutateArray' 'dcp_publicstatus' type)}}
                 data-test-status-checkbox={{type}}
               >

--- a/mirage/factories/project.js
+++ b/mirage/factories/project.js
@@ -13,10 +13,10 @@ export default Factory.extend({
   // dcpPublicStatus and dcpPublicstatusSimp should not receive random mock data
   // because their values are critical to expressing project state.
 
-  // Domain is ['Filed', 'Certified', 'Approved', 'Withdrawn']
+  // Domain is ['Prefiled', Filed', 'In Public Review', 'Completed']
   dcpPublicstatus: 'Filed',
 
-  // Domain is ['Filed', 'In Public Review', 'Completed', 'Unknown']
+  // Domain is ['Prefiled', 'Filed', 'In Public Review', 'Completed', 'Unknown']
   // This field is derived from dcpPublicstatus.
   // See https://github.com/NYCPlanning/zap-api/blob/develop/queries/projects/show.sql#L28
   dcpPublicstatusSimp: 'Filed',

--- a/tests/index.html
+++ b/tests/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>LabsApplicantMaps Tests</title>
+    <title>LabsZapSearch Tests</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/tests/integration/components/map-info-box-test.js
+++ b/tests/integration/components/map-info-box-test.js
@@ -12,7 +12,7 @@ module('Integration | Component | map-info-box', function(hooks) {
 
     await render(hbs`{{map-info-box}}`);
 
-    assert.equal(this.element.textContent.trim().replace(/\s/g, ''), 'FiledInPublicReviewCompletedDisclaimer');
+    assert.equal(this.element.textContent.trim().replace(/\s/g, ''), 'PrefiledFiledInPublicReviewCompletedDisclaimer');
 
     // Template block usage:
     await render(hbs`
@@ -21,6 +21,6 @@ module('Integration | Component | map-info-box', function(hooks) {
       {{/map-info-box}}
     `);
 
-    assert.equal(this.element.textContent.trim().replace(/\s/g, ''), 'FiledInPublicReviewCompletedDisclaimertemplateblocktext');
+    assert.equal(this.element.textContent.trim().replace(/\s/g, ''), 'PrefiledFiledInPublicReviewCompletedDisclaimertemplateblocktext');
   });
 });


### PR DESCRIPTION
A data update in CRM changed the values for project stage to include `Prefiled`, `Filed`, `In Public Review`, and `Completed`. This PR is responding to backend changes in zap-api PR [#79](https://github.com/NYCPlanning/zap-api/pull/79)

This PR:
- updates the project stage checkbox filter to include "Prefiled" which is reflected in `show-geography.hbs` template
- implements map layer style (various files) and map legend style (`map-info-box` component) updates to include "Prefiled"
- in order to get tests to pass, a passthrough for `labs-layers-api-staging.herokuapp` was added in the `mirage/config.js`

Addresses zap-api issue [#42](https://github.com/NYCPlanning/zap-api/issues/42)

![Prefiled_addition](https://user-images.githubusercontent.com/26672885/74483048-a4c0c300-4e83-11ea-8c21-ed1014a2ebda.png)
