### PR TITLE
13238 project packages documents

### DIFF
--- a/client/app/components/show-project/public-documents.js
+++ b/client/app/components/show-project/public-documents.js
@@ -1,0 +1,21 @@
+import Component from '@ember/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class PublicDocumentsComponent extends Component {
+  @tracked showPublicDocuments = false;
+
+  get existsPublicDocuments () {
+    const allPublicDocuments = this.packages.reduce(
+      (allDocuments, curPackage) => allDocuments.concat(curPackage.documents),
+      [],
+    );
+
+    return allPublicDocuments.length > 0;
+  }
+
+  @action
+  toggleShowPublicDocuments() {
+    this.showPublicDocuments = !this.showPublicDocuments;
+  }
+}

--- a/client/app/components/show-project/public-documents/package-documents.js
+++ b/client/app/components/show-project/public-documents/package-documents.js
@@ -1,0 +1,89 @@
+import Component from '@ember/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import ENV from 'labs-zap-search/config/environment';
+
+export const DCPPACKAGETYPE = {
+  INFORMATION_MEETING: {
+    code: 717170014,
+    label: 'Information Meeting',
+  },
+  PAS_PACKAGE: {
+    code: 717170000,
+    label: 'PAS Package',
+  },
+  DRAFT_LU_PACKAGE: {
+    code: 717170001,
+    label: 'Draft LU Package',
+  },
+  FILED_LU_PACKAGE: {
+    code: 717170011,
+    label: 'Filed LU Package',
+  },
+  DRAFT_EAS: {
+    code: 717170002,
+    label: 'Draft EAS',
+  },
+  FILED_EAS: {
+    code: 717170012,
+    label: 'Filed EAS',
+  },
+  EIS: {
+    code: 717170003,
+    label: 'EIS',
+  },
+  PDEIS: {
+    code: 717170013,
+    label: 'PDEIS',
+  },
+  RWCDS: {
+    code: 717170004,
+    label: 'RWCDS',
+  },
+  LEGAL: {
+    code: 717170005,
+    label: 'Legal',
+  },
+  WRP_PACKAGE: {
+    code: 717170006,
+    label: 'WRP Package',
+  },
+  TECHNICAL_MEMO: {
+    code: 717170007,
+    label: 'Technical Memo',
+  },
+  DRAFT_SCOPE_OF_WORK: {
+    code: 717170008,
+    label: 'Draft Scope of Work',
+  },
+  FINAL_SCOPE_OF_WORK: {
+    code: 717170009,
+    label: 'Final Scope of Work',
+  },
+  WORKING_PACKAGE: {
+    code: 717170010,
+    label: 'Working Package',
+  },
+};
+
+
+export default class PackageDocumentsComponent extends Component {
+  host = ENV.host;
+
+  @tracked showPackageDocuments = false;
+
+  get packageType() {
+    const option = Object.values(DCPPACKAGETYPE).findBy('code', this.package.dcpPackagetype);
+
+    if (option) {
+      return option.label;
+    }
+
+    return 'Unknown package';
+  }
+
+  @action
+  toggleShowPackageDocuments() {
+    this.showPackageDocuments = !this.showPackageDocuments;
+  }
+}

--- a/client/app/helpers/build-url.js
+++ b/client/app/helpers/build-url.js
@@ -65,8 +65,10 @@ function acris(bbl) {
 }
 
 function LowerCaseBorough(borough) {
-  const boroText = borough.replace(/\s/g, '-');
-  return boroText.toLowerCase();
+  if (borough) {
+    return borough.replace(/\s/g, '-').toLowerCase();
+  }
+  return '';
 }
 
 function CommProfiles(boro, cd) {

--- a/client/app/models/package.js
+++ b/client/app/models/package.js
@@ -1,0 +1,33 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class PackageModel extends Model {
+  @belongsTo('project', { async: false })
+  project;
+
+  @attr('number')
+  statuscode;
+
+  @attr('date')
+  dcpStatusdate;
+
+  @attr('date')
+  dcpPackagesubmissiondate
+
+  @attr('number')
+  statecode;
+
+  @attr('number')
+  dcpPackagetype;
+
+  @attr('number')
+  dcpVisibility;
+
+  @attr('number')
+  dcpPackageversion
+
+  @attr('string')
+  dcpPackagenotes
+
+  @attr({ defaultValue: () => [] })
+  documents;
+}

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -30,6 +30,9 @@ export default class ProjectModel extends Model {
 
   @hasMany('assignment', { async: false }) assignments;
 
+  @hasMany('package', { async: false })
+  packages;
+
   @attr() applicantteam;
 
   // array of applicant objects
@@ -111,5 +114,11 @@ export default class ProjectModel extends Model {
       type: 'geojson',
       data,
     };
+  }
+
+  @computed('packages')
+  get sortedPackages() {
+    return this.packages.sortBy('dcpPackagesubmissiondate')
+      .reverse();
   }
 }

--- a/client/app/routes/show-project.js
+++ b/client/app/routes/show-project.js
@@ -9,7 +9,7 @@ export default class ShowProjectRoute extends Route {
   async model({ id }) {
     const project = await this.store.findRecord('project', id, {
       reload: true,
-      include: 'actions,milestones,dispositions,dispositions.action,users,assignments.user',
+      include: 'actions,milestones,dispositions,dispositions.action,users,assignments.user,packages',
     });
     return project;
   }

--- a/client/app/styles/layouts/_l-default.scss
+++ b/client/app/styles/layouts/_l-default.scss
@@ -295,6 +295,27 @@ body {
   }
 }
 
+// Public Documents
+.clickable-header {
+  cursor: pointer;
+}
+
+h4.clickable-header {
+  margin-bottom: 0px;
+}
+
+h5.clickable-header {
+  margin-bottom: 5px;
+}
+
+.public-documents-list {
+  padding-left: 12px;
+}
+
+.package-documents-list {
+  padding-left: 24px;
+}
+
 //
 // Gutters
 // --------------------------------------------------

--- a/client/app/templates/components/show-project/public-documents.hbs
+++ b/client/app/templates/components/show-project/public-documents.hbs
@@ -1,0 +1,36 @@
+<p>
+  {{#if this.existsPublicDocuments}}
+    <h4
+      class="clickable-header"
+      onClick={{this.toggleShowPublicDocuments}}
+    >
+      <FaIcon
+        @icon={{if this.showPublicDocuments "caret-down" "caret-right"}}
+      />
+      Public Documents
+    </h4>
+
+    {{#if this.showPublicDocuments}}
+      <ul
+        class="no-bullet public-documents-list"
+      >
+        {{#each @packages as |package|}}
+          <li>
+            <ShowProject::PublicDocuments::PackageDocuments
+              @package={{package}}
+            />
+          </li>
+        {{/each}}
+      </ul>
+    {{/if}}
+  {{else}}
+    <h5
+      class="gray"
+    >
+      <FaIcon
+        @icon="caret-right"
+      />
+      No Public Documents for this project
+    </h5>
+  {{/if}}
+</p>

--- a/client/app/templates/components/show-project/public-documents/package-documents.hbs
+++ b/client/app/templates/components/show-project/public-documents/package-documents.hbs
@@ -1,0 +1,27 @@
+<h5
+  class="clickable-header"
+  onClick={{this.toggleShowPackageDocuments}}
+>
+  <FaIcon
+    @icon={{if this.showPackageDocuments "caret-down" "caret-right"}}
+  />
+  {{this.packageType}} v{{@package.dcpPackageversion}}
+</h5>
+
+{{#if this.showPackageDocuments}}
+  <ul
+    class="no-bullet package-documents-list"
+  >
+    {{#each @package.documents as |document|}}
+      <li>
+        <a
+          href={{concat this.host '/document' document.serverRelativeUrl}}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {{document.name}}
+        </a>
+      </li>
+    {{/each}}
+  </ul>
+{{/if}}

--- a/client/app/templates/show-project.hbs
+++ b/client/app/templates/show-project.hbs
@@ -43,10 +43,16 @@
           {{/if}}
         </p>
 
+        <ShowProject::PublicDocuments
+          @packages={{this.model.sortedPackages}}
+        />
+
         <div class="grid-x grid-padding-x">
           <p class="cell auto">
             <strong>Status:</strong>
-            <span class="label dark-gray publicstatus-{{dasherize model.dcpPublicstatusSimp}}">{{model.dcpPublicstatusSimp}}</span>
+            {{#if model.dcpPublicstatusSimp}}
+              <span class="label dark-gray publicstatus-{{dasherize model.dcpPublicstatusSimp}}">{{model.dcpPublicstatusSimp}}</span>
+            {{/if}}
           </p>
           {{#if model.dcpUlurpNonulurp}}
             <p class="cell small-6 text-right">

--- a/client/mirage/models/project.js
+++ b/client/mirage/models/project.js
@@ -6,4 +6,5 @@ export default Model.extend({
   dispositions: hasMany(),
   milestones: hasMany(),
   assignments: hasMany(),
+  packages: hasMany(),
 });

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -12,12 +12,14 @@ import { DispositionModule } from './disposition/disposition.module';
 import { OdataModule } from './odata/odata.module';
 import { AssignmentModule } from './assignment/assignment.module';
 import { DocumentModule } from './document/document.module';
+import { CrmModule } from './crm/crm.module';
 
 @Module({
   imports: [
     ProjectModule,
     ContactModule,
     ConfigModule,
+    CrmModule,
     AuthModule,
     DispositionModule,
     OdataModule,

--- a/server/src/crm/crm.module.ts
+++ b/server/src/crm/crm.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '../config/config.module';
+import { CrmService } from '../crm/crm.service';
+
+@Module({
+  imports: [
+    ConfigModule,
+  ],
+  providers: [CrmService],
+  exports: [CrmService],
+})
+export class CrmModule {}

--- a/server/src/crm/crm.service.ts
+++ b/server/src/crm/crm.service.ts
@@ -1,0 +1,544 @@
+import {
+  HttpException,
+  HttpStatus,
+  Injectable
+} from '@nestjs/common';
+import * as zlib from 'zlib';
+import * as Request from 'request';
+import { ConfigService } from '../config/config.service';
+import { ADAL } from '../_utils/adal';
+
+/**
+ * This service is responsible for providing convenience
+ * methods for interacting with CRM.
+ * TODO: Leverage the oData service written by @allthesignals
+ * See
+ * https://github.com/NYCPlanning/labs-zap-api/blob/api-only/src/odata/odata.service.ts
+ * https://github.com/NYCPlanning/labs-zap-api/blob/api-only/src/contact/contact.service.ts
+ *
+ * @class      CrmService (name)
+ */
+@Injectable()
+export class CrmService {
+  crmUrlPath = '';
+  crmHost = '';
+  host = '';
+
+  constructor(
+    private readonly config: ConfigService,
+  ) {
+    ADAL.ADAL_CONFIG = {
+      CRMUrl: this.config.get('CRM_HOST'),
+      webAPIurl: this.config.get('CRM_URL_PATH'),
+      clientId: this.config.get('CLIENT_ID'),
+      clientSecret: this.config.get('CLIENT_SECRET'),
+      tenantId: this.config.get('TENANT_ID'),
+      authorityHostUrl: this.config.get('AUTHORITY_HOST_URL'),
+      tokenPath: this.config.get('TOKEN_PATH'),
+    };
+
+    this.crmUrlPath = this.config.get('CRM_URL_PATH');
+    this.crmHost = this.config.get('CRM_HOST');
+    this.host = `${this.crmHost}${this.crmUrlPath}`;
+  }
+
+  async get(entity: string, query: string, ...options) {
+    try {
+      const sanitizedQuery = query.replace(/^\s+|\s+$/g, '');
+      const response = await this._get(`${entity}?${sanitizedQuery}`, ...options);
+      const {
+        value: records,
+        '@odata.count': count,
+      } = response;
+
+      return {
+        count,
+        records,
+      };
+    } catch (e) {
+      throw new HttpException({
+        code: 'QUERY_FAILED',
+        title: 'Could not find entity',
+        detail: e,
+      }, HttpStatus.NOT_FOUND);
+    }
+  }
+
+  async create(query, data, headers = {}) {
+    return this._create(query, data, headers);
+  }
+
+  async update(entity, guid, data, headers = {}) {
+    return this._update(entity, guid, data, headers);
+  }
+
+  async delete(entitySetName, guid, headers = {}) {
+    const query = entitySetName + "(" + guid + ")";
+
+    return this._sendDeleteRequest(query, headers);
+  }
+
+  async associate(relationshipName, entitySetName1, guid1, entitySetName2, guid2, headers = {}) {
+    return this._associate(relationshipName, entitySetName1, guid1, entitySetName2, guid2, headers);
+  }
+
+  /**
+   * Makes a CRM Web API query using the passed in query in XML format
+   *
+   * @param      {string}  entity     the pluralized version of the entity
+   * @param      {string}  xmlQuery   query string to additionally filter, in XML
+   * @return     {string}
+   */
+  async getWithXMLQuery(entity: string, xmlQuery: string, ...options) {
+    const response = await this._get(`${entity}?fetchXml=${xmlQuery}`, ...options);
+    return response;
+  }
+
+  // this provides the formatted values but doesn't do it for top level
+  // TODO: where should this happen? 
+  _fixLongODataAnnotations(dataObj) {
+    return dataObj;
+  }
+
+  _parseErrorMessage(json) {
+    if (json) {
+      if (json.error) {
+        return json.error;
+      }
+      if (json._error) {
+        return json._error;
+      }
+    }
+    return "Error";
+  }
+
+  _dateReviver(key, value) {
+    if (typeof value === 'string') {
+      // YYYY-MM-DDTHH:mm:ss.sssZ => parsed as UTC
+      // YYYY-MM-DD => parsed as local date
+
+      if (value != "") {
+        const a = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)Z$/.exec(value);
+
+        if (a) {
+          const s = parseInt(a[6]);
+          const ms = Number(a[6]) * 1000 - s * 1000;
+          return new Date(Date.UTC(parseInt(a[1]), parseInt(a[2]) - 1, parseInt(a[3]), parseInt(a[4]), parseInt(a[5]), s, ms));
+        }
+
+        const b = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+
+        if (b) {
+          return new Date(parseInt(b[1]), parseInt(b[2]) - 1, parseInt(b[3]), 0, 0, 0, 0);
+        }
+      }
+    }
+
+    return value;
+  }
+
+  async _get(query, maxPageSize = 100, headers = {}): Promise<any> {
+    //  get token
+    const JWToken = await ADAL.acquireToken();
+    const options = {
+      url: `${this.host}${query}`,
+      headers: {
+        'Accept-Encoding': 'gzip, deflate',
+        'Content-Type': 'application/json; charset=utf-8',
+        Authorization: `Bearer ${JWToken}`,
+        'OData-MaxVersion': '4.0',
+        'OData-Version': '4.0',
+        Accept: 'application/json',
+        Prefer: 'odata.include-annotations="*"',
+        ...headers
+      },
+      encoding: null,
+    };
+
+    return new Promise((resolve, reject) => {
+      Request.get(options, (error, response, body) => {
+        const encoding = response.headers['content-encoding'];
+
+        if (!error && response.statusCode === 200) {
+          // If response is gzip, unzip first
+
+          const parseResponse = jsonText => {
+            const json_string = jsonText.toString('utf-8');
+
+            var result = JSON.parse(json_string, this._dateReviver);
+            if (result["@odata.context"].indexOf("/$entity") >= 0) {
+              // retrieve single
+              result = this._fixLongODataAnnotations(result);
+            }
+            else if (result.value) {
+              // retrieve multiple
+              var array = [];
+              for (var i = 0; i < result.value.length; i++) {
+                array.push(this._fixLongODataAnnotations(result.value[i]));
+              }
+              result.value = array;
+            }
+            resolve(result);
+          };
+
+          if (encoding && encoding.indexOf('gzip') >= 0) {
+            zlib.gunzip(body, (err, dezipped) => {
+              parseResponse(dezipped);
+            });
+          }
+          else {
+            parseResponse(body);
+          }
+        } else {
+          const parseError = jsonText => {
+            // Bug: sometimes CRM returns 'object reference' error
+            // Fix: if we retry error will not show again
+            const json_string = jsonText.toString('utf-8');
+            const result = JSON.parse(json_string, this._dateReviver);
+            const err = this._parseErrorMessage(result);
+
+            if (err == "Object reference not set to an instance of an object.") {
+              this._get(query, maxPageSize, options)
+                .then(
+                  resolve, reject
+                );
+            } else {
+              reject(err);
+            }
+          };
+
+          if (encoding && encoding.indexOf('gzip') >= 0) {
+            zlib.gunzip(body, (err, dezipped) => {
+              parseError(dezipped);
+            });
+          } else {
+            parseError(body);
+          }
+        }
+      });
+    });
+  }
+
+  async _create(query, data, headers): Promise<any> {
+    //  get token
+    const JWToken = await ADAL.acquireToken();
+    const options = {
+      url: `${this.host + query}`,
+      headers: {
+        'Accept-Encoding': 'gzip, deflate',
+        'Content-Type': 'application/json; charset=utf-8',
+        Authorization: `Bearer ${JWToken}`,
+        'OData-MaxVersion': '4.0',
+        'OData-Version': '4.0',
+        Accept: 'application/json',
+        Prefer: 'return=representation',
+        ...headers
+      },
+      body: JSON.stringify(data),
+      encoding: null,
+    };
+
+    return new Promise((resolve, reject) => {
+      Request.post(options, (error, response, body) => {
+        const encoding = response.headers['content-encoding'];
+
+        if (error || (response.statusCode != 200 && response.statusCode != 201 && response.statusCode != 204 && response.statusCode != 1223)) {
+          const parseError = jsonText => {
+            // Bug: sometimes CRM returns 'object reference' error
+            // Fix: if we retry error will not show again
+            const json_string = jsonText.toString('utf-8');
+
+            var result = JSON.parse(json_string, this._dateReviver);
+            var err = this._parseErrorMessage(result);
+            reject(err);
+          };
+          if (encoding && encoding.indexOf('gzip') >= 0) {
+            zlib.gunzip(body, (err, dezipped) => {
+              parseError(dezipped);
+            });
+          }
+          else {
+            parseError(body);
+
+          }
+        }
+        else if (response.statusCode === 200 || response.statusCode === 201) {
+          const parseResponse = jsonText => {
+            const json_string = jsonText.toString('utf-8');
+            var result = JSON.parse(json_string, this._dateReviver);
+            resolve(result);
+          };
+
+          if (encoding && encoding.indexOf('gzip') >= 0) {
+            zlib.gunzip(body, (err, dezipped) => {
+              parseResponse(dezipped);
+            });
+          }
+          else {
+            parseResponse(body);
+          }
+        }
+        else if (response.statusCode === 204 || response.statusCode === 1223) {
+          const uri = response.headers["OData-EntityId"];
+          if (uri) {
+            // create request - server sends new id
+            const regExp = /\(([^)]+)\)/;
+            const matches = regExp.exec(uri);
+            const newEntityId = matches[1];
+            resolve(newEntityId);
+          }
+          else {
+            // other type of request - no response
+            resolve();
+          }
+        }
+        else {
+          resolve();
+        }
+      });
+    })
+  }
+
+  async _update(entitySetName, guid, data, headers) {
+    var query = entitySetName + "(" + guid + ")";
+    return this._sendPatchRequest(query, data, headers);
+  }
+
+  async _sendPatchRequest(query, data, headers) {
+    //  get token
+    const JWToken = await ADAL.acquireToken();
+    const options = {
+      url: `${this.host + query}`,
+      headers: {
+        'Accept-Encoding': 'gzip, deflate',
+        'Content-Type': 'application/json; charset=utf-8',
+        Authorization: `Bearer ${JWToken}`,
+        'OData-MaxVersion': '4.0',
+        'OData-Version': '4.0',
+        Accept: 'application/json',
+        Prefer: 'odata.include-annotations="*"',
+        ...headers
+      },
+      body: JSON.stringify(data),
+      encoding: null,
+    };
+
+    return new Promise((resolve, reject) => {
+      Request.patch(options, (error, response, body) => {
+        const encoding = response.headers['content-encoding'];
+
+        if (error || response.statusCode != 204) {
+          const parseError = jsonText => {
+            const json_string = jsonText.toString('utf-8');
+            var result = JSON.parse(json_string, this._dateReviver);
+            var err = this._parseErrorMessage(result);
+            reject(err);
+          };
+          if (encoding && encoding.indexOf('gzip') >= 0) {
+            zlib.gunzip(body, (err, dezipped) => {
+              parseError(dezipped);
+            });
+          }
+          else {
+            parseError(body);
+
+          }
+        }
+        else resolve(body);
+      })
+    });
+  }
+
+  async _sendDeleteRequest(query, headers) {
+    // get token
+    const JWToken = await ADAL.acquireToken();
+    const options = {
+      url: `${this.host + query}`,
+      headers: {
+        'Accept-Encoding': 'gzip, deflate',
+        'Content-Type': 'application/json; charset=utf-8',
+        Authorization: `Bearer ${JWToken}`,
+        'OData-MaxVersion': '4.0',
+        'OData-Version': '4.0',
+        Accept: 'application/json',
+        Prefer: 'odata.include-annotations="*"',
+        ...headers
+      },
+      encoding: null,
+    };
+
+    return new Promise((resolve, reject) => {
+      Request.delete(options, (error, response, body) => {
+        const encoding = response.headers['content-encoding'];
+
+        if (error || (response.statusCode != 204 && response.statusCode != 1223)) {
+          const parseError = jsonText => {
+            const json_string = jsonText.toString('utf-8');
+            const result = JSON.parse(json_string, this._dateReviver);
+            const err = this._parseErrorMessage(result);
+            reject(err);
+          };
+          if (encoding && encoding.indexOf('gzip') >= 0) {
+            zlib.gunzip(body, (err, dezipped) => {
+              parseError(dezipped);
+            });
+          }
+          else {
+            parseError(body);
+
+          }
+        }
+        else resolve();
+      })
+    });
+  }
+
+  async _associate(relationshipName, entitySetName1, guid1, entitySetName2, guid2, headers) {
+    const query = entitySetName1 + "(" + guid1 + ")/" + relationshipName + "/$ref";
+    const data = {
+      "@odata.id": this.host + entitySetName2 + "(" + guid2 + ")"
+    };
+    return this.create(query, data, headers);
+  }
+
+  async generateSharePointAccessToken(): Promise<any> {
+    const TENANT_ID = this.config.get('TENANT_ID');
+    const SHAREPOINT_CLIENT_ID = this.config.get('SHAREPOINT_CLIENT_ID');
+    const SHAREPOINT_CLIENT_SECRET = this.config.get('SHAREPOINT_CLIENT_SECRET');
+    const ADO_PRINCIPAL = this.config.get('ADO_PRINCIPAL');
+    const SHAREPOINT_TARGET_HOST = this.config.get('SHAREPOINT_TARGET_HOST');
+
+    const clientId = `${SHAREPOINT_CLIENT_ID}@${TENANT_ID}`;
+    const data = `
+      grant_type=client_credentials
+      &client_id=${clientId}
+      &client_secret=${SHAREPOINT_CLIENT_SECRET}
+      &resource=${ADO_PRINCIPAL}/${SHAREPOINT_TARGET_HOST}@${TENANT_ID}
+    `;
+
+    const options = {
+      url: `https://accounts.accesscontrol.windows.net/${TENANT_ID}/tokens/OAuth/2`,
+      headers: {
+        'Accept-Encoding': 'gzip, deflate',
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'OData-MaxVersion': '4.0',
+        'OData-Version': '4.0',
+        Accept: 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: data,
+      encoding: null,
+    };
+
+    return new Promise(resolve => {
+      Request.get(options, (error, response, body) => {
+        const stringifiedBody = body.toString('utf-8');
+        if (response.statusCode >= 400) {
+          console.log('error', stringifiedBody);
+        }
+
+        resolve(JSON.parse(stringifiedBody));
+      });
+    })
+  }
+
+  // Retrieves a list of files in a given Sharepoint folder
+  async getSharepointFolderFiles(folderIdentifier): Promise<any> {
+    try {
+      const { access_token } = await this.generateSharePointAccessToken();
+      const SHAREPOINT_CRM_SITE = this.config.get('SHAREPOINT_CRM_SITE');
+
+      // Escape apostrophes by duplicating any apostrophes.
+      // See https://sharepoint.stackexchange.com/a/165224
+      const formattedFolderIdentifier = folderIdentifier.replace(/'/g, "''");
+      const url = encodeURI(`https://nyco365.sharepoint.com/sites/${SHAREPOINT_CRM_SITE}/_api/web/GetFolderByServerRelativeUrl('/sites/${SHAREPOINT_CRM_SITE}/${formattedFolderIdentifier}')/Files`);
+
+      const options = {
+        url,
+        headers: {
+          'Authorization': `Bearer ${access_token}`,
+          Accept: 'application/json',
+        },
+      };
+
+      return new Promise(resolve => {
+        Request.post(options, (error, response, body) => {
+          const stringifiedBody = body.toString('utf-8');
+          if (response.statusCode >= 400) {
+            throw new HttpException({
+              code: 'LOAD_FOLDER_FAILED',
+              title: 'Error loading sharepoint files',
+              detail: `Could not load file list from Sharepoint folder "${formattedFolderIdentifier}". ${stringifiedBody}`,
+            }, HttpStatus.NOT_FOUND);
+          }
+
+          resolve(JSON.parse(stringifiedBody));
+        });
+      })
+    } catch (e) {
+      if (e instanceof HttpException) {
+        throw e;
+      } else {
+        throw new HttpException({
+          code: 'REQUEST_FOLDER_FAILED',
+          title: 'Error requesting sharepoint files',
+          detail: `Error while constructing request for Sharepoint folder files`,
+        }, HttpStatus.INTERNAL_SERVER_ERROR);
+      }
+    }
+  }
+
+  /**
+   * Uses the given url server relative url to create a request to the Sharepoint API
+   * for respective file. Server relative urls have this format:
+   *   /sites/<site>/<entity_name>/<folder_name>/filename.pdf
+   * For example,
+   *   /sites/dcpuat2/dcp_package/2021M0268_DraftEAS_1_996699F37323EB11A813001DD8309FA8/EAS%20Full%20Form.pdf
+   * @param      {string}  serverRelativeUrl { server relative url }
+   * @return     {stream}  { Returns a pipeable file stream }
+   */
+  async getSharepointFile(serverRelativeUrl): Promise<any> {
+    const { access_token } = await this.generateSharePointAccessToken();
+    const SHAREPOINT_CRM_SITE = this.config.get('SHAREPOINT_CRM_SITE');
+
+    // see https://docs.microsoft.com/en-us/previous-versions/office/sharepoint-server/dn775742(v=office.15)
+    const url = `https://nyco365.sharepoint.com/sites/${SHAREPOINT_CRM_SITE}/_api/web/GetFileByServerRelativeUrl('/${serverRelativeUrl}')/$value?binaryStringResponseBody=true`;
+
+    const options = {
+      url,
+      headers: {
+        'Authorization': `Bearer ${access_token}`,
+      },
+    };
+
+    // this returns a pipeable stream
+    return Request.get(options)
+      .on('error', (e) => console.log(e));
+  }
+
+  async deleteSharepointFile(serverRelativeUrl): Promise<any> {
+    const { access_token } = await this.generateSharePointAccessToken();
+    const SHAREPOINT_CRM_SITE = this.config.get('SHAREPOINT_CRM_SITE');
+    const url = `https://nyco365.sharepoint.com/sites/${SHAREPOINT_CRM_SITE}/_api/web/GetFileByServerRelativeUrl('${serverRelativeUrl}')`;
+
+    const options = {
+      url,
+      headers: {
+        'Authorization': `Bearer ${access_token}`,
+        Accept: 'application/json',
+        'X-HTTP-Method': 'DELETE',
+      },
+    };
+
+    return new Promise(resolve => {
+      Request.del(options, (error, response, body) => {
+        const stringifiedBody = body.toString('utf-8');
+        if (response.statusCode >= 400) {
+          console.log('error', stringifiedBody);
+        }
+
+        resolve();
+      });
+    })
+  }
+}

--- a/server/src/document/document.controller.spec.ts
+++ b/server/src/document/document.controller.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigModule } from '../config/config.module';
 import { DocumentController } from './document.controller';
+import { DocumentService } from './document.service';
+import { CrmModule } from '../crm/crm.module';
 
 describe('Document Controller', () => {
   let controller: DocumentController;
@@ -9,7 +11,9 @@ describe('Document Controller', () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [
         ConfigModule,
+        CrmModule,
       ],
+      providers: [DocumentService],
       controllers: [DocumentController],
     }).compile();
 

--- a/server/src/document/document.controller.ts
+++ b/server/src/document/document.controller.ts
@@ -1,4 +1,5 @@
 import { Controller,
+  Get,
   Post,
   Req,
   Res,
@@ -6,9 +7,11 @@ import { Controller,
   UploadedFile,
   HttpStatus,
   HttpException,
+  Param,
   Session,
 } from '@nestjs/common';
 import { ConfigService } from '../config/config.service';
+import { DocumentService } from './document.service';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Request } from 'express';
 import { CRMWebAPI } from '../_utils/crm-web-api';
@@ -17,6 +20,7 @@ import { CRMWebAPI } from '../_utils/crm-web-api';
 export class DocumentController {
   constructor(
     private readonly config: ConfigService,
+    private readonly documentService: DocumentService,
   ) {}
 
   /** Uploads a single document
@@ -64,5 +68,12 @@ export class DocumentController {
     } else {
       response.status(400).send({ "error": 'You can only upload files to dcp_communityboarddisposition at this time' });
     }
+  }
+
+  @Get('/*')
+  async read(@Param() path, @Res() res) {
+    const stream = await this.documentService.getPublicPackageDocument(path);
+
+    stream.pipe(res);
   }
 }

--- a/server/src/document/document.module.ts
+++ b/server/src/document/document.module.ts
@@ -1,11 +1,20 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '../config/config.module';
 import { DocumentController } from './document.controller';
+import { DocumentService } from './document.service';
+import { CrmModule } from '../crm/crm.module';
 
 @Module({
   imports: [
     ConfigModule,
+    CrmModule,
   ],
-  controllers: [DocumentController]
+  controllers: [DocumentController],
+  providers: [
+    DocumentService,
+  ],
+  exports: [
+    DocumentService,
+  ],
 })
 export class DocumentModule {}

--- a/server/src/document/document.service.ts
+++ b/server/src/document/document.service.ts
@@ -1,0 +1,173 @@
+import { Injectable, HttpStatus, HttpException } from '@nestjs/common';
+import { CrmService } from '../crm/crm.service';
+
+const PACKAGE_VISIBILITY = {
+  GENERAL_PUBLIC: 717170003,
+}
+const PACKAGE_STATUSCODE = {
+  SUBMITTED: 717170012,
+}
+
+// Inserts hyphens into an unhyphenated GUID string
+// e.g. 
+// 996699F37323EB11A813001DD8309FA8 
+// becomes
+// 996699F3-7323-EB11-A813-001DD8309FA8
+//
+// https://docs.microsoft.com/en-us/dynamics-nav/guid-data-type
+function hyphenateGUID(unhyphenatedGUID) {
+  return [
+    unhyphenatedGUID.slice(0, 8),
+    '-',
+    unhyphenatedGUID.slice(8, 12),
+    '-',
+    unhyphenatedGUID.slice(12,16),
+    '-',
+    unhyphenatedGUID.slice(16,20),
+    '-',
+    unhyphenatedGUID.slice(20),
+  ].join('');
+}
+
+@Injectable()
+export class DocumentService {
+  constructor(
+    private readonly crmService: CrmService,
+  ){}
+
+  // We retrieve documents from the Sharepoint folder (`folderIdentifier` in the
+  // code below) that holds both documents from past revisions and the current
+  // revision. CRM automatically carries over documents from past revisions into
+  // this folder, and we deliberately upload documents for the latest/current
+  // revision into this folder.
+  async findPackageSharepointDocuments(packageName, id: string) {
+    try {
+      const strippedPackageName = packageName.replace(/-/g, '').replace(/\s+/g, '').replace(/'+/g, '').replace(/^\~|\#|\%|\&|\*|\{|\}|\\|\:|\<|\>|\?|\/|\||\"/g, '');
+      const folderIdentifier = `${strippedPackageName}_${id.toUpperCase().replace(/-/g, '')}`;
+
+      const { value: documents } = await this.crmService.getSharepointFolderFiles(`dcp_package/${folderIdentifier}`);
+
+      if (documents) {
+        return documents.map(document => ({
+          name: document['Name'],
+          timeCreated: document['TimeCreated'],
+          serverRelativeUrl: document['ServerRelativeUrl'],
+        }));
+      }
+
+      return [];
+    } catch (e) {
+      // Relay errors from crmService 
+      if (e instanceof HttpException) {
+        throw e;
+      } else {
+        throw new HttpException({
+          code: 'SHAREPOINT_FOLDER_ERROR',
+          title: 'Bad Sharepoint folder lookup',
+          detail: `An error occured while constructing and looking up folder for package. Perhaps the package name or id is wrong.`,
+          meta: {
+            packageName: packageName,
+            packageId: id,
+          }
+        }, HttpStatus.INTERNAL_SERVER_ERROR);
+      }
+    }
+  }
+
+
+  /**
+   * Injects associated documents into the given package
+   *
+   * @param      {Object{ dcp_name, dcp_packageid }} CRM Package with
+   *              dcp_name and dcp_packageid properties
+   * @return     {[Object]} The CRM Package with the 'documents' property hydrated,
+   *              if associated documents exist in CRM.
+   */
+  public async packageWithDocuments(projectPackage: any) {
+    const {
+      dcp_name,
+      dcp_packageid,
+    } = projectPackage;
+
+    try {
+      return {
+        ...projectPackage,
+        documents: await this.findPackageSharepointDocuments(dcp_name, dcp_packageid),
+      };
+    } catch {
+      const errorMessage = `Error loading documents for package ${dcp_name}.`;
+      console.log(errorMessage);
+
+      throw new HttpException({
+        "code": "PACKAGE_WITH_DOCUMENTS",
+        "title": "Package Documents Error",
+        "detail": errorMessage,
+      }, HttpStatus.NOT_FOUND);
+    }
+  }
+
+  // "path" refers to the "relative server path", the path
+  // to the file itself on the sharepoint host. It has the format
+  //
+  //   /sites/<site>/<entity_name>/<folder_name>/filename.pdf
+  //
+  // For example,
+  //
+  //   /sites/dcpuat2/dcp_package/2021M0268_DraftEAS_1_996699F37323EB11A813001DD8309FA8/EAS%20Full%20Form.pdf
+  //
+  // Note that <folder_name> has this format:
+  //
+  //   <package_name>_<PACKAGEID>
+  //
+  // where package_name is the dcp_name property on the package
+  // (spaces replaced with underscores)
+  // and PACKAGEID is the package dcp_packageid property, stripped
+  // of hyphens.
+  //
+  // We have assurance of this. See
+  // https://dcp-paperless.visualstudio.com/dcp-paperless-dynamics/_workitems/edit/13366
+  public async getPublicPackageDocument(path) {
+    const pathSegment = path[0];
+    const packageFolder = pathSegment.split('/')[3];
+    const packageFolderSegments = packageFolder.split('_');
+    const strippedPackageId = packageFolderSegments[packageFolderSegments.length - 1];
+
+    // we need to re-insert hyphens to recreate the actual packageId
+    // TODO: Consider asking to preseve hyphens in Package ID
+    const packageId = hyphenateGUID(strippedPackageId);
+
+    try {
+      // Only documents belonging to public, submitted packages should be accessible
+      // to the public. So we make sure the requested document is associated with at least one
+      // public, submitted package.
+      const { records: [firstPackage] } = await this.crmService.get('dcp_packages', `
+        $select=dcp_packageid
+        &$filter=dcp_packageid eq ${packageId}
+        and (
+          dcp_visibility eq ${PACKAGE_VISIBILITY.GENERAL_PUBLIC}
+        )
+        and (
+          statuscode eq ${PACKAGE_STATUSCODE.SUBMITTED}
+        )
+      `);
+
+      if (!firstPackage) {
+        const errorMessage = `No document access.`;
+        console.log(`Client attempted to retrieve document ${pathSegment}, but no associated public, submitted packages were found.`);
+        throw new HttpException({
+          "code": "NO_DOCUMENT_ACCESS",
+          "detail": errorMessage,
+        }, HttpStatus.FORBIDDEN);
+      }
+
+      return await this.crmService.getSharepointFile(pathSegment);
+    } catch(e) {
+      const errorMessage = `Unable to provide document access. ${JSON.stringify(e.message)}`;
+      console.log(errorMessage);
+      throw new HttpException({
+        "code": "DOCUMENT_GET_ERROR",
+        "detail": errorMessage,
+      }, HttpStatus.FORBIDDEN);
+    }
+  }
+}

--- a/server/src/package/packages.attrs.ts
+++ b/server/src/package/packages.attrs.ts
@@ -1,0 +1,16 @@
+export const PACKAGE_ATTRS = [
+  'statuscode',
+  'statecode',
+  'dcp_packagetype',
+  'dcp_visibility',
+  'dcp_packageversion',
+  '_dcp_rwcdsform_value',
+  '_dcp_pasform_value',
+  '_dcp_landuseapplication_value',
+  'dcp_packageid',
+  'dcp_name',
+  'dcp_statusdate',
+  'dcp_packagesubmissiondate',
+  'dcp_packagenotes',
+  'documents',
+];

--- a/server/src/project/project.entity.ts
+++ b/server/src/project/project.entity.ts
@@ -14,6 +14,7 @@ export const KEYS = [
   'dcp_sisubdivision',
   'dcp_sischoolseat',
   'dcp_projectbrief',
+  'dcp_projectid',
   'dcp_projectname',
   'dcp_publicstatus',
   'dcp_publicstatus_simp',
@@ -44,6 +45,7 @@ export const KEYS = [
   'actions',
   'milestones',
   'dispositions',
+  'packages',
 ];
 
 export const ACTION_KEYS = [

--- a/server/src/project/project.module.ts
+++ b/server/src/project/project.module.ts
@@ -4,12 +4,16 @@ import { ProjectService } from './project.service';
 import { ConfigModule } from '../config/config.module';
 import { CartoModule } from '../carto/carto.module';
 import { OdataModule } from '../odata/odata.module';
+import { CrmModule } from '../crm/crm.module';
+import { DocumentModule } from '../document/document.module';
 
 @Module({
   imports: [
     OdataModule,
     ConfigModule,
     CartoModule,
+    CrmModule,
+    DocumentModule,
   ],
   controllers: [ProjectController],
   providers: [ProjectService],

--- a/server/src/project/project.service.spec.ts
+++ b/server/src/project/project.service.spec.ts
@@ -4,6 +4,8 @@ import { CartoService } from '../carto/carto.service';
 import { ConfigModule } from '../config/config.module';
 import { OdataModule } from '../odata/odata.module';
 import { ProjectController } from './project.controller';
+import { CrmModule } from '../crm/crm.module';
+import { DocumentModule } from '../document/document.module';
 
 describe('ProjectService', () => {
   let service: ProjectService;
@@ -13,6 +15,8 @@ describe('ProjectService', () => {
       imports: [
         OdataModule,
         ConfigModule,
+        CrmModule,
+        DocumentModule,
       ],
       controllers: [ProjectController],
       providers: [ProjectService, CartoService],


### PR DESCRIPTION
### Summary
Sets up backend to deliver Projects with submitted, public Packages that have a sideloaded Documents information. 
Sets up backend code to deliver the Documents for download.
Sets up frontend code to list those Documents grouped by Packages on the Project profile page.

See project 2021M0268 in (on dev/uat2) for an example. 
![image](https://user-images.githubusercontent.com/3311663/99596566-670d3f80-29ab-11eb-8a70-12a7fb9c2a3e.png)

#### Task/Bug Number
Fixes [AB#13238](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13238)

### Technical Explanation
  - Introduced a guard to make sure only documents belonging to General Public, Submitted packages can be downloaded.
  - There's also the addition of a few extra guards to protect against errors when variables are null. Also some fixes due to problems revealed by deepscan (e.g. using regex for find and replace instead of a string).