### PR TITLE
Use system-provided relative URL; expand subfolders in documents

### DIFF
--- a/server/src/artifact/artifact.service.ts
+++ b/server/src/artifact/artifact.service.ts
@@ -66,24 +66,18 @@ export class ArtifactService {
     // property is a single-valued property, a string representing the absolute Sharepoint URL.
     // So we have to split the string to get the "relative URL" portion.
     const {
-      dcp_artifactsid,
       dcp_name,
       dcp_artifactdocumentlocation,
     } = projectArtifact;
 
     if (dcp_artifactdocumentlocation) {
       try {
-        // Here we assume that the "entity" segment of the dcp_artifactdocumentlocation URL
-        // will be dcp_artifacts, since it is a artifact document location.
-        // Also that the segment divides the absolute URL into two tokens.
         // Example value for dcp_artifactdocumentlocation:
         // https://nyco365.sharepoint.com/sites/dcppfsuat2/dcp_artifacts/P2016K0021 - Area Map - 1_77A5253923FBE911A9BC001DD8308EF1
 
-        const formattedId = dcp_artifactsid.toUpperCase().replace(/-/g, '');
-
         return {
           ...projectArtifact,
-          documents: await this.getArtifactSharepointDocuments(`${dcp_name}_${formattedId}`, dcp_name),
+          documents: await this.getArtifactSharepointDocuments(dcp_artifactdocumentlocation, dcp_name),
         };
       } catch (e) {
         const errorMessage = `Error loading documents for artifact ${dcp_name}. ${JSON.stringify(e)}`;

--- a/server/src/package/package.service.ts
+++ b/server/src/package/package.service.ts
@@ -24,7 +24,7 @@ export class PackageService {
 
     if (relativeurl) {
       try {
-        const documents = await this.sharepointService.getSharepointFolderFiles(`dcp_package/${relativeurl}`);
+        const documents = await this.sharepointService.getSharepointFolderFiles(`dcp_package/${relativeurl}`, '?$expand=Files,Folders,Folders/Files,Folders/Folders/Files,Folders/Folders/Folders/Files');
 
         if (documents) {
           return documents.map(document => ({


### PR DESCRIPTION
Previously, I reversed some of @godfreyyeung's changes to infer the document sharepoint path from an assumed convention. However, because these are separate systems, downstream edits were not being synchronized, leading to failing queries.

Now, this uses the provided FULL path, for packages, which is then split into a relative path, and passed along.

Artifacts, as @godfreyyeung has discovered and designed around, expresses package paths a little differently, not providing them as true relative paths (with in the packages means removing the host from the url), but instead as the plain folder names.

This change handles these separately.

TODO: Major major refactors to package/artifact services. 