### PR TITLE
Show CPC tooltip only if Sharepoint url exists

### DIFF
--- a/client/app/templates/show-project.hbs
+++ b/client/app/templates/show-project.hbs
@@ -117,19 +117,19 @@
                             action.statuscode
                           )
                         }}
-                          {{#tool-tipster
-                            content='City Planning Commision Report'
-                            tagName='span'
-                          }}
                             {{#if (and (not-eq action.statuscode ACTION_STATUSCODE_ACTIVE) action.dcpSpabsoluteurl)}}
+                            {{#tool-tipster
+                              content='City Planning Commision Report'
+                              tagName='span'
+                            }}
                               <a href={{build-url "cpcReport" action.dcpUlurpnumber action.dcpSpabsoluteurl}} target="_blank">
                                 {{action.dcpUlurpnumber}}
                                 {{fa-icon 'external-link-alt'}}
                               </a>
+                              {{/tool-tipster}}
                             {{else}}
                               {{action.dcpUlurpnumber}}
                             {{/if}}
-                          {{/tool-tipster}}
                         {{else}}
                           {{action.dcpUlurpnumber}}
                         {{/if}}


### PR DESCRIPTION
With the the merge of #1273, this tooltip below appears in most cases. It should only appear when the ULURP number is linking to a CPC report.

![66b8f744-c41c-4bdf-8541-a194ed0db386](https://user-images.githubusercontent.com/662963/104656035-a0e98200-568c-11eb-8331-d2a953fc0173.jpg)