### PR TITLE
1153: revise logic for lup tab assignments

### DIFF
--- a/server/src/assignment/assignment.service.ts
+++ b/server/src/assignment/assignment.service.ts
@@ -2,7 +2,6 @@ import { Injectable } from '@nestjs/common';
 import { OdataService, overwriteCodesWithLabels } from '../odata/odata.service';
 import {
   all,
-  any,
   comparisonOperator,
   containsAnyOf
 } from '../odata/odata.module';
@@ -175,10 +174,6 @@ function generateAssignmentsQueryObject(query) {
     }),
   );
   const DISPOSITIONS_FILTER = all(
-    any(
-      comparisonOperator('dcp_visibility', 'eq', 717170004),
-      comparisonOperator('dcp_visibility', 'eq', 717170003),
-    ),
     `(not ${comparisonOperator('statuscode', 'eq', 717170001)})`,
   );
 
@@ -207,16 +202,8 @@ function generateAssignmentsQueryObject(query) {
 // TODO: finish this — currently defaults to "to review"!
 function computeStatusTab(project, lupteam) {
   const {
-    dcp_dcp_project_dcp_projectmilestone_project: projectMilestones,
     dcp_dcp_project_dcp_communityboarddisposition_project: dispositions,
   } = project;
-
-  // retrieve the LUP's relevant projectMilestones
-  const participantProjectMilestones = projectMilestones.filter(
-    milestone => (milestone.dcp_milestone === '923beec4-dad0-e711-8116-1458d04e2fb8' && lupteam.dcp_lupteammemberrole === 'CB')
-      || (milestone.dcp_milestone === '943beec4-dad0-e711-8116-1458d04e2fb8' && lupteam.dcp_lupteammemberrole === 'BP')
-      || (milestone.dcp_milestone === '963beec4-dad0-e711-8116-1458d04e2fb8' && lupteam.dcp_lupteammemberrole === 'BB')
-    );
 
   const participantDispositions = dispositions.filter(
     disposition => disposition.dcp_representing === 'Borough President' && lupteam.dcp_lupteammemberrole === 'BP'
@@ -228,21 +215,36 @@ function computeStatusTab(project, lupteam) {
     return 'archive';
   }
 
-  if (participantProjectMilestones.find(milestone => milestone.statuscode === 'Not Started')) {
-    return 'upcoming';
-  }
-
   // TODO: this is sensitive to sort order. we need to revise this!!!
   if (
-    participantProjectMilestones.find(milestone => ['In Progress', 'Completed'].includes(milestone.statuscode))
-      && participantDispositions.find(disposition => ['Inactive'].includes(disposition.statecode) && ['Submitted', 'Not Submitted'].includes(disposition.statuscode))) {
+    participantDispositions.find(disposition =>
+      // dcp_visibility 717170003 is General Public
+      // dcp_visibility 717170004 is LUP
+      [717170003, 717170004].includes(disposition.dcp_visibility)
+      && ['Submitted', 'Not Submitted'].includes(disposition.statuscode)
+      && ['Inactive'].includes(disposition.statecode))
+    ) {
     return 'reviewed';
   }
 
   if (
-    participantProjectMilestones.find(milestone => ['In Progress', 'Completed'].includes(milestone.statuscode))
-      && participantDispositions.find(disposition => ['Active'].includes(disposition.statecode) && ['Draft', 'Saved'].includes(disposition.statuscode))) {
+    participantDispositions.find(disposition =>
+      // dcp_visibility 717170003 is General Public
+      // dcp_visibility 717170004 is LUP
+      [717170003, 717170004].includes(disposition.dcp_visibility)
+      && ['Draft', 'Saved'].includes(disposition.statuscode)
+      && ['Active'].includes(disposition.statecode))
+    ) {
     return 'to-review';
+  }
+
+  if (
+    participantDispositions.find(disposition =>
+      disposition.dcp_visibility == null
+      && ['Draft'].includes(disposition.statuscode)
+      && ['Active'].includes(disposition.statecode))
+    ) {
+    return 'upcoming';
   }
 
   return null;


### PR DESCRIPTION
Addresses #1153. The issue contains a table documenting the desired logic for placing projects on the different tabs.

This PR:
- Updates the logic for the tab assignments to depend on disposition visibility instead of milestone status
- Removes the visibility filter that was previously being applied to all dispositions