### PR TITLE
13238 Set up backend to deliver Project Package docs

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -12,12 +12,14 @@ import { DispositionModule } from './disposition/disposition.module';
 import { OdataModule } from './odata/odata.module';
 import { AssignmentModule } from './assignment/assignment.module';
 import { DocumentModule } from './document/document.module';
+import { CrmModule } from './crm/crm.module';
 
 @Module({
   imports: [
     ProjectModule,
     ContactModule,
     ConfigModule,
+    CrmModule,
     AuthModule,
     DispositionModule,
     OdataModule,

--- a/server/src/crm/crm.module.ts
+++ b/server/src/crm/crm.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '../config/config.module';
+import { CrmService } from '../crm/crm.service';
+
+@Module({
+  imports: [
+    ConfigModule,
+  ],
+  providers: [CrmService],
+  exports: [CrmService],
+})
+export class CrmModule {}

--- a/server/src/crm/crm.service.ts
+++ b/server/src/crm/crm.service.ts
@@ -1,0 +1,535 @@
+import {
+  HttpException,
+  HttpStatus,
+  Injectable
+} from '@nestjs/common';
+import * as zlib from 'zlib';
+import * as Request from 'request';
+import { ConfigService } from '../config/config.service';
+import { ADAL } from '../_utils/adal';
+
+/**
+ * This service is responsible for providing convenience
+ * methods for interacting with CRM.
+ * TODO: Leverage the oData service written by @allthesignals
+ * See
+ * https://github.com/NYCPlanning/labs-zap-api/blob/api-only/src/odata/odata.service.ts
+ * https://github.com/NYCPlanning/labs-zap-api/blob/api-only/src/contact/contact.service.ts
+ *
+ * @class      CrmService (name)
+ */
+@Injectable()
+export class CrmService {
+  crmUrlPath = '';
+  crmHost = '';
+  host = '';
+
+  constructor(
+    private readonly config: ConfigService,
+  ) {
+    ADAL.ADAL_CONFIG = {
+      CRMUrl: this.config.get('CRM_HOST'),
+      webAPIurl: this.config.get('CRM_URL_PATH'),
+      clientId: this.config.get('CLIENT_ID'),
+      clientSecret: this.config.get('CLIENT_SECRET'),
+      tenantId: this.config.get('TENANT_ID'),
+      authorityHostUrl: this.config.get('AUTHORITY_HOST_URL'),
+      tokenPath: this.config.get('TOKEN_PATH'),
+    };
+
+    this.crmUrlPath = this.config.get('CRM_URL_PATH');
+    this.crmHost = this.config.get('CRM_HOST');
+    this.host = `${this.crmHost}${this.crmUrlPath}`;
+  }
+
+  async get(entity: string, query: string, ...options) {
+    try {
+      const sanitizedQuery = query.replace(/^\s+|\s+$/g, '');
+      const response = await this._get(`${entity}?${sanitizedQuery}`, ...options);
+      const {
+        value: records,
+        '@odata.count': count,
+      } = response;
+
+      return {
+        count,
+        records,
+      };
+    } catch (e) {
+      throw new HttpException({
+        code: 'QUERY_FAILED',
+        title: 'Could not find entity',
+        detail: e,
+      }, HttpStatus.NOT_FOUND);
+    }
+  }
+
+  async create(query, data, headers = {}) {
+    return this._create(query, data, headers);
+  }
+
+  async update(entity, guid, data, headers = {}) {
+    return this._update(entity, guid, data, headers);
+  }
+
+  async delete(entitySetName, guid, headers = {}) {
+    const query = entitySetName + "(" + guid + ")";
+
+    return this._sendDeleteRequest(query, headers);
+  }
+
+  async associate(relationshipName, entitySetName1, guid1, entitySetName2, guid2, headers = {}) {
+    return this._associate(relationshipName, entitySetName1, guid1, entitySetName2, guid2, headers);
+  }
+
+  /**
+   * Makes a CRM Web API query using the passed in query in XML format
+   *
+   * @param      {string}  entity     the pluralized version of the entity
+   * @param      {string}  xmlQuery   query string to additionally filter, in XML
+   * @return     {string}
+   */
+  async getWithXMLQuery(entity: string, xmlQuery: string, ...options) {
+    const response = await this._get(`${entity}?fetchXml=${xmlQuery}`, ...options);
+    return response;
+  }
+
+  // this provides the formatted values but doesn't do it for top level
+  // TODO: where should this happen? 
+  _fixLongODataAnnotations(dataObj) {
+    return dataObj;
+  }
+
+  _parseErrorMessage(json) {
+    if (json) {
+      if (json.error) {
+        return json.error;
+      }
+      if (json._error) {
+        return json._error;
+      }
+    }
+    return "Error";
+  }
+
+  _dateReviver(key, value) {
+    if (typeof value === 'string') {
+      // YYYY-MM-DDTHH:mm:ss.sssZ => parsed as UTC
+      // YYYY-MM-DD => parsed as local date
+
+      if (value != "") {
+        const a = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)Z$/.exec(value);
+
+        if (a) {
+          const s = parseInt(a[6]);
+          const ms = Number(a[6]) * 1000 - s * 1000;
+          return new Date(Date.UTC(parseInt(a[1]), parseInt(a[2]) - 1, parseInt(a[3]), parseInt(a[4]), parseInt(a[5]), s, ms));
+        }
+
+        const b = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+
+        if (b) {
+          return new Date(parseInt(b[1]), parseInt(b[2]) - 1, parseInt(b[3]), 0, 0, 0, 0);
+        }
+      }
+    }
+
+    return value;
+  }
+
+  async _get(query, maxPageSize = 100, headers = {}): Promise<any> {
+    //  get token
+    const JWToken = await ADAL.acquireToken();
+    const options = {
+      url: `${this.host}${query}`,
+      headers: {
+        'Accept-Encoding': 'gzip, deflate',
+        'Content-Type': 'application/json; charset=utf-8',
+        Authorization: `Bearer ${JWToken}`,
+        'OData-MaxVersion': '4.0',
+        'OData-Version': '4.0',
+        Accept: 'application/json',
+        Prefer: 'odata.include-annotations="*"',
+        ...headers
+      },
+      encoding: null,
+    };
+
+    return new Promise((resolve, reject) => {
+      Request.get(options, (error, response, body) => {
+        const encoding = response.headers['content-encoding'];
+
+        if (!error && response.statusCode === 200) {
+          // If response is gzip, unzip first
+
+          const parseResponse = jsonText => {
+            const json_string = jsonText.toString('utf-8');
+
+            var result = JSON.parse(json_string, this._dateReviver);
+            if (result["@odata.context"].indexOf("/$entity") >= 0) {
+              // retrieve single
+              result = this._fixLongODataAnnotations(result);
+            }
+            else if (result.value) {
+              // retrieve multiple
+              var array = [];
+              for (var i = 0; i < result.value.length; i++) {
+                array.push(this._fixLongODataAnnotations(result.value[i]));
+              }
+              result.value = array;
+            }
+            resolve(result);
+          };
+
+          if (encoding && encoding.indexOf('gzip') >= 0) {
+            zlib.gunzip(body, (err, dezipped) => {
+              parseResponse(dezipped);
+            });
+          }
+          else {
+            parseResponse(body);
+          }
+        } else {
+          const parseError = jsonText => {
+            // Bug: sometimes CRM returns 'object reference' error
+            // Fix: if we retry error will not show again
+            const json_string = jsonText.toString('utf-8');
+            const result = JSON.parse(json_string, this._dateReviver);
+            const err = this._parseErrorMessage(result);
+
+            if (err == "Object reference not set to an instance of an object.") {
+              this._get(query, maxPageSize, options)
+                .then(
+                  resolve, reject
+                );
+            } else {
+              reject(err);
+            }
+          };
+
+          if (encoding && encoding.indexOf('gzip') >= 0) {
+            zlib.gunzip(body, (err, dezipped) => {
+              parseError(dezipped);
+            });
+          } else {
+            parseError(body);
+          }
+        }
+      });
+    });
+  }
+
+  async _create(query, data, headers): Promise<any> {
+    //  get token
+    const JWToken = await ADAL.acquireToken();
+    const options = {
+      url: `${this.host + query}`,
+      headers: {
+        'Accept-Encoding': 'gzip, deflate',
+        'Content-Type': 'application/json; charset=utf-8',
+        Authorization: `Bearer ${JWToken}`,
+        'OData-MaxVersion': '4.0',
+        'OData-Version': '4.0',
+        Accept: 'application/json',
+        Prefer: 'return=representation',
+        ...headers
+      },
+      body: JSON.stringify(data),
+      encoding: null,
+    };
+
+    return new Promise((resolve, reject) => {
+      Request.post(options, (error, response, body) => {
+        const encoding = response.headers['content-encoding'];
+
+        if (error || (response.statusCode != 200 && response.statusCode != 201 && response.statusCode != 204 && response.statusCode != 1223)) {
+          const parseError = jsonText => {
+            // Bug: sometimes CRM returns 'object reference' error
+            // Fix: if we retry error will not show again
+            const json_string = jsonText.toString('utf-8');
+
+            var result = JSON.parse(json_string, this._dateReviver);
+            var err = this._parseErrorMessage(result);
+            reject(err);
+          };
+          if (encoding && encoding.indexOf('gzip') >= 0) {
+            zlib.gunzip(body, (err, dezipped) => {
+              parseError(dezipped);
+            });
+          }
+          else {
+            parseError(body);
+
+          }
+        }
+        else if (response.statusCode === 200 || response.statusCode === 201) {
+          const parseResponse = jsonText => {
+            const json_string = jsonText.toString('utf-8');
+            var result = JSON.parse(json_string, this._dateReviver);
+            resolve(result);
+          };
+
+          if (encoding && encoding.indexOf('gzip') >= 0) {
+            zlib.gunzip(body, (err, dezipped) => {
+              parseResponse(dezipped);
+            });
+          }
+          else {
+            parseResponse(body);
+          }
+        }
+        else if (response.statusCode === 204 || response.statusCode === 1223) {
+          const uri = response.headers["OData-EntityId"];
+          if (uri) {
+            // create request - server sends new id
+            const regExp = /\(([^)]+)\)/;
+            const matches = regExp.exec(uri);
+            const newEntityId = matches[1];
+            resolve(newEntityId);
+          }
+          else {
+            // other type of request - no response
+            resolve();
+          }
+        }
+        else {
+          resolve();
+        }
+      });
+    })
+  }
+
+  async _update(entitySetName, guid, data, headers) {
+    var query = entitySetName + "(" + guid + ")";
+    return this._sendPatchRequest(query, data, headers);
+  }
+
+  async _sendPatchRequest(query, data, headers) {
+    //  get token
+    const JWToken = await ADAL.acquireToken();
+    const options = {
+      url: `${this.host + query}`,
+      headers: {
+        'Accept-Encoding': 'gzip, deflate',
+        'Content-Type': 'application/json; charset=utf-8',
+        Authorization: `Bearer ${JWToken}`,
+        'OData-MaxVersion': '4.0',
+        'OData-Version': '4.0',
+        Accept: 'application/json',
+        Prefer: 'odata.include-annotations="*"',
+        ...headers
+      },
+      body: JSON.stringify(data),
+      encoding: null,
+    };
+
+    return new Promise((resolve, reject) => {
+      Request.patch(options, (error, response, body) => {
+        const encoding = response.headers['content-encoding'];
+
+        if (error || response.statusCode != 204) {
+          const parseError = jsonText => {
+            const json_string = jsonText.toString('utf-8');
+            var result = JSON.parse(json_string, this._dateReviver);
+            var err = this._parseErrorMessage(result);
+            reject(err);
+          };
+          if (encoding && encoding.indexOf('gzip') >= 0) {
+            zlib.gunzip(body, (err, dezipped) => {
+              parseError(dezipped);
+            });
+          }
+          else {
+            parseError(body);
+
+          }
+        }
+        else resolve(body);
+      })
+    });
+  }
+
+  async _sendDeleteRequest(query, headers) {
+    // get token
+    const JWToken = await ADAL.acquireToken();
+    const options = {
+      url: `${this.host + query}`,
+      headers: {
+        'Accept-Encoding': 'gzip, deflate',
+        'Content-Type': 'application/json; charset=utf-8',
+        Authorization: `Bearer ${JWToken}`,
+        'OData-MaxVersion': '4.0',
+        'OData-Version': '4.0',
+        Accept: 'application/json',
+        Prefer: 'odata.include-annotations="*"',
+        ...headers
+      },
+      encoding: null,
+    };
+
+    return new Promise((resolve, reject) => {
+      Request.delete(options, (error, response, body) => {
+        const encoding = response.headers['content-encoding'];
+
+        if (error || (response.statusCode != 204 && response.statusCode != 1223)) {
+          const parseError = jsonText => {
+            const json_string = jsonText.toString('utf-8');
+            const result = JSON.parse(json_string, this._dateReviver);
+            const err = this._parseErrorMessage(result);
+            reject(err);
+          };
+          if (encoding && encoding.indexOf('gzip') >= 0) {
+            zlib.gunzip(body, (err, dezipped) => {
+              parseError(dezipped);
+            });
+          }
+          else {
+            parseError(body);
+
+          }
+        }
+        else resolve();
+      })
+    });
+  }
+
+  async _associate(relationshipName, entitySetName1, guid1, entitySetName2, guid2, headers) {
+    const query = entitySetName1 + "(" + guid1 + ")/" + relationshipName + "/$ref";
+    const data = {
+      "@odata.id": this.host + entitySetName2 + "(" + guid2 + ")"
+    };
+    return this.create(query, data, headers);
+  }
+
+  async generateSharePointAccessToken(): Promise<any> {
+    const TENANT_ID = this.config.get('TENANT_ID');
+    const SHAREPOINT_CLIENT_ID = this.config.get('SHAREPOINT_CLIENT_ID');
+    const SHAREPOINT_CLIENT_SECRET = this.config.get('SHAREPOINT_CLIENT_SECRET');
+    const ADO_PRINCIPAL = this.config.get('ADO_PRINCIPAL');
+    const SHAREPOINT_TARGET_HOST = this.config.get('SHAREPOINT_TARGET_HOST');
+
+    const clientId = `${SHAREPOINT_CLIENT_ID}@${TENANT_ID}`;
+    const data = `
+      grant_type=client_credentials
+      &client_id=${clientId}
+      &client_secret=${SHAREPOINT_CLIENT_SECRET}
+      &resource=${ADO_PRINCIPAL}/${SHAREPOINT_TARGET_HOST}@${TENANT_ID}
+    `;
+
+    const options = {
+      url: `https://accounts.accesscontrol.windows.net/${TENANT_ID}/tokens/OAuth/2`,
+      headers: {
+        'Accept-Encoding': 'gzip, deflate',
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'OData-MaxVersion': '4.0',
+        'OData-Version': '4.0',
+        Accept: 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: data,
+      encoding: null,
+    };
+
+    return new Promise(resolve => {
+      Request.get(options, (error, response, body) => {
+        const stringifiedBody = body.toString('utf-8');
+        if (response.statusCode >= 400) {
+          console.log('error', stringifiedBody);
+        }
+
+        resolve(JSON.parse(stringifiedBody));
+      });
+    })
+  }
+
+  // Retrieves a list of files in a given Sharepoint folder
+  async getSharepointFolderFiles(folderIdentifier): Promise<any> {
+    try {
+      const { access_token } = await this.generateSharePointAccessToken();
+      const SHAREPOINT_CRM_SITE = this.config.get('SHAREPOINT_CRM_SITE');
+
+      // Escape apostrophes by duplicating any apostrophes.
+      // See https://sharepoint.stackexchange.com/a/165224
+      const formattedFolderIdentifier = folderIdentifier.replace(/'/g, "''");
+      const url = encodeURI(`https://nyco365.sharepoint.com/sites/${SHAREPOINT_CRM_SITE}/_api/web/GetFolderByServerRelativeUrl('/sites/${SHAREPOINT_CRM_SITE}/${formattedFolderIdentifier}')/Files`);
+
+      const options = {
+        url,
+        headers: {
+          'Authorization': `Bearer ${access_token}`,
+          Accept: 'application/json',
+        },
+      };
+
+      return new Promise(resolve => {
+        Request.post(options, (error, response, body) => {
+          const stringifiedBody = body.toString('utf-8');
+          if (response.statusCode >= 400) {
+            throw new HttpException({
+              code: 'LOAD_FOLDER_FAILED',
+              title: 'Error loading sharepoint files',
+              detail: `Could not load file list from Sharepoint folder "${formattedFolderIdentifier}". ${stringifiedBody}`,
+            }, HttpStatus.NOT_FOUND);
+          }
+
+          resolve(JSON.parse(stringifiedBody));
+        });
+      })
+    } catch (e) {
+      if (e instanceof HttpException) {
+        throw e;
+      } else {
+        throw new HttpException({
+          code: 'REQUEST_FOLDER_FAILED',
+          title: 'Error requesting sharepoint files',
+          detail: `Error while constructing request for Sharepoint folder files`,
+        }, HttpStatus.INTERNAL_SERVER_ERROR);
+      }
+    }
+  }
+
+  async getSharepointFile(serverRelativeUrl): Promise<any> {
+    const { access_token } = await this.generateSharePointAccessToken();
+    const SHAREPOINT_CRM_SITE = this.config.get('SHAREPOINT_CRM_SITE');
+
+    // see https://docs.microsoft.com/en-us/previous-versions/office/sharepoint-server/dn775742(v=office.15)
+    const url = `https://nyco365.sharepoint.com/sites/${SHAREPOINT_CRM_SITE}/_api/web/GetFileByServerRelativeUrl('/${serverRelativeUrl}')/$value?binaryStringResponseBody=true`;
+
+    const options = {
+      url,
+      headers: {
+        'Authorization': `Bearer ${access_token}`,
+      },
+    };
+
+    // this returns a pipeable stream
+    return Request.get(options)
+      .on('error', (e) => console.log(e));
+  }
+
+  async deleteSharepointFile(serverRelativeUrl): Promise<any> {
+    const { access_token } = await this.generateSharePointAccessToken();
+    const SHAREPOINT_CRM_SITE = this.config.get('SHAREPOINT_CRM_SITE');
+    const url = `https://nyco365.sharepoint.com/sites/${SHAREPOINT_CRM_SITE}/_api/web/GetFileByServerRelativeUrl('${serverRelativeUrl}')`;
+
+    const options = {
+      url,
+      headers: {
+        'Authorization': `Bearer ${access_token}`,
+        Accept: 'application/json',
+        'X-HTTP-Method': 'DELETE',
+      },
+    };
+
+    return new Promise(resolve => {
+      Request.del(options, (error, response, body) => {
+        const stringifiedBody = body.toString('utf-8');
+        if (response.statusCode >= 400) {
+          console.log('error', stringifiedBody);
+        }
+
+        resolve();
+      });
+    })
+  }
+}

--- a/server/src/document/document.controller.spec.ts
+++ b/server/src/document/document.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigModule } from '../config/config.module';
 import { DocumentController } from './document.controller';
+import { CrmModule } from '../crm/crm.module';
 
 describe('Document Controller', () => {
   let controller: DocumentController;
@@ -9,6 +10,7 @@ describe('Document Controller', () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [
         ConfigModule,
+        CrmModule,
       ],
       controllers: [DocumentController],
     }).compile();

--- a/server/src/document/document.controller.ts
+++ b/server/src/document/document.controller.ts
@@ -1,4 +1,5 @@
 import { Controller,
+  Get,
   Post,
   Req,
   Res,
@@ -6,9 +7,11 @@ import { Controller,
   UploadedFile,
   HttpStatus,
   HttpException,
+  Param,
   Session,
 } from '@nestjs/common';
 import { ConfigService } from '../config/config.service';
+import { CrmService } from '../crm/crm.service';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Request } from 'express';
 import { CRMWebAPI } from '../_utils/crm-web-api';
@@ -17,6 +20,7 @@ import { CRMWebAPI } from '../_utils/crm-web-api';
 export class DocumentController {
   constructor(
     private readonly config: ConfigService,
+    private readonly crmService: CrmService,
   ) {}
 
   /** Uploads a single document
@@ -64,5 +68,16 @@ export class DocumentController {
     } else {
       response.status(400).send({ "error": 'You can only upload files to dcp_communityboarddisposition at this time' });
     }
+  }
+
+  // "path" refers to the "relative server path", the path
+  // to the file itself on the sharepoint host. for example,
+  // /sites/dcpuat2/.../filename.png
+  @Get('/*')
+  async read(@Param() path, @Res() res) {
+    const pathSegment = path[0];
+    const stream = await this.crmService.getSharepointFile(pathSegment);
+
+    stream.pipe(res);
   }
 }

--- a/server/src/document/document.module.ts
+++ b/server/src/document/document.module.ts
@@ -1,11 +1,20 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '../config/config.module';
 import { DocumentController } from './document.controller';
+import { DocumentService } from './document.service';
+import { CrmModule } from '../crm/crm.module';
 
 @Module({
   imports: [
     ConfigModule,
+    CrmModule,
   ],
-  controllers: [DocumentController]
+  controllers: [DocumentController],
+  providers: [
+    DocumentService,
+  ],
+  exports: [
+    DocumentService,
+  ],
 })
 export class DocumentModule {}

--- a/server/src/document/document.service.ts
+++ b/server/src/document/document.service.ts
@@ -1,0 +1,80 @@
+import { Injectable, HttpStatus, HttpException } from '@nestjs/common';
+import { CrmService } from '../crm/crm.service';
+
+@Injectable()
+export class DocumentService {
+  constructor(
+    private readonly crmService: CrmService,
+  ){}
+
+  // We retrieve documents from the Sharepoint folder (`folderIdentifier` in the
+  // code below) that holds both documents from past revisions and the current
+  // revision. CRM automatically carries over documents from past revisions into
+  // this folder, and we deliberately upload documents for the latest/current
+  // revision into this folder.
+  async findPackageSharepointDocuments(packageName, id: string) {
+    try {
+      const strippedPackageName = packageName.replace(/-/g, '').replace(/\s+/g, '').replace(/'+/g, '').replace(/^\~|\#|\%|\&|\*|\{|\}|\\|\:|\<|\>|\?|\/|\||\"/g, '');
+      const folderIdentifier = `${strippedPackageName}_${id.toUpperCase().replace(/-/g, '')}`;
+
+      const { value: documents } = await this.crmService.getSharepointFolderFiles(`dcp_package/${folderIdentifier}`);
+
+      if (documents) {
+        return documents.map(document => ({
+          name: document['Name'],
+          timeCreated: document['TimeCreated'],
+          serverRelativeUrl: document['ServerRelativeUrl'],
+        }));
+      }
+
+      return [];
+    } catch (e) {
+      // Relay errors from crmService 
+      if (e instanceof HttpException) {
+        throw e;
+      } else {
+        throw new HttpException({
+          code: 'SHAREPOINT_FOLDER_ERROR',
+          title: 'Bad Sharepoint folder lookup',
+          detail: `An error occured while constructing and looking up folder for package. Perhaps the package name or id is wrong.`,
+          meta: {
+            packageName: packageName,
+            packageId: id,
+          }
+        }, HttpStatus.INTERNAL_SERVER_ERROR);
+      }
+    }
+  }
+
+
+  /**
+   * Injects associated documents into the given package
+   *
+   * @param      {Object{ dcp_name, dcp_packageid }} CRM Package with
+   *              dcp_name and dcp_packageid properties
+   * @return     {[Object]} The CRM Package with the 'documents' property hydrated,
+   *              if associated documents exist in CRM.
+   */
+  public async packageWithDocuments(projectPackage: any) {
+    const {
+      dcp_name,
+      dcp_packageid,
+    } = projectPackage;
+
+    try {
+      return {
+        ...projectPackage,
+        documents: await this.findPackageSharepointDocuments(dcp_name, dcp_packageid),
+      };
+    } catch {
+      const errorMessage = `Error loading documents for package ${dcp_name}.`;
+      console.log(errorMessage);
+
+      throw new HttpException({
+        "code": "PACKAGE_WITH_DOCUMENTS",
+        "title": "Package Documents Error",
+        "detail": errorMessage,
+      }, HttpStatus.NOT_FOUND);
+    }
+  }
+}

--- a/server/src/package/packages.attrs.ts
+++ b/server/src/package/packages.attrs.ts
@@ -1,0 +1,16 @@
+export const PACKAGE_ATTRS = [
+  'statuscode',
+  'statecode',
+  'dcp_packagetype',
+  'dcp_visibility',
+  'dcp_packageversion',
+  '_dcp_rwcdsform_value',
+  '_dcp_pasform_value',
+  '_dcp_landuseapplication_value',
+  'dcp_packageid',
+  'dcp_name',
+  'dcp_statusdate',
+  'dcp_packagesubmissiondate',
+  'dcp_packagenotes',
+  'documents',
+];

--- a/server/src/project/project.entity.ts
+++ b/server/src/project/project.entity.ts
@@ -14,6 +14,7 @@ export const KEYS = [
   'dcp_sisubdivision',
   'dcp_sischoolseat',
   'dcp_projectbrief',
+  'dcp_projectid',
   'dcp_projectname',
   'dcp_publicstatus',
   'dcp_publicstatus_simp',
@@ -44,6 +45,7 @@ export const KEYS = [
   'actions',
   'milestones',
   'dispositions',
+  'packages',
 ];
 
 export const ACTION_KEYS = [

--- a/server/src/project/project.module.ts
+++ b/server/src/project/project.module.ts
@@ -4,12 +4,16 @@ import { ProjectService } from './project.service';
 import { ConfigModule } from '../config/config.module';
 import { CartoModule } from '../carto/carto.module';
 import { OdataModule } from '../odata/odata.module';
+import { CrmModule } from '../crm/crm.module';
+import { DocumentModule } from '../document/document.module';
 
 @Module({
   imports: [
     OdataModule,
     ConfigModule,
     CartoModule,
+    CrmModule,
+    DocumentModule,
   ],
   controllers: [ProjectController],
   providers: [ProjectService],

--- a/server/src/project/project.service.spec.ts
+++ b/server/src/project/project.service.spec.ts
@@ -4,6 +4,8 @@ import { CartoService } from '../carto/carto.service';
 import { ConfigModule } from '../config/config.module';
 import { OdataModule } from '../odata/odata.module';
 import { ProjectController } from './project.controller';
+import { CrmModule } from '../crm/crm.module';
+import { DocumentModule } from '../document/document.module';
 
 describe('ProjectService', () => {
   let service: ProjectService;
@@ -13,6 +15,8 @@ describe('ProjectService', () => {
       imports: [
         OdataModule,
         ConfigModule,
+        CrmModule,
+        DocumentModule,
       ],
       controllers: [ProjectController],
       providers: [ProjectService, CartoService],


### PR DESCRIPTION
### Summary
This PR sets up the backend so that it sideloads an individual Project with Packages, and each package has an array of documents. This is in preparation to list documents by package on the Profile Profile page. 

### Task
Fixes [AB#13238](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13238)

### Technical Details
  - The entry point for this PR is the `getProject()` method in project.service.ts. There, it will acquire the Project's associated packages, saturate it with documents, and insert it into the response payload for an individual project. 
  - The Applicant Portal's CRM service was (reverse?) ported to Zap Search, in hopes that it will "Strangle out" Zap Search's older API to talk to CRM. crm.service.ts is essentially a copy of what is currently in applicant portal.
  - The new document.service.ts is an improvement over the Applicant Portal's document.service.ts. Eventually some of the modifications could be moved over to Applicant Portal. 
  - I'm adding the `@Get('/*')` endpoint here in preparation for making the files available for download. @allthesignals  do you foresee any issue with this?
