### PR TITLE
13248: fix block search filter and fix geometry filtering

### DIFF
--- a/server/src/project/geometry/geometry.service.ts
+++ b/server/src/project/geometry/geometry.service.ts
@@ -128,7 +128,7 @@ const any = (...statements) => {
   ];
 };
 const containsString = (key, value, entityName='') => {
-  return `<condition ${entityName ? `entityname="${entityName}"` : '' } attribute="${key}" operator="like" value="% ${value} %" />`
+  return `<condition ${entityName ? `entityname="${entityName}"` : '' } attribute="${key}" operator="like" value="%25${value}%25" />`
 };
 
 // configure received params, provide procedures for generating queries.
@@ -147,8 +147,8 @@ const QUERY_TEMPLATES = {
   boroughs: (queryParamValue) =>
     containsAnyOf('dcp_borough', coerceToNumber(mapInLookup(queryParamValue, BOROUGH_LOOKUP)), 'dcp_project'),
 
-  blocks: (queryParamValue) =>
-    containsAnyOf('dcp_validatedblock', queryParamValue, 'dcp_projectbbl'),
+  block: (queryParamValue) =>
+    containsString('dcp_validatedblock', [queryParamValue], 'dcp_projectbbl'),
 
   dcp_ulurp_nonulurp: (queryParamValue) =>
     containsAnyOf('dcp_ulurp_nonulurp', coerceToNumber(mapInLookup(queryParamValue, ULURP_LOOKUP)), 'dcp_project'),
@@ -182,6 +182,9 @@ const QUERY_TEMPLATES = {
       containsString('dcp_ceqrnumber', queryParamValue, 'dcp_project'),
       containsString('dcp_name', queryParamValue, 'dcp_projectapplicant'),
       containsString('dcp_ulurpnumber', queryParamValue, 'dcp_projectaction'),
+      containsString('dcp_docket', queryParamValue, 'dcp_projectaction'),
+      containsString('dcp_comment', queryParamValue, 'dcp_projectaction'),
+      containsString('dcp_historiczoningresolutionsectionnumber', queryParamValue, 'dcp_projectaction'),
     ),
 };
 

--- a/server/src/project/project.service.ts
+++ b/server/src/project/project.service.ts
@@ -159,8 +159,8 @@ const QUERY_TEMPLATES = {
       comparisonOperator('dcp_certifiedreferred', 'lt', coerceToDateString(queryParamValue[1])),
     ),
 
-  blocks: (queryParamValue) =>
-    containsAnyOf('dcp_validatedblock', queryParamValue, {
+  block: (queryParamValue) =>
+    containsAnyOf('dcp_validatedblock', [queryParamValue], {
       childEntity: 'dcp_dcp_project_dcp_projectbbl_project'
     }),
 
@@ -198,7 +198,7 @@ export const ALLOWED_FILTERS = [
   'dcp_publicstatus', // 'Prefiled', 'Filed', 'In Public Review', 'Completed', 'Unknown'
   'dcp_certifiedreferred',
   'project_applicant_text',
-  'blocks', // not sure this gets used
+  'block',
   'distance_from_point',
   'radius_from_point',
   'zoning-resolutions',


### PR DESCRIPTION
### Summary
This PR fixes the block search (which was not working at all), and fixes the geometry filtering for Text Match filter and Action Types  filter.

### Task
Addresses [AB#13248](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13248), this PR also involves other fixes that were discovered while working on this task

### Technical Explanation
- there were typos between the frontend block filter and the backend block filter which were causing the filter to not work at all -- this was fixed
- filters that depended on the `containsString` function in `geometry.service` were faulty, the `containsString` function was fixed in this PR
- fields within text match filter -- `dcp_comment`, `dcp_docket`, and `dcp_historiczoningresolutionsectionnumber` -- were not added to the `geometry.service` when they were intially added to the `project.service`, this PR includes them