### PR TITLE
13588 Activate CPC report link for a handful of action statuscodes

### DIFF
--- a/client/app/templates/show-project.hbs
+++ b/client/app/templates/show-project.hbs
@@ -112,16 +112,20 @@
                     <p class="text-small no-margin">
                       {{#if action.dcpUlurpnumber}}
                         ULURP Number:
-                        {{#if (eq action.statuscode "Approved")}}
+                        {{#if (in-array
+                            (array "Approved" "Certified" "Referred" "Disapproved" "Terminated" "Withdrawn" "Study Complete")
+                            action.statuscode
+                          )
+                        }}
                           {{#tool-tipster
                             content='City Planning Commision Report'
                             tagName='span'
                           }}
                             {{#if (and (not-eq action.statuscode ACTION_STATUSCODE_ACTIVE) action.dcpSpabsoluteurl)}}
-                            <a href={{build-url "cpcReport" action.dcpUlurpnumber action.dcpSpabsoluteurl}} target="_blank">
-                              {{action.dcpUlurpnumber}}
-                              {{fa-icon 'external-link-alt'}}
-                            </a>
+                              <a href={{build-url "cpcReport" action.dcpUlurpnumber action.dcpSpabsoluteurl}} target="_blank">
+                                {{action.dcpUlurpnumber}}
+                                {{fa-icon 'external-link-alt'}}
+                              </a>
                             {{else}}
                               {{action.dcpUlurpnumber}}
                             {{/if}}


### PR DESCRIPTION
Previously, on the project profile, the CPC report link under an action only activated if the action had statuscode of "Approved".
This PR activates the CPC report link for actions which have the following status: 
Approved
Certified
Referred
Disapproved
Terminated
Withdrawn
Study Complete

Fixes [AB#13588](https://dcp-paperless.visualstudio.com/d36fd830-9029-4b77-b0c4-b0df2012eb98/_workitems/edit/13588)