### PR TITLE
13579: update dcp_publicstatus label prefiled to noticed

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Use query Parameters for filtering:
 
     `dcp_femafloodzoneshadedx` *default false* - flood zone boolean
 
-    `dcp_publicstatus[] ` *default ['Prefiled', Filed', 'In Public Review', Completed']* - the project's public status
+    `dcp_publicstatus[] ` *default ['Noticed', Filed', 'In Public Review', Completed']* - the project's public status
 
     `dcp_certifiedreferred[]` - array of unix epoch timestamps to filter for date range
 

--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -83,7 +83,7 @@ $fieldset-border: $callout-border;
 //
 // Custom app modules and styles
 // --------------------------------------------------
-$prefiled-color: #d6d426;
+$noticed-color: #d6d426;
 $filed-color: #78D271;
 $in-public-review-color: #0979C3;
 $completed-color: #a6cee3;

--- a/client/app/styles/modules/_m-categorical-colors.scss
+++ b/client/app/styles/modules/_m-categorical-colors.scss
@@ -3,8 +3,8 @@
 // --------------------------------------------------
 
 .label {
-  .publicstatus-prefiled & {
-    background: $prefiled-color;
+  .publicstatus-noticed & {
+    background: $noticed-color;
     color: $black;
   }
   .publicstatus-filed & {
@@ -26,8 +26,8 @@
 }
 
 .fa-map-marker-alt {
-  .publicstatus-prefiled & {
-    color: $prefiled-color;
+  .publicstatus-noticed & {
+    color: $noticed-color;
   }
   .publicstatus-filed & {
     color: $filed-color;
@@ -42,7 +42,7 @@
     color: $dark-gray;
   }
 
-  .publicstatus-prefiled .button:hover &,
+  .publicstatus-noticed .button:hover &,
   .publicstatus-filed .button:hover &,
   .publicstatus-in-public-review .button:hover &,
   .publicstatus-completed .button:hover &,

--- a/client/app/styles/modules/_m-map-info-box.scss
+++ b/client/app/styles/modules/_m-map-info-box.scss
@@ -34,8 +34,8 @@
     .white {
       color: #fff;
     }
-    .stage-prefiled {
-      color: $prefiled-color;
+    .stage-noticed {
+      color: $noticed-color;
     }
     .stage-filed {
       color: $filed-color;

--- a/client/app/templates/components/map-info-box.hbs
+++ b/client/app/templates/components/map-info-box.hbs
@@ -3,8 +3,8 @@
     <li>
       <span class="fa-layers fa-fw">
         {{fa-icon 'circle' class="white" transform="shrink-2"}}
-        {{fa-icon 'circle' class="stage-prefiled" transform="shrink-6"}}
-      </span>Prefiled
+        {{fa-icon 'circle' class="stage-noticed" transform="shrink-6"}}
+      </span>Noticed
     </li>
     <li>
       <span class="fa-layers fa-fw">

--- a/client/app/templates/components/upcoming-project-card.hbs
+++ b/client/app/templates/components/upcoming-project-card.hbs
@@ -134,7 +134,7 @@
 
       {{waive-hearings-popup assignment=this.assignment showPopup=showPopup}}
       <ul class="no-bullet no-margin">
-        {{#if (eq this.assignment.project.dcpPublicstatus 'Prefiled')}}
+        {{#if (eq this.assignment.project.dcpPublicstatus 'Noticed')}}
           <p>This application has not yet been filed.</p>
         {{else}}
           {{#each this.assignment.assigneeDisplayMilestones as |milestone idx|}}

--- a/client/app/templates/show-geography.hbs
+++ b/client/app/templates/show-geography.hbs
@@ -104,9 +104,9 @@
         as |section|}}
         {{#section.filter-wrapper
           filterTitle=(get-label-for 'filters.dcp_publicstatus')
-          tooltip='These checkboxes filter projects by their stage in the application process. "Prefiled" refers to applications that are likely to be filed or enter public review in the next 30 days. “Filed” refers to applications that have been submitted but have not yet started the public review process. “In Public Review” refers to applications that have graduated to the public review process. “Completed” refers to applications that have been Approved, Disapproved, Withdrawn or Terminated.'}}
+          tooltip='These checkboxes filter projects by their stage in the application process. "Noticed" refers to applications that are likely to be filed or enter public review in the next 30 days. “Filed” refers to applications that have been submitted but have not yet started the public review process. “In Public Review” refers to applications that have graduated to the public review process. “Completed” refers to applications that have been Approved, Disapproved, Withdrawn or Terminated.'}}
           <ul class="menu vertical medium-horizontal stage-checkboxes">
-            {{#each (array 'Prefiled' 'Filed' 'In Public Review' 'Completed' 'Unknown') as |type|}}
+            {{#each (array 'Noticed' 'Filed' 'In Public Review' 'Completed' 'Unknown') as |type|}}
               <li {{action section.delegate-mutation (action 'mutateArray' 'dcp_publicstatus' type)}}
                 data-test-status-checkbox={{type}}
               >

--- a/client/mirage/factories/project.js
+++ b/client/mirage/factories/project.js
@@ -13,10 +13,10 @@ export default Factory.extend({
   // dcpPublicStatus and dcpPublicstatusSimp should not receive random mock data
   // because their values are critical to expressing project state.
 
-  // Domain is ['Prefiled', Filed', 'In Public Review', 'Completed']
+  // Domain is ['Noticed', Filed', 'In Public Review', 'Completed']
   dcpPublicstatus: 'Filed',
 
-  // Domain is ['Prefiled', 'Filed', 'In Public Review', 'Completed', 'Unknown']
+  // Domain is ['Noticed', 'Filed', 'In Public Review', 'Completed', 'Unknown']
   // This field is derived from dcpPublicstatus.
   // See https://github.com/NYCPlanning/zap-api/blob/develop/queries/projects/show.sql#L28
   dcpPublicstatusSimp: 'Filed',

--- a/client/tests/integration/components/map-info-box-test.js
+++ b/client/tests/integration/components/map-info-box-test.js
@@ -12,7 +12,7 @@ module('Integration | Component | map-info-box', function(hooks) {
 
     await render(hbs`{{map-info-box}}`);
 
-    assert.equal(this.element.textContent.trim().replace(/\s/g, ''), 'PrefiledFiledInPublicReviewCompletedDisclaimer');
+    assert.equal(this.element.textContent.trim().replace(/\s/g, ''), 'NoticedFiledInPublicReviewCompletedDisclaimer');
 
     // Template block usage:
     await render(hbs`
@@ -21,6 +21,6 @@ module('Integration | Component | map-info-box', function(hooks) {
       {{/map-info-box}}
     `);
 
-    assert.equal(this.element.textContent.trim().replace(/\s/g, ''), 'PrefiledFiledInPublicReviewCompletedDisclaimertemplateblocktext');
+    assert.equal(this.element.textContent.trim().replace(/\s/g, ''), 'NoticedFiledInPublicReviewCompletedDisclaimertemplateblocktext');
   });
 });

--- a/server/queries/assignments/index.sql
+++ b/server/queries/assignments/index.sql
@@ -433,7 +433,7 @@ SELECT
         dcp_projectcompleted,
         dcp_publicstatus,
         CASE
-          WHEN dcp_publicstatus = 'Prefiled' THEN 'Prefiled'
+          WHEN dcp_publicstatus = 'Noticed' THEN 'Noticed'
           WHEN dcp_publicstatus = 'Filed' THEN 'Filed'
           WHEN dcp_publicstatus = 'In Public Review' THEN 'In Public Review'
           WHEN dcp_publicstatus = 'Completed' THEN 'Completed'

--- a/server/queries/helpers/generate-vector-tile.sql
+++ b/server/queries/helpers/generate-vector-tile.sql
@@ -18,7 +18,7 @@ FROM (
   ) x, tilebounds
   WHERE x.$6^ && tilebounds.geom
   ORDER BY CASE WHEN dcp_publicstatus_simp = 'In Public Review' then 1
-                WHEN dcp_publicstatus_simp = 'Prefiled' then 2
+                WHEN dcp_publicstatus_simp = 'Noticed' then 2
                 WHEN dcp_publicstatus_simp = 'Filed' then 3
                 WHEN dcp_publicstatus_simp = 'Completed' then 4
                 ELSE 5

--- a/server/queries/projects/index.sql
+++ b/server/queries/projects/index.sql
@@ -17,7 +17,7 @@ WHERE coalesce(dcp_publicstatus_simp, 'Unknown') IN (${dcp_publicstatus:csv})
   ${blockQuery^}
 ORDER BY lastmilestonedate DESC NULLS LAST,
 CASE  WHEN dcp_publicstatus_simp = 'In Public Review' then 1
-      WHEN dcp_publicstatus_simp = 'Prefiled' then 2
+      WHEN dcp_publicstatus_simp = 'Noticed' then 2
       WHEN dcp_publicstatus_simp = 'Filed' then 3
       WHEN dcp_publicstatus_simp = 'Completed' then 4
             ELSE 5

--- a/server/queries/projects/show.sql
+++ b/server/queries/projects/show.sql
@@ -24,7 +24,7 @@ SELECT
   dcp_femafloodzoneshadedx,
   dcp_projectcompleted,
   CASE
-    WHEN p.dcp_publicstatus = 'Prefiled' THEN 'Prefiled'
+    WHEN p.dcp_publicstatus = 'Noticed' THEN 'Noticed'
     WHEN p.dcp_publicstatus = 'Filed' THEN 'Filed'
     WHEN p.dcp_publicstatus = 'In Public Review' THEN 'In Public Review'
     WHEN p.dcp_publicstatus = 'Completed' THEN 'Completed'

--- a/server/src/assignment/assignment.service.ts
+++ b/server/src/assignment/assignment.service.ts
@@ -217,7 +217,7 @@ function generateAssignmentsQueryObject(contact) {
 
     // todo maybe alias these crm named relationships
     // filters by projects with associations having some connection to contactid
-    // OR infers an association through recodedCbFullName (for prefiled)
+    // OR infers an association through recodedCbFullName (for Noticed)
     $filter: `
       dcp_visibility eq 717170003
       and ((dcp_dcp_project_dcp_communityboarddisposition_project/any
@@ -261,7 +261,7 @@ function computeStatusTab(project, lupteam, recodedCbFullName, fullname) {
   // REDO: Terrible: mix of labeled/coded.
   // Some values come through here as labeled, not coded, so we look for both the labeled
   // and coded versions
-  if ((project.dcp_publicstatus === 717170005 || project.dcp_publicstatus === 'Prefiled') // Prefiled
+  if ((project.dcp_publicstatus === 717170005 || project.dcp_publicstatus === 'Noticed') // Noticed
     && (project.dcp_ulurp_nonulurp === 717170001 || project.dcp_ulurp_nonulurp === 'ULURP') // ULURP
     && project.dcp_validatedcommunitydistricts.includes(recodedCbFullName)) {
     return 'upcoming';

--- a/server/src/project/project.service.ts
+++ b/server/src/project/project.service.ts
@@ -48,7 +48,7 @@ export const ULURP_LOOKUP = {
   'ULURP': 717170001,
 };
 export const PROJECT_STATUS_LOOKUP = {
-  Prefiled: 717170005,
+  Noticed: 717170005,
   Filed: 717170000,
   'In Public Review': 717170001,
   Completed: 717170002,
@@ -200,7 +200,7 @@ export const ALLOWED_FILTERS = [
   'dcp_ulurp_nonulurp', // 'ULURP', 'Non-ULURP'
   'dcp_femafloodzonea',
   'dcp_femafloodzoneshadedx',
-  'dcp_publicstatus', // 'Prefiled', 'Filed', 'In Public Review', 'Completed', 'Unknown'
+  'dcp_publicstatus', // 'Noticed', 'Filed', 'In Public Review', 'Completed', 'Unknown'
   'dcp_certifiedreferred',
   'project_applicant_text',
   'block',


### PR DESCRIPTION
Update the label for `dcp_publicstatus` code `717170005` to represent the new CRM label. From "Prefiled" to "Noticed". 

This just required a surface-level change in the label since both the old and new label represented the same code in CRM. 

Addresses [AB#13579](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13579)