### PR TITLE
2795 Add City Council Disposition as a hearing type for CPC Meeting

### DIFF
--- a/client/app/components/hearings-list-for-milestones-list.js
+++ b/client/app/components/hearings-list-for-milestones-list.js
@@ -52,12 +52,14 @@ export default class HearingsListForMilestonesListComponent extends Component {
     'Borough President Review': 'Borough President',
     'Borough Board Review': 'Borough Board',
     'Community Board Review': 'Community Board',
+    'City Planning Commission Review': 'City Council',
   }
 
   participantRecommendationLookup = {
     'Borough President': 'dcpBoroughpresidentrecommendation',
     'Borough Board': 'dcpBoroughboardrecommendation',
     'Community Board': 'dcpCommunityboardrecommendation',
+    'City Council': 'dcpCitycouncilvote',
   }
 
   // An array of disposition models that match the current milestone that is passed in

--- a/client/app/models/disposition.js
+++ b/client/app/models/disposition.js
@@ -97,6 +97,8 @@ export default class DispositionModel extends Model {
 
   @attr('number', { defaultValue: null }) dcpCommunityboardrecommendation;
 
+  @attr('number', { defaultValue: null }) dcpCitycouncilvote;
+
   // sourced from dcp_dcpConsideration
   // memo, exta information from participant
   @attr('string', { defaultValue: '' }) dcpConsideration;

--- a/server/src/project/project.service.ts
+++ b/server/src/project/project.service.ts
@@ -250,7 +250,7 @@ function generateQueryObject(query, overrides?) {
     "dcp_sisubdivision",
     "dcp_sischoolseat",
     "dcp_projectbrief",
-    'dcp_additionalpublicinformation',
+    "dcp_additionalpublicinformation",
     "dcp_projectname",
     "dcp_publicstatus",
     "dcp_projectcompleted",
@@ -386,7 +386,7 @@ export class ProjectService {
     // results in a silent failure.
     const EXPANSIONS = [
       `dcp_dcp_project_dcp_projectmilestone_project($filter=${MILESTONES_FILTER};$select=dcp_milestone,dcp_name,dcp_plannedstartdate,dcp_plannedcompletiondate,dcp_actualstartdate,dcp_actualenddate,statuscode,dcp_milestonesequence,dcp_remainingplanneddayscalculated,dcp_remainingplanneddays,dcp_goalduration,dcp_actualdurationasoftoday,_dcp_milestone_value,_dcp_milestoneoutcome_value,dcp_reviewmeetingdate)`,
-      "dcp_dcp_project_dcp_communityboarddisposition_project($select=dcp_publichearinglocation,dcp_dateofpublichearing,dcp_boroughpresidentrecommendation,dcp_boroughboardrecommendation,dcp_communityboardrecommendation,dcp_consideration,dcp_votelocation,dcp_datereceived,dcp_dateofvote,statecode,statuscode,dcp_docketdescription,dcp_votinginfavorrecommendation,dcp_votingagainstrecommendation,dcp_votingabstainingonrecommendation,dcp_totalmembersappointedtotheboard,dcp_wasaquorumpresent,_dcp_recommendationsubmittedby_value,dcp_representing,_dcp_projectaction_value)",
+      "dcp_dcp_project_dcp_communityboarddisposition_project($select=dcp_publichearinglocation,dcp_dateofpublichearing,dcp_boroughpresidentrecommendation,dcp_boroughboardrecommendation,dcp_citycouncilvote,dcp_communityboardrecommendation,dcp_consideration,dcp_votelocation,dcp_datereceived,dcp_dateofvote,statecode,statuscode,dcp_docketdescription,dcp_votinginfavorrecommendation,dcp_votingagainstrecommendation,dcp_votingabstainingonrecommendation,dcp_totalmembersappointedtotheboard,dcp_wasaquorumpresent,_dcp_recommendationsubmittedby_value,dcp_representing,_dcp_projectaction_value)",
       `dcp_dcp_project_dcp_projectaction_project($filter=${ACTIONS_FILTER};$select=_dcp_action_value,dcp_name,statuscode,statecode,dcp_ulurpnumber,_dcp_zoningresolution_value,dcp_ccresolutionnumber,dcp_spabsoluteurl)`,
       "dcp_dcp_project_dcp_projectbbl_project($select=dcp_bblnumber;$filter=statuscode eq 1 and dcp_validatedblock ne null)", // TODO: add filter to exclude inactives
       "dcp_dcp_project_dcp_projectkeywords_project($select=dcp_name,_dcp_keyword_value)",


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
<!---
Try to keep this more non-technical, and provide a wide angle, simple explanation of the problem and solution.
   - What was wrong?
   - What is the fix?
   - Why?
     - What is the purpose?
     - How is it better?
   - Screenshots of the affected areas in the frontend are really nice!
-->
It wasn't displaying public hearing information for City Planning Commission Review milestones. This change maps the City Planning Commission Review milestone to the dispositions time, "City Council". Unclear if this is the correct mapping, but easy enough to change. 

<img width="353" alt="image" src="https://user-images.githubusercontent.com/5004319/119918540-a73f1300-bf36-11eb-8773-b20984726dc8.png">


#### Tasks/Bug Numbers
 - Fixes [AB#2795](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/2795)

### Technical Explanation
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 

Nothing was "wrong" exactly, this is a new feature. The fix here maps the City Planning Commission Review milestone to the City Council disposition. This change maps those together so it displays in the project profile.

**List any ad-hoc, miscellaneous updates included**

Adds to the select of the query dcp_citycouncilvote.

### Any other info you think would help a reviewer understand this PR?
