### PR TITLE
13264 Restore map on project profile page

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -55,6 +55,7 @@
     "nestjs-typeorm-paginate": "^1.0.2",
     "nock": "^11.7.0",
     "node-cache": "^4.2.1",
+    "node-fetch": "^2.6.1",
     "node-pg-migrate": "^3.23.3",
     "odata": "^1.0.4",
     "odata-parser": "^1.4.1",

--- a/server/src/carto/carto.module.ts
+++ b/server/src/carto/carto.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CartoService } from '../carto/carto.service';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [CartoService],
+  exports:[CartoService],
+})
+export class CartoModule {}

--- a/server/src/carto/carto.service.ts
+++ b/server/src/carto/carto.service.ts
@@ -1,0 +1,44 @@
+import { Injectable } from '@nestjs/common';
+import * as fetch from 'node-fetch';
+
+@Injectable()
+export class CartoService {
+  cartoUsername = 'planninglabs';
+
+  buildSqlUrl(cleanedQuery, format = 'json', method) { // eslint-disable-line
+    let url = `https://${this.cartoUsername}.carto.com/api/v2/sql`;
+    url += method === 'get' ? `?q=${cleanedQuery}&format=${format}` : '';
+
+    return url;
+  };
+
+  async fetchCarto(query, format = 'json', method = 'get') {
+    const cleanedQuery = query.replace('\n', '');
+    const url = this.buildSqlUrl(cleanedQuery, format, method);
+
+    let fetchOptions = {};
+
+    if (method === 'post') {
+      fetchOptions = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+        },
+        body: `q=${cleanedQuery}&format=${format}`,
+      };
+    }
+
+    let cartoResponse = await fetch(url, fetchOptions);
+
+    if (cartoResponse.ok) {
+      cartoResponse = await cartoResponse.json();
+
+      if (format === 'json')
+        return cartoResponse.rows;
+
+      return cartoResponse;
+    }
+
+    throw new Error('Request to carto failed.');
+  };
+}

--- a/server/src/project/project.module.ts
+++ b/server/src/project/project.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 import { ProjectController } from './project.controller';
 import { ProjectService } from './project.service';
 import { ConfigModule } from '../config/config.module';
+import { CartoModule } from '../carto/carto.module';
 import { OdataModule } from '../odata/odata.module';
 
 @Module({
   imports: [
-  	OdataModule,
-  	ConfigModule,
+    OdataModule,
+    ConfigModule,
+    CartoModule,
   ],
   controllers: [ProjectController],
   providers: [ProjectService],

--- a/server/src/project/project.service.spec.ts
+++ b/server/src/project/project.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ProjectService } from './project.service';
+import { CartoService } from '../carto/carto.service';
 import { ConfigModule } from '../config/config.module';
 import { OdataModule } from '../odata/odata.module';
 import { ProjectController } from './project.controller';
@@ -14,7 +15,7 @@ describe('ProjectService', () => {
         ConfigModule,
       ],
       controllers: [ProjectController],
-      providers: [ProjectService],
+      providers: [ProjectService, CartoService],
     }).compile();
 
     service = module.get<ProjectService>(ProjectService);

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -5586,6 +5586,11 @@ node-fetch@2.6.0, node-fetch@^2.3.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
 
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"


### PR DESCRIPTION
### Summary
This PR restores the map on the Project profile page. Previously it was disabled and read "No map available"
![image](https://user-images.githubusercontent.com/3311663/98318670-f0784700-1f93-11eb-889d-bed6f6520189.png)

Fixes [AB#13264](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13264)

### Technical Details
The changes are mostly backend because the crux of the fix is to ensure that a value for the Project bblFeaturecollection property is sent from the backend.

The backend took a couple steps to construct the bblFeaturecollection value
  1. When constructing the response for a single project (project.service.ts -> `findOneByName()`), sends a Fetch request to the Carto API to get Mappluto geometry data for the target Project's list of BBLs. 
     - The Fetch request included a SQL query that made use of PostGresSQL's `st_AsGeoJSON` spatial function to transform geometry to GeoJSON. 
  2. Transforms the returned geometry GeoJSON for a polygon into a GeoJSON  "FeatureCollection", which is the expected format for Project.bblFeaturecollection in the frontend. This is specified in the sample test data file `client/mirage/test-data/bbl-feature-collection.js`

The frontend was already all set up to display the geometries again, once bblFeaturecollection is saturated!