### PR TITLE
13574: reinstate the not-found page for when the URL contains a project dcp_name that does not exist

### DIFF
--- a/client/app/routes/show-project.js
+++ b/client/app/routes/show-project.js
@@ -26,6 +26,9 @@ export default class ShowProjectRoute extends Route {
   @action
   error(e) {
     console.log(e); // eslint-disable-line
-    // this.transitionTo('not-found', 'not-found');
+    if (e.errors) {
+      const isNotFound = e.errors.map(err => err.status).includes('404');
+      if (isNotFound) this.transitionTo('not-found', 'not-found');
+    }
   }
 }

--- a/server/src/project/project.service.ts
+++ b/server/src/project/project.service.ts
@@ -1,4 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { 
+  Injectable,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
 import { Serializer } from 'jsonapi-serializer';
 import { dasherize } from 'inflected';
 import { ConfigService } from '../config/config.service';
@@ -371,6 +375,7 @@ export class ProjectService {
       // TODO: i think there is a limit of 5 expansions so this one does not even appear
       'dcp_dcp_project_dcp_projectaddress_project($select=dcp_name)',
     ];
+    
     const { records: projects } = await this.dynamicsWebApi
       .queryFromObject('dcp_projects', {
         $select: DEFAULT_PROJECT_SHOW_FIELDS,
@@ -381,6 +386,13 @@ export class ProjectService {
         $expand: EXPANSIONS.join(','),
       }, 1);
     const [firstProject] = projects;
+
+    if (projects.length < 1)
+      throw new HttpException({
+        "code": "PROJECT_NOT_FOUND", 
+        "title": "Project not found",
+        "detail": `Project ${name} not found`,
+      }, HttpStatus.NOT_FOUND);
 
     const transformedProject = await transformProjectAttributes(firstProject);
 


### PR DESCRIPTION
### Summary
Previously when a user entered a URL with a project id that did not exist, the project page would load indefinitely. Now when a user visits the project page of a project that does not exist, the user will see a "Not Found" page.

**Note**: the PR's diff is a bit confusing and misleading, so please feel free to ask questions!

### Tasks
Addresses [AB#13574](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13574)

### Technical Explanation
Previously when a user entered a URL with a project `dcp_name` that did not exist, other `500` errors were showing up based off of Try Catch blocks that exist in the project service. These errors were "clouding" the actual error, which was that a project for that specific `dcp_name` did not exist. 

**In the backend**: This PR throws an `HttpException` of `NOT_FOUND` in the project service if the array of projects returned from the crm service is less than 1. This PR also creates an `if` statement in the project service that will only run the other transforms on the project object if there was actually a project returned from CRM. This means that no errors that are indirectly tied to `firstProject` being undefined (e.g. not being able to find milestones on an undefined object) will be clouding the actual 404 error.

**In the frontend**: The show-project.js route now has a check for any errors that have a status of `404`, and if a 404 error exists, then the route transitions to the Not Found page. 