### PR TITLE
13475 List revision milestones appear after original milestone

### DIFF
--- a/client/app/components/project-milestone.js
+++ b/client/app/components/project-milestone.js
@@ -22,7 +22,7 @@ export default class ProjectMilestoneComponent extends Component {
     const date1 = this.get('milestone.displayDate');
     const date2 = this.get('milestone.displayDate2');
 
-    if (!date2 && moment(date1).isBefore()) { return 'past'; }
+    if (moment(date1).isBefore() && !date2) { return 'past'; }
 
     if (moment(date1).isBefore() && moment(date2).isBefore()) { return 'past'; }
 

--- a/server/src/project/_utils/transform-milestones.ts
+++ b/server/src/project/_utils/transform-milestones.ts
@@ -220,8 +220,17 @@ function transformAliases(milestone) {
 }
 
 function sortMilestones(prev, next) {
-  return (prev.display_sequence - next.display_sequence)
-    || (prev.display_date - next.display_date);
+  const displaySequenceDifference = prev.display_sequence - next.display_sequence;
+
+  if (displaySequenceDifference === 0) {
+    if (!prev.display_date)
+      return 1;
+    if (!next.display_date)
+      return -1;
+    return prev.display_date - next.display_date;
+  }
+
+  return displaySequenceDifference;
 }
 
 export const transformMilestones = (milestones, project) => {


### PR DESCRIPTION
Previously, milestones with null dcp_actualenddate were sorted to appear
earlier than saturated dcp_actualenddate. We want the reverse, so that
revision milestones appear after the original milestone.

Fixes [AB#13475](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13475)