### PR TITLE
make getSharepointFolderFiles flex; recurse file/folders

### DIFF
--- a/server/src/artifact/artifact.service.ts
+++ b/server/src/artifact/artifact.service.ts
@@ -18,7 +18,7 @@ export class ArtifactService {
   async getArtifactSharepointDocuments(relativeUrl, dcp_name) {
     if (relativeUrl) {
       try {
-        const { value: documents } = await this.sharepointService.getSharepointFolderFiles(`dcp_artifacts/${relativeUrl}`);
+        const documents = await this.sharepointService.getSharepointFolderFiles(`dcp_artifacts/${relativeUrl}`, '?$expand=Files,Folders,Folders/Files,Folders/Folders/Files,Folders/Folders/Folders/Files');
 
         if (documents) {
           return documents.map(document => ({

--- a/server/src/package/package.service.ts
+++ b/server/src/package/package.service.ts
@@ -24,7 +24,7 @@ export class PackageService {
 
     if (relativeurl) {
       try {
-        const { value: documents } = await this.sharepointService.getSharepointFolderFiles(`dcp_package/${relativeurl}`);
+        const documents = await this.sharepointService.getSharepointFolderFiles(`dcp_package/${relativeurl}`);
 
         if (documents) {
           return documents.map(document => ({


### PR DESCRIPTION
This change modifies the getSharepointFolderFiles method to make it more flexible, and to make it include 3 levels deep of nested subfolders. It then unnests and flattens files found.

![image](https://user-images.githubusercontent.com/5004319/103992085-9c3f3e00-5161-11eb-9e3d-e351121165b9.png)
