### PR TITLE
13246: zoning resolution dropdown filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ Use query Parameters for filtering:
 
     `action-types[]` - array of action types
 
+    `zoning-resolutions[]` - array of zoning resolutions
+
     `boroughs[]` - array of borough names, including 'Citywide'
 
     `dcp_ceqrtype[]` - array of CEQR types

--- a/client/app/controllers/query-parameters/show-geography.js
+++ b/client/app/controllers/query-parameters/show-geography.js
@@ -84,6 +84,16 @@ export const projectParams = new QueryParams({
       return value.split(',');
     },
   },
+  'zoning-resolutions': {
+    defaultValue: [],
+    refresh: true,
+    serialize(value) {
+      return value.toString();
+    },
+    deserialize(value = '') {
+      return value.split(',');
+    },
+  },
   dcp_publicstatus: {
     defaultValue: ['Filed', 'In Public Review'].sort(),
     refresh: true,

--- a/client/app/controllers/show-geography.js
+++ b/client/app/controllers/show-geography.js
@@ -77,6 +77,15 @@ export default class ShowGeographyController extends GeographyParachuteControlle
     return (pageTotal < MAX_PAGES) || ((page * MAX_PAGES) >= total);
   }
 
+  // remap the zoning resolutions to match the `lookup-action-type` and `lookup-community-district` filters
+  // this is so that we can standardize and keep the `replaceProperty` action working for each of these "lookups"
+  @computed('model')
+  get zoningResolutions() {
+    const allZoningResolutions = this.model;
+    const zoningResolutionsRemapped = allZoningResolutions.map(zr => ({ code: zr.id, name: zr.dcpZoningresolution }));
+    return zoningResolutionsRemapped;
+  }
+
   /**
    * Contructs an Ember Data friendly query object to be passed along
    * to calls to the `store`. This constructs an object representing

--- a/client/app/models/zoning-resolution.js
+++ b/client/app/models/zoning-resolution.js
@@ -1,0 +1,6 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class ZoningResolutionModel extends Model {
+  @attr()
+  dcpZoningresolution;
+}

--- a/client/app/routes/show-geography.js
+++ b/client/app/routes/show-geography.js
@@ -1,7 +1,12 @@
 import Route from '@ember/routing/route';
 
 export default class ShowGeographyRoute extends Route {
-  setupController(controller) {
+  async model() {
+    return this.store.findAll('zoning-resolution');
+  }
+
+  async setupController(controller, model) {
+    super.setupController(controller, model);
     controller.fetchData.perform({ unloadAll: true });
   }
 }

--- a/client/app/templates/show-geography.hbs
+++ b/client/app/templates/show-geography.hbs
@@ -275,6 +275,29 @@
         {{/section.filter-wrapper}}
       {{/filters.section}}
 
+      {{!-- FILTER: ZONING RESOLUTION TYPE --}}
+      {{#filters.section
+        filterNames='zoning-resolutions'
+        as |section|}}
+        {{#section.filter-wrapper
+          filterTitle=(get-label-for 'filters.zoning-resolutions')
+          tooltip='Filter by Zoning Resolution.'}}
+          {{#power-select-multiple
+            options=this.zoningResolutions
+            selected=(contains-keys
+              this.zoningResolutions
+              zoning-resolutions
+              key='code')
+            placeholder="Select some zoning resolutions..."
+            searchField='name'
+            onchange=(action section.delegate-mutation (action 'replaceProperty' 'zoning-resolutions'))
+            as |zoningResolution|
+          }}
+            {{zoningResolution.name}}
+          {{/power-select-multiple}}
+        {{/section.filter-wrapper}}
+      {{/filters.section}}
+
       {{!-- FILTER: FEMA FLOOD ZONE --}}
       {{#filters.section
         filterNames=(array 'dcp_femafloodzonea' 'dcp_femafloodzoneshadedx')

--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -97,6 +97,7 @@ module.exports = function(environment) {
         distance_from_point: 'Radius Filter',
         project_applicant_text: 'Text Match',
         radius_from_point: 'Radius Filter',
+        'zoning-resolutions': 'Zoning Resolutions',
       },
     },
   };

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -88,6 +88,7 @@ export default function () {
     return new Response(401, { some: 'header' }, { errors: ['Unauthorized'] });
   });
   this.get('/users/:id');
+  this.get('/zoning-resolutions');
 
   this.get('/actions');
   this.get('/assignments', function(schema, request) {

--- a/client/tests/acceptance/filter-checkbox-test.js
+++ b/client/tests/acceptance/filter-checkbox-test.js
@@ -53,6 +53,32 @@ module('Acceptance | filter checkbox', function(hooks) {
     assert.equal(currentURL(), '/projects?action-types=BF&applied-filters=action-types%2Cdcp_publicstatus');
   });
 
+  test('User clicks zoning resolution box, fills in zoning resolution name, selects zoning resolution type', async function(assert) {
+    server.createList('project', 20);
+
+    this.server.create('zoning-resolution', 1, {
+      dcpZoningresolution: 'AppendixD',
+    });
+    this.server.create('zoning-resolution', 2, {
+      dcpZoningresolution: 'AppendixF',
+    });
+    this.server.create('zoning-resolution', 3, {
+      dcpZoningresolution: '74-116',
+    });
+
+    await visit('/');
+    await click('[data-test-filter-section="filter-section-zoning-resolutions"] .switch-paddle');
+    await click('[data-test-filter-control="filter-section-zoning-resolutions"] .ember-power-select-multiple-options');
+    // Choose the second option in the select options, which is "AppendixF", which has an id of 2.
+    // Due to how we format the "action-type" options text, ember-power-select has difficulty selecting the text,
+    // so we use an index number instead.
+    await selectChoose('[data-test-filter-control="filter-section-zoning-resolutions"]', '.ember-power-select-option', 1);
+
+    // since we query _dcp_zoningresolution_value on the dcp_projectaction entity, our queryparam here is an id
+    // rather than the name of the zoning resolution
+    assert.equal(currentURL(), '/projects?applied-filters=dcp_publicstatus%2Czoning-resolutions&zoning-resolutions=2');
+  });
+
   test('User clicks ULURP checkbox and it filters', async function(assert) {
     server.createList('project', 20);
     await visit('/');

--- a/client/tests/unit/models/zoning-resolution-test.js
+++ b/client/tests/unit/models/zoning-resolution-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Model | zoning resolution', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const store = this.owner.lookup('service:store');
+    const model = store.createRecord('zoning-resolution', {});
+    assert.ok(model);
+  });
+});

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -13,6 +13,7 @@ import { OdataModule } from './odata/odata.module';
 import { AssignmentModule } from './assignment/assignment.module';
 import { DocumentModule } from './document/document.module';
 import { CrmModule } from './crm/crm.module';
+import { ZoningResolutionsModule } from './zoning-resolutions/zoning-resolutions.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { CrmModule } from './crm/crm.module';
     OdataModule,
     AssignmentModule,
     DocumentModule,
+    ZoningResolutionsModule,
    ],
   controllers: [AppController],
 })

--- a/server/src/project/geometry/geometry.service.ts
+++ b/server/src/project/geometry/geometry.service.ts
@@ -141,6 +141,9 @@ const QUERY_TEMPLATES = {
   'action-types': (queryParamValue) =>
     equalsAnyOf('dcp_name', queryParamValue, 'dcp_projectaction'),
 
+  'zoning-resolutions': (queryParamValue) =>
+    queryParamValue.map(value => `dcp_dcp_project_dcp_projectaction_project/any(o:o/_dcp_zoningresolution_value eq '${value}')`).join(' or '),
+
   boroughs: (queryParamValue) =>
     containsAnyOf('dcp_borough', coerceToNumber(mapInLookup(queryParamValue, BOROUGH_LOOKUP)), 'dcp_project'),
 

--- a/server/src/project/project.service.ts
+++ b/server/src/project/project.service.ts
@@ -135,6 +135,9 @@ const QUERY_TEMPLATES = {
       childEntity: 'dcp_dcp_project_dcp_projectaction_project'
     }),
 
+  'zoning-resolutions': (queryParamValue) =>
+    queryParamValue.map(value => `dcp_dcp_project_dcp_projectaction_project/any(o:o/_dcp_zoningresolution_value eq '${value}')`).join(' or '),
+
   boroughs: (queryParamValue) =>
     equalsAnyOf('dcp_borough', coerceToNumber(mapInLookup(queryParamValue, BOROUGH_LOOKUP))),
 
@@ -198,6 +201,7 @@ export const ALLOWED_FILTERS = [
   'blocks', // not sure this gets used
   'distance_from_point',
   'radius_from_point',
+  'zoning-resolutions',
 ];
 
 export const generateFromTemplate = (query, template) => {

--- a/server/src/zoning-resolutions/zoning-resolutions.controller.ts
+++ b/server/src/zoning-resolutions/zoning-resolutions.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Controller,
+  Get,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { CrmService } from '../crm/crm.service';
+import { Serializer } from 'jsonapi-serializer';
+import { dasherize } from 'inflected';
+
+const ACTIVE_STATUSCODE = 1;
+const ACTIVE_STATECODE = 0;
+
+const ZONING_RESOLUTION_KEYS = [
+  'dcp_zoningresolution',
+];
+
+@Controller('zoning-resolutions')
+export class ZoningResolutionsController {
+  constructor(
+    private readonly crmService: CrmService,
+  ) {}
+
+  @Get('/')
+  async zoningResolutions() {
+    try {
+      const { records } = await this.crmService.get('dcp_zoningresolutions',
+        `$select=dcp_zoningresolution
+        &$filter=
+        statuscode eq ${ACTIVE_STATUSCODE}
+        and statecode eq ${ACTIVE_STATECODE}
+    `);
+      return this.serialize(records);
+    } catch (e) {
+      if (e instanceof HttpException) {
+        throw e;
+      } else {
+        throw new HttpException({
+          code: 'FIND_ZONINGRESOLUTIONS_FAILED',
+          title: 'Failed getting zoning resolutions',
+          detail: `An unknown server error occured while getting zoning resolutions. ${e.message}`,
+        }, HttpStatus.INTERNAL_SERVER_ERROR);
+      }
+    }
+  }
+
+  // Serializes an array of objects into a JSON:API document
+  serialize(records, opts?: object): Serializer {
+    const ZoningResolutionSerializer = new Serializer('zoning-resolutions', {
+      attributes: ZONING_RESOLUTION_KEYS,
+      id: 'dcp_zoningresolutionid',
+      meta: { ...opts },
+      keyForAttribute(key) {
+        let dasherized = dasherize(key);
+
+        if (dasherized[0] === '-') {
+          dasherized = dasherized.substring(1);
+        }
+
+        return dasherized;
+      },
+    });
+
+    return ZoningResolutionSerializer.serialize(records);
+  }
+}

--- a/server/src/zoning-resolutions/zoning-resolutions.module.ts
+++ b/server/src/zoning-resolutions/zoning-resolutions.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { CrmModule } from '../crm/crm.module';
+import { ZoningResolutionsController } from './zoning-resolutions.controller';
+
+@Module({
+  imports: [
+    CrmModule,
+  ],
+  providers: [],
+  exports: [],
+  controllers: [ZoningResolutionsController],
+})
+export class ZoningResolutionsModule {}


### PR DESCRIPTION
**Summary**
This PR adds a new filter to the filters section for "Zoning Resolutions". It works similarly to the Action Type filter where users can search zoning resolution types from a dropdown, and then select multiple zoning resolutions so that the filtered projects have ANY of the zoning resolution types selected. 

**Addresses Task [AB#13246](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13246)**

**Technical Explanation**
Each `dcp_projectaction` entity has a navigation property called `dcp_ZoningResolution`. The projectAction entity therefore has a field called `_dcp_zoningresolution_value` which lists the id for the associated zoning resolution. 

We load ALL possible zoning resolutions from CRM -- this functions as a lookup for zoning resolution `name`-to-`id`. The name field on the `dcp_zoningresolution` is called `dcp_zoningresolution`. We use these loaded zoning resolutions as the options in the filter dropdown. 

When a user selects a zoning resolution name from the dropdown, the id that is associated with the selected name appears in the queryparams. We then use this value to query for projectActions that have the field `_dcp_zoningresolution_value` equal to that id. 