### PR TITLE
13549: update cpc report links to pull from CRM field in projectaction entity

### DIFF
--- a/client/app/controllers/show-project.js
+++ b/client/app/controllers/show-project.js
@@ -16,6 +16,8 @@ export default class ShowProjectController extends Controller {
 
   showPopup = false;
 
+  ACTION_STATUSCODE_ACTIVE = 1;
+
   bblFeatureCollectionLayerFill = {
     id: 'project-geometry-fill',
     type: 'fill',

--- a/client/app/helpers/build-url.js
+++ b/client/app/helpers/build-url.js
@@ -45,7 +45,7 @@ function bisweb(bbl) {
   return `http://a810-bisweb.nyc.gov/bisweb/PropertyBrowseByBBLServlet?allborough=${boro}&allblock=${block}&alllot=${lot}&go5=+GO+&requestid=0`;
 }
 
-function cpcReport(ulurp) {
+function cpcReport(ulurp, cpcUrl) {
   // for ulurp numbers that have a letter at the end of the 6 numbers to represent the version (ex. the "A" in C18005AZMX)
   // pull 6 numbers AND next character after the last number
   const ulurpNumberWithLetter = (ulurp.match(/(\d+)./g)[0]).toLowerCase();
@@ -53,10 +53,10 @@ function cpcReport(ulurp) {
 
   // the ulurp numbers with that extra letter have overall 11 characters compared to the usual 10
   if (ulurp.length > 10) {
-    return `http://www1.nyc.gov/assets/planning/download/pdf/about/cpc/${ulurpNumberWithLetter}.pdf`;
+    return `${cpcUrl}/${ulurpNumberWithLetter}.pdf`;
   }
 
-  return `http://www1.nyc.gov/assets/planning/download/pdf/about/cpc/${ulurpNumberWithoutLetter}.pdf`;
+  return `${cpcUrl}/${ulurpNumberWithoutLetter}.pdf`;
 }
 
 function acris(bbl) {
@@ -80,7 +80,7 @@ export function buildUrl([type, value, option]) {
   if (type === 'zoningResolution') return zoningResolution(value);
   if (type === 'zola') return zola(value);
   if (type === 'bisweb') return bisweb(value);
-  if (type === 'cpcReport') return cpcReport(value);
+  if (type === 'cpcReport') return cpcReport(value, option);
   if (type === 'acris') return acris(value);
   if (type === 'CommProfiles') return CommProfiles(value, option);
 

--- a/client/app/models/action.js
+++ b/client/app/models/action.js
@@ -49,4 +49,6 @@ export default class ActionModel extends Model {
 
   // sourced from dcp_ccresolutionnumber
   @attr('string') dcpCcresolutionnumber;
+
+  @attr('string') dcpSpabsoluteurl;
 }

--- a/client/app/templates/show-project.hbs
+++ b/client/app/templates/show-project.hbs
@@ -117,10 +117,14 @@
                             content='City Planning Commision Report'
                             tagName='span'
                           }}
-                            <a href={{build-url "cpcReport" action.dcpUlurpnumber}} target="_blank">
+                            {{#if (and (not-eq action.statuscode ACTION_STATUSCODE_ACTIVE) action.dcpSpabsoluteurl)}}
+                            <a href={{build-url "cpcReport" action.dcpUlurpnumber action.dcpSpabsoluteurl}} target="_blank">
                               {{action.dcpUlurpnumber}}
                               {{fa-icon 'external-link-alt'}}
                             </a>
+                            {{else}}
+                              {{action.dcpUlurpnumber}}
+                            {{/if}}
                           {{/tool-tipster}}
                         {{else}}
                           {{action.dcpUlurpnumber}}

--- a/server/queries/projects/show.sql
+++ b/server/queries/projects/show.sql
@@ -50,7 +50,8 @@ SELECT
       'dcp_prefix', a.dcp_prefix,
       'statuscode', a.statuscode,
       'dcp_ccresolutionnumber', a.dcp_ccresolutionnumber,
-      'dcp_zoningresolution', z.dcp_zoningresolution
+      'dcp_zoningresolution', z.dcp_zoningresolution,
+      'dcp_spabsoluteurl', a.dcp_spabsoluteurl
     ))
     FROM dcp_projectaction a
     LEFT JOIN dcp_zoningresolution z ON a.dcp_zoningresolution = z.dcp_zoningresolutionid

--- a/server/src/assignment/assignment.service.ts
+++ b/server/src/assignment/assignment.service.ts
@@ -234,7 +234,7 @@ function generateAssignmentsQueryObject(contact) {
     $expand: `
       dcp_dcp_project_dcp_communityboarddisposition_project($filter=${DISPOSITIONS_FILTER}),
       dcp_dcp_project_dcp_projectmilestone_project($filter=${MILESTONES_FILTER};$select=dcp_milestone,dcp_name,dcp_plannedstartdate,dcp_plannedcompletiondate,dcp_actualstartdate,dcp_actualenddate,statuscode,dcp_milestonesequence,dcp_remainingplanneddayscalculated,dcp_remainingplanneddays,dcp_goalduration,dcp_actualdurationasoftoday,_dcp_milestone_value,_dcp_milestoneoutcome_value),
-      dcp_dcp_project_dcp_projectaction_project($select=_dcp_action_value,dcp_name,statuscode,statecode,dcp_ulurpnumber,_dcp_zoningresolution_value,dcp_ccresolutionnumber),
+      dcp_dcp_project_dcp_projectaction_project($select=_dcp_action_value,dcp_name,statuscode,statecode,dcp_ulurpnumber,_dcp_zoningresolution_value,dcp_ccresolutionnumber,dcp_spabsoluteurl),
       dcp_dcp_project_dcp_projectbbl_project,
       dcp_dcp_project_dcp_projectlupteam_project($filter=(_dcp_lupteammember_value eq ${contactid}) and (statuscode eq 1))
     `,

--- a/server/src/project/project.entity.ts
+++ b/server/src/project/project.entity.ts
@@ -58,6 +58,7 @@ export const ACTION_KEYS = [
   'dcp_ccresolutionnumber',
   '_dcp_action_value',
   '_dcp_zoningresolution_value',
+  'dcp_spabsoluteurl',
 ];
 
 export const MILESTONE_KEYS = [

--- a/server/src/project/project.service.ts
+++ b/server/src/project/project.service.ts
@@ -355,14 +355,16 @@ export class ProjectService {
         comparisonStrategy: (prop, val) => comparisonOperator(prop, 'eq', val),
       }),
     );
-    const ACTIONS_FILTER = `(not ${comparisonOperator('statuscode', 'eq', 717170003)})`;
+
+    const ACTION_STATUSCODE_DEACTIVATED = 717170003;
+    const ACTIONS_FILTER = `(not ${comparisonOperator('statuscode', 'eq', ACTION_STATUSCODE_DEACTIVATED)})`;
 
     // WARNING: Only 5 expansions are allowed by Web API. Requesting more expansions
     // results in a silent failure.
     const EXPANSIONS = [
       `dcp_dcp_project_dcp_projectmilestone_project($filter=${MILESTONES_FILTER};$select=dcp_milestone,dcp_name,dcp_plannedstartdate,dcp_plannedcompletiondate,dcp_actualstartdate,dcp_actualenddate,statuscode,dcp_milestonesequence,dcp_remainingplanneddayscalculated,dcp_remainingplanneddays,dcp_goalduration,dcp_actualdurationasoftoday,_dcp_milestone_value,_dcp_milestoneoutcome_value,dcp_reviewmeetingdate)`,
       'dcp_dcp_project_dcp_communityboarddisposition_project($select=dcp_publichearinglocation,dcp_dateofpublichearing,dcp_boroughpresidentrecommendation,dcp_boroughboardrecommendation,dcp_communityboardrecommendation,dcp_consideration,dcp_votelocation,dcp_datereceived,dcp_dateofvote,statecode,statuscode,dcp_docketdescription,dcp_votinginfavorrecommendation,dcp_votingagainstrecommendation,dcp_votingabstainingonrecommendation,dcp_totalmembersappointedtotheboard,dcp_wasaquorumpresent,_dcp_recommendationsubmittedby_value,dcp_representing,_dcp_projectaction_value)',
-      `dcp_dcp_project_dcp_projectaction_project($filter=${ACTIONS_FILTER};$select=_dcp_action_value,dcp_name,statuscode,statecode,dcp_ulurpnumber,_dcp_zoningresolution_value,dcp_ccresolutionnumber)`,
+      `dcp_dcp_project_dcp_projectaction_project($filter=${ACTIONS_FILTER};$select=_dcp_action_value,dcp_name,statuscode,statecode,dcp_ulurpnumber,_dcp_zoningresolution_value,dcp_ccresolutionnumber,dcp_spabsoluteurl)`,
       'dcp_dcp_project_dcp_projectbbl_project($select=dcp_bblnumber;$filter=statuscode eq 1 and dcp_validatedblock ne null)', // TODO: add filter to exclude inactives
       'dcp_dcp_project_dcp_projectkeywords_project($select=dcp_name,_dcp_keyword_value)',
 


### PR DESCRIPTION
### Summary
Update the CPC Report link that appears as a Ulurp number under the action item on a project page. The URL for this link will now pull from a new field in CRM. 

Test project: 2020M0334

### Task
Addresses [AB#13549](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13549)

### Technical Explanation
There is now a field in CRM on the `dcp_projectaction` entity called `dcp_spabsoluteurl`. This field contains a link for the sharepoint CPC report documents folder. I updated the build-url helper so that the link in this field is passed into the build-url function instead of hardcoding the link that we had before. 