### PR TITLE
2804 Remove CPC Reports link from CPC Vote milestone

### DIFF
--- a/client/app/templates/components/project-milestone.hbs
+++ b/client/app/templates/components/project-milestone.hbs
@@ -64,9 +64,6 @@
       {{#if (eq milestone.dcpMilestone "9e3beec4-dad0-e711-8116-1458d04e2fb8")}}
         <li><a href="https://www1.nyc.gov/site/planning/about/commission-meetings.page" target="_blank">{{fa-icon "external-link-alt"}} CPC Public Meeting Calendar</a></li>
       {{/if}}
-      {{#if (eq milestone.dcpMilestone "a43beec4-dad0-e711-8116-1458d04e2fb8")}}
-        <li><a href="http://a030-cpc.nyc.gov/html/cpc/index.aspx" target="_blank">{{fa-icon "external-link-alt"}} CPC Reports</a></li>
-      {{/if}}
       {{#each milestone.milestoneLinks as |link|}}
         <li><a href="{{link.url}}" target="_blank">{{link.filename}}</a></li>
       {{/each}}


### PR DESCRIPTION
Fixes [AB#2804](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/2804)