### PR TITLE
795 Install helpscout beacon

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -44,5 +44,7 @@
     <script src="{{rootURL}}assets/labs-zap-search.js"></script>
 
     {{content-for "body-footer"}}
+
+    <script type="text/javascript">!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});</script><script type="text/javascript">window.Beacon('init', '5782616e-c1ec-4db4-8365-1c83eb3e66a3')</script>
   </body>
 </html>

--- a/client/mirage/config.js
+++ b/client/mirage/config.js
@@ -18,6 +18,7 @@ export default function () {
   this.passthrough('https://layers-api-staging.planninglabs.nyc/**');
   this.passthrough('https://labs-layers-api-staging.herokuapp.com/v1/base/style.json');
   this.passthrough('/test-data/**');
+  this.passthrough('https://d3hb14vkzrxvla.cloudfront.net/**');
 
   // If the project_lup_status queryParam is set, this endpoint
   // returns CB projects (projects belonging to the first mirage User)


### PR DESCRIPTION
See this Helpscout document for a bit of context:
https://docs.helpscout.com/article/1356-add-beacon-to-your-website-or-app

Upon inspecting network requests, the helpscout script pings `https://d3hb14vkzrxvla.cloudfront.net/**`, so I added that to our passthroughs so we can preview in development (and squash mirage errors). 

Fixes AB#795

![image](https://user-images.githubusercontent.com/3311663/105239737-beea3300-5b21-11eb-9ea3-88f7d7e3db83.png)