### PR TITLE
hotfix: add netlify.app to cors

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -23,7 +23,7 @@ function generateSSLConfiguration() {
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     cors: {
-      origin: [/\.planninglabs\.nyc$/, /\.planning\.nyc\.gov$/, 'http://localhost:4200', 'https://localhost:4200', /\.netlify\.com/, 'https://local.planninglabs.nyc:4200'],
+      origin: [/\.planninglabs\.nyc$/, /\.planning\.nyc\.gov$/, 'http://localhost:4200', 'https://localhost:4200', /\.netlify\.com/, 'https://local.planninglabs.nyc:4200', /\.netlify\.app/],
       credentials: true,
     },
 


### PR DESCRIPTION
Add netlify.app to cors so that community profiles test data url can pull from zap api