### PR TITLE
1103: add heroku layers api passthrough to mirage config to fix tests

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -11,6 +11,7 @@ export default function () {
   this.passthrough('https://raw.githubusercontent.com/**');
   this.passthrough('https://tiles.planninglabs.nyc/**');
   this.passthrough('https://layers-api-staging.planninglabs.nyc/**');
+  this.passthrough('https://labs-layers-api-staging.herokuapp.com/v1/base/style.json');
   this.passthrough('/test-data/**');
 
   // If the project_lup_status queryParam is set, this endpoint


### PR DESCRIPTION
Add heroku layers api passthrough to mirage config to fix tests