### PR TITLE
1019: Fix field validation bug in recommendation form

### DIFF
--- a/app/controllers/my-projects/assignment/recommendations/add.js
+++ b/app/controllers/my-projects/assignment/recommendations/add.js
@@ -270,8 +270,13 @@ export default class MyProjectsProjectRecommendationsAddController extends Contr
       dispositionChangeset.set(targetField, recommendation);
     }
 
-    // IDs for Waiver of Recommendation
-    if (([717170002, 717170006, 717170008].includes(recommendation)) && (participantType !== 'BP')) {
+    // For Borough Board, 71717002 = 'Waiver of Recommendation', For Community Board, 71717008 = 'Waiver of Recommendation'
+    const boroughBoardWaiverOfRecommendation = ([717170002].includes(recommendation)) && (participantType === 'BB');
+    const communityBoardWaiverOfRecommendation = ([717170008].includes(recommendation)) && (participantType === 'CB');
+
+    // A selection of 'Waiver of Recommendation' makes these four vote & member fields irrelevant
+    // Borough Presidents (BP) do not have these vote & member fields at all
+    if (boroughBoardWaiverOfRecommendation || communityBoardWaiverOfRecommendation) {
       dispositionChangeset.validate('dcpVotinginfavorrecommendation');
       dispositionChangeset.validate('dcpVotingagainstrecommendation');
       dispositionChangeset.validate('dcpVotingabstainingonrecommendation');


### PR DESCRIPTION
### Bug:
Previously, a user selection of the recommendation options `Disapproved` and `Received after Clock Expired` would cause the Votes in Favor, Votes Against, Abstain, and Total Members fields to automatically validate. This would happen without the user interacting with those fields or
clicking the "Continue" button, which is not expected behavior.

Addresses Issue #1019 

### Cause of Bug:
The bug was being caused by a recommendation code error in the action `setDispositionChangesetRec` in the `recommendations/add.js` controller. The action was checking for three recommendation codes (e.g. `717170002`) and assuming these all to correspond to the label `Waiver of Recommendation`. But different codes correlate to different labels based  on the participant type (e.g. `Community Board`).

See `RECOMMENDATION_OPTIONSET_BY_PARTICIPANT_TYPE_LOOKUP` in `recommendations/add.js` controller for these recommendation code-to-label relationships.

### Fix:
In order to fix this, the if statement checking for relevant recommendation codes in this action was broken out into two separate if statements, each one checking for codes that correlated to a specific participant type.