### PR TITLE
Fix artifact naming

### DIFF
--- a/client/app/components/show-project/public-documents/artifact-documents.js
+++ b/client/app/components/show-project/public-documents/artifact-documents.js
@@ -10,7 +10,7 @@ export default class ArtifactDocumentsComponent extends Component {
   @tracked showArtifactDocuments = false;
 
   get formattedArtifactName() {
-    return this.artifact.dcpName.split(' - ')[1];
+    return this.artifact.dcpName.split(' - ')[1] || this.artifact.dcpName;
   }
 
   get hasArtifactDocuments() {


### PR DESCRIPTION
Review after commits from #1285.

This change defaults to the artifact name if the formatting fails (due to the absence of a dash).
