### PR TITLE
769 alphabetize doc list

### DIFF
--- a/client/app/components/show-project/public-documents/artifact-documents.js
+++ b/client/app/components/show-project/public-documents/artifact-documents.js
@@ -10,7 +10,7 @@ export default class ArtifactDocumentsComponent extends Component {
   @tracked showArtifactDocuments = false;
 
   get formattedArtifactName() {
-    return this.artifact.dcpName.split(' - ')[1];
+    return this.artifact.dcpName.split(' - ')[1] || this.artifact.dcpName;
   }
 
   get hasArtifactDocuments() {

--- a/client/app/templates/components/show-project/public-documents/artifact-documents.hbs
+++ b/client/app/templates/components/show-project/public-documents/artifact-documents.hbs
@@ -13,7 +13,7 @@
     <ul
       class="no-bullet public-documents-list-item"
     >
-      {{#each @artifact.documents as |document|}}
+      {{#each (sort-by 'serverRelativeUrl' @artifact.documents) as |document|}}
         <li>
           <a
             href={{concat this.host '/document/artifact' document.serverRelativeUrl}}

--- a/client/app/templates/components/show-project/public-documents/package-documents.hbs
+++ b/client/app/templates/components/show-project/public-documents/package-documents.hbs
@@ -13,7 +13,7 @@
     <ul
       class="no-bullet public-documents-list-item"
     >
-      {{#each @package.documents as |document|}}
+      {{#each (sort-by 'serverRelativeUrl' @package.documents) as |document|}}
         <li>
           <a
             href={{concat this.host '/document/package' document.serverRelativeUrl}}

--- a/client/ember-cli-build.js
+++ b/client/ember-cli-build.js
@@ -21,7 +21,7 @@ module.exports = function(defaults) {
       foundationJs: 'all',
     },
     'ember-composable-helpers': {
-      only: ['take', 'drop'],
+      only: ['take', 'drop', 'sort-by'],
     },
     hinting: IS_TEST, // Disable linting for all builds but test
     // tests: IS_TEST, // Don't even generate test files unless a test build


### PR DESCRIPTION
Please review commits after #1286 

Leverages the sort-by helper to alphabetize docs by their serverRelativeurl. Sorting by relative url is intended to capture some of the nested folder logic from in Sharepoint.