### PR TITLE
Remove use of Folder and File properties in shpt service to match UAT2 responses

### DIFF
--- a/server/src/sharepoint/sharepoint.service.ts
+++ b/server/src/sharepoint/sharepoint.service.ts
@@ -99,12 +99,9 @@ export class SharepointService {
               detail: `Could not load file list from Sharepoint folder "${formattedFolderIdentifier}". ${stringifiedBody}`,
             }, HttpStatus.NOT_FOUND);
           }
-          const folderfiles = JSON.parse(stringifiedBody);
+          const { value: folderFiles } = JSON.parse(stringifiedBody);
 
-          resolve([
-            ...(folderfiles['Files'] ? folderfiles['Files'] : []),
-            ...(folderfiles['Folders'] ? unnest(folderfiles['Folders']) : []),
-          ]);
+          resolve(folderFiles);
         });
       })
     } catch (e) {


### PR DESCRIPTION
According to @allthesignals , production Sharepoint may deliver a different response format for files than UAT2.

Production now returns a response with `Folders` and `Files` properties, but UAT2 does not. Instead it holds an array of all package documents in a `value`  property.

Related to AB#769

@ksinghprod 