### PR TITLE
Fix layout of site-message component's icon

### DIFF
--- a/app/templates/components/site-message.hbs
+++ b/app/templates/components/site-message.hbs
@@ -3,7 +3,7 @@
   <div class="site-message {{if warning 'warning'}}">
 
     {{#if warning}}
-      <div class="grid-x grid-margin-x align-middle">
+      <div class="grid-x grid-margin-x">
         <div class="cell text-center medium-text-left medium-shrink">
           {{fa-icon 'exclamation-triangle' size='2x' class='yellow-dark'}}
         </div>


### PR DESCRIPTION
The warning icon is currently aligned vertically with the message's content. It's an especially weird layout if that content scrolls: 

![image](https://user-images.githubusercontent.com/409279/77460294-43bbd180-6dd7-11ea-9e1f-e40cbf8a0eef.png)

This PR simply aligns the icon to the top: 

![image](https://user-images.githubusercontent.com/409279/77460478-8087c880-6dd7-11ea-8bd8-81256a319361.png)

