### PR TITLE
Provide debug only link-out to CRM

### DIFF
--- a/client/app/controllers/show-project.js
+++ b/client/app/controllers/show-project.js
@@ -14,7 +14,11 @@ export default class ShowProjectController extends Controller {
   @service
   session
 
+  queryParams = ['debug'];
+
   showPopup = false;
+
+  debug = false;
 
   bblFeatureCollectionLayerFill = {
     id: 'project-geometry-fill',

--- a/client/app/helpers/link-to-crm.js
+++ b/client/app/helpers/link-to-crm.js
@@ -1,0 +1,15 @@
+import { helper } from '@ember/component/helper';
+import ENV from '../config/environment';
+
+export default helper(function linkToCrm([type, id]) {
+  const { environment } = ENV;
+  let host;
+
+  if (environment === 'development') {
+    host = 'https://dcppfsuat2.crm9.dynamics.com';
+  } else {
+    host = 'https://nycdcppfs.crm9.dynamics.com';
+  }
+
+  return `${host}/main.aspx?etn=${type}&id={${id}}&pagetype=entityrecord`;
+});

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -55,7 +55,7 @@ export default class ProjectModel extends Model {
 
   @attr('boolean') dcpFemafloodzonea;
 
-@attr('boolean') dcpFemafloodzoneshadedx;
+  @attr('boolean') dcpFemafloodzoneshadedx;
 
   @attr('boolean') dcpSisubdivision;
 
@@ -64,6 +64,8 @@ export default class ProjectModel extends Model {
   @attr('string') dcpProjectbrief;
 
   @attr('string') dcpProjectname;
+
+  @attr('string') dcpProjectid;
 
   @attr('string', { defaultValue: '' }) dcpPublicstatus;
 

--- a/client/app/templates/show-project.hbs
+++ b/client/app/templates/show-project.hbs
@@ -8,8 +8,13 @@
           {{else}}
             Project {{model.dcpName}}
           {{/if}}
-        </h1>
 
+          {{#if this.debug}}
+            <a href="{{link-to-crm 'dcp_project' model.dcpProjectid}}" target="_blank">
+              {{fa-icon 'external-link-alt'}}
+            </a>
+          {{/if}}
+        </h1>
         <div class="grid-x">
           <div class="cell medium-auto">
             <p class="lead">

--- a/client/tests/integration/helpers/link-to-crm-test.js
+++ b/client/tests/integration/helpers/link-to-crm-test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | link-to-crm', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it renders', async function(assert) {
+    this.set('type', 'dcp_project');
+    this.set('id', '1234');
+
+    await render(hbs`{{link-to-crm type id}}`);
+
+    assert.equal(this.element.textContent.trim(), 'https://nycdcppfs.crm9.dynamics.com/main.aspx?etn=dcp_project&id={1234}&pagetype=entityrecord');
+  });
+});


### PR DESCRIPTION
This PR adds a query param to the "show project" route, `debug`, which is false by default.

This query param is used to show or hide a hyperlink that constructs a URL for the related CRM project page.

![image](https://user-images.githubusercontent.com/5004319/106020970-4c81d180-6092-11eb-80c8-9aafeca4ded7.png)

I'm add this to make it easier to get to the CRM information, which is the source of truth. This should make debugging a little easier.