### PR TITLE
hotfix: fix URL to ULURP suspension press release

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -68,6 +68,6 @@
 }}
   <h3>Update on City Planning Business in light of COVID-19</h3>
   <p>To minimize the potential spread of COVID-19, many Department of City Planning (DCP) staff members will temporarily work remotely. All borough offices are currently closed. The main office at <b>120 Broadway remains open 9 a.m. to 5 p.m.</b> If you need assistance, please call (212) 720-3300.</p>
-  <p>The City’s Uniform Land Use Review Procedure (ULURP) is suspended as of the close of business on Monday, March 16, 2020 by Mayoral Executive Order. <a href="/site/planning/about/press-releases/pr-20200316.page">Read details of the ULURP suspension</a>.</p>
+  <p>The City’s Uniform Land Use Review Procedure (ULURP) is suspended as of the close of business on Monday, March 16, 2020 by Mayoral Executive Order. <a href="https://www1.nyc.gov/site/planning/about/press-releases/pr-20200316.page">Read details of the ULURP suspension</a>.</p>
   <p>Land use applications will be accepted Mondays and Thursdays. Please e-mail <a href="mailto:savila@planning.nyc.gov">savila@planning.nyc.gov</a> or call (212) 720-3366 to schedule an appointment. The <a href="https://zap.planning.nyc.gov/projects">Zoning Application Portal</a> will be updated as normal.</p>
 {{/site-message}}


### PR DESCRIPTION
The URL to the press release explaining the ULURP suspension was invalid. Fixed it with the correct one pulled from DCP's website.