### PR TITLE
1099: remove requirement text on borough president waive hearings popup

### DIFF
--- a/app/templates/components/waive-hearings-popup.hbs
+++ b/app/templates/components/waive-hearings-popup.hbs
@@ -19,8 +19,10 @@
         <small class="display-inline-block">Opt out of noticing a public hearing for:</small>
         <span class="display-inline-block">{{assignment.project.dcpProjectname}}</span>
       </h3>
-      <p>Without proper notice of a public hearing, the {{participant-type-label assignment.dcpLupteammemberrole}}'s recommendation does not comply with City Charter requirements.
-      NYC Planning will still accept a recommendation, but a disapproval will not trigger an automatic City Council call up.</p>
+      {{#if (not-eq assignment.dcpLupteammemberrole 'BP')}}
+        <p>Without proper notice of a public hearing, the {{participant-type-label assignment.dcpLupteammemberrole}}'s recommendation does not comply with City Charter requirements.
+        NYC Planning will still accept a recommendation, but a disapproval will not trigger an automatic City Council call up.</p>
+      {{/if}}
       <p><strong>Are you sure you want to opt out of noticing a public hearing?</strong></p>
       <button
         class="button small"


### PR DESCRIPTION
Because borough president's are NOT required to submit a hearing to comply with the City Charter, the modal warning message that notified the user of this requirement was removed. 

Instead, the modal now just lists (1) the name of the rezoning and (2) a question whether the
user is sure they want to opt out of the hearing.

<img width="691" alt="Screen Shot 2020-02-18 at 12 08 46 PM" src="https://user-images.githubusercontent.com/26672885/74760364-49f2e700-5248-11ea-8dc2-eb1215406dc2.png">

Addresses #1099 
