### PR TITLE
Treat null as empty string for dcpNameofpersoncompletingthisform

### DIFF
--- a/client/app/models/disposition.js
+++ b/client/app/models/disposition.js
@@ -64,7 +64,7 @@ export default class DispositionModel extends Model {
   // sourced from dcp_dcpDateofpublichearing
   @attr('date', { defaultValue: null }) dcpDateofpublichearing;
 
-  @attr('string', { defaultValue: 'ZAP LUP Portal' }) dcpNameofpersoncompletingthisform;
+  @attr('string-null-triggers-default', { defaultValue: 'ZAP LUP Portal' }) dcpNameofpersoncompletingthisform;
 
   // sourced from dcp_projectactionid in dcp_projectaction table
   // e.g. 9bbfbec7-2407-ea11-a9aa-001dd8308025

--- a/client/app/transforms/string-null-triggers-default.js
+++ b/client/app/transforms/string-null-triggers-default.js
@@ -1,0 +1,11 @@
+import DS from 'ember-data';
+
+// in Ember data, an undefined value triggers an
+// attribute's defaultValue. nulls, however, do not.
+// this transform treats null as undefineds so that
+// defaultValue is triggered.
+export default DS.Transform.extend({
+  deserialize(serialized) { return serialized || undefined; },
+
+  serialize(deserialized) { return deserialized; },
+});

--- a/client/tests/acceptance/user-can-submit-recommendation-form-test.js
+++ b/client/tests/acceptance/user-can-submit-recommendation-form-test.js
@@ -337,6 +337,7 @@ module('Acceptance | user can submit recommendation form', function(hooks) {
     await click('[data-test-submit]');
 
     assert.equal(currentURL(), '/my-projects/1/recommendations/done');
+    assert.equal(this.server.db.dispositions[0].dcpNameofpersoncompletingthisform, 'ZAP LUP Portal');
   });
 
   test('BP User can submit a recommendation for each action', async function(assert) {

--- a/client/tests/unit/transforms/string-null-triggers-default-test.js
+++ b/client/tests/unit/transforms/string-null-triggers-default-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Transform | null triggers default', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const transform = this.owner.lookup('transform:string-null-triggers-default');
+
+    assert.equal(transform.deserialize(null), undefined);
+  });
+});


### PR DESCRIPTION
Creates a special transform that treats null values as empty strings. Adds an assertion in one of the acceptance tests.
