### PR TITLE
874 fix action filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ The frontend will then send api calls to `localhost:3000`, assuming you are runn
 
 Sign in by going to `localhost:4200/login#access_token=test`
 
+After running the backend you will see a message in your terminal saying `SKIP_AUTH is true! The cookie token is token=<your-token>; Path=/; HttpOnly. Add this to your request headers.`
+
+Visit `localhost:4200/login#access_token=<your-token>` to sign in
+
 ### Connecting to staging or production
 
 ```

--- a/app/templates/show-geography.hbs
+++ b/app/templates/show-geography.hbs
@@ -245,7 +245,7 @@
       {{/filters.section}}
 
       {{!-- FILTER: ACTION TYPE --}}
-{{!--       {{#filters.section
+      {{#filters.section
         filterNames='action-types'
         as |section|}}
         {{#section.filter-wrapper
@@ -269,7 +269,7 @@
             {{/if}}
           {{/power-select-multiple}}
         {{/section.filter-wrapper}}
-      {{/filters.section}} --}}
+      {{/filters.section}}
 
       {{!-- FILTER: FEMA FLOOD ZONE --}}
       {{#filters.section

--- a/tests/acceptance/filter-checkbox-test.js
+++ b/tests/acceptance/filter-checkbox-test.js
@@ -40,6 +40,19 @@ module('Acceptance | filter checkbox', function(hooks) {
     assert.equal(currentURL(), '/projects?applied-filters=community-districts%2Cdcp_publicstatus&community-districts=BK02');
   });
 
+  test('User clicks action box, fills in action name, selects action type', async function(assert) {
+    server.createList('project', 20);
+    await visit('/');
+    await click('[data-test-filter-section="filter-section-action-type"] .switch-paddle');
+    await click('[data-test-filter-control="filter-section-action-type"] .ember-power-select-multiple-options');
+    // Choose the second option in the select options, which is "BF - Business Franchise".
+    // Due to how we format the "action-type" options text, ember-power-select has difficulty selecting the text,
+    // so we use an index number instead.
+    await selectChoose('[data-test-filter-control="filter-section-action-type"]', '.ember-power-select-option', 1);
+
+    assert.equal(currentURL(), '/projects?action-types=BF&applied-filters=action-types%2Cdcp_publicstatus');
+  });
+
   test('User clicks ULURP checkbox and it filters', async function(assert) {
     server.createList('project', 20);
     await visit('/');


### PR DESCRIPTION
### Changes:
Previously the action filter on the projects list page was not working and had to be removed. The commit where it was removed: d95b8e7.

This PR re-adds the action filter, which is now working again. The reason for the filter break is not known.

### Tests:
This PR adds a test in `filter-checkbox-test` acceptance test to assure that query parameters are changing appropriately when a user interacts with the action filter. This test does not actually test the full filter functionality, since that is handled in the backend. The actual filter functionality was tested manually.

Addresses #874 