### PR TITLE
990 Use different helpscout beacon for LUPP routes

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -44,7 +44,5 @@
     <script src="{{rootURL}}assets/labs-zap-search.js"></script>
 
     {{content-for "body-footer"}}
-
-    <script type="text/javascript">!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});</script><script type="text/javascript">window.Beacon('init', '5782616e-c1ec-4db4-8365-1c83eb3e66a3')</script>
   </body>
 </html>

--- a/client/app/templates/application.hbs
+++ b/client/app/templates/application.hbs
@@ -56,3 +56,8 @@
 <div id="reveal-modal-container">
 </div>
 
+{{#if (string-includes currentRouteName "my-projects")}}
+  <script type="text/javascript">!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});</script><script type="text/javascript">window.Beacon('init', '9a027170-0976-46ac-afba-8d1322ef19d6')</script>
+{{else}}
+  <script type="text/javascript">!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});</script><script type="text/javascript">window.Beacon('init', '5782616e-c1ec-4db4-8365-1c83eb3e66a3')</script>
+{{/if}}


### PR DESCRIPTION
With this change, the LUP portion of the app will use a different Helpscout beacon id than other parts of the app (the public Search sections). The different helpscout beacons are toggled by inspecting the current route name.

Fixes [AB#990](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/990)