### PR TITLE
2805 only show outcomes for started/in-progress

### DIFF
--- a/client/app/templates/components/project-milestone.hbs
+++ b/client/app/templates/components/project-milestone.hbs
@@ -183,30 +183,30 @@
         {{/if}}
       {{/each}}
     {{/hearings-list-for-milestones-list}}
-  {{/if}}
 
-  {{#if (and
-    milestone.isCPCPublicMeetingPublicHearing
-    (is-same-or-after milestone.dcpReviewmeetingdate)
-  )}}
-    <ul class="sub-milestones no-bullet">
-      <li class="grid-x small-margin-bottom">
-        <div class="cell shrink small-margin-right">
-          {{!-- This is always "calendar" icon, because for this milestone, it should always have happened in the past --}}
-          {{fa-icon icon='calendar' fixedWidth=true class='light-gray'}}
-        </div>
-        <div class="cell auto">
-          {{milestones/public-hearing
-            hearing=(hash
-              disposition=(hash
-                dcpDateofpublichearing=milestone.dcpReviewmeetingdate
+    {{#if (and
+      milestone.isCPCPublicMeetingPublicHearing
+      (is-same-or-after milestone.dcpReviewmeetingdate)
+    )}}
+      <ul class="sub-milestones no-bullet">
+        <li class="grid-x small-margin-bottom">
+          <div class="cell shrink small-margin-right">
+            {{!-- This is always "calendar" icon, because for this milestone, it should always have happened in the past --}}
+            {{fa-icon icon='calendar' fixedWidth=true class='light-gray'}}
+          </div>
+          <div class="cell auto">
+            {{milestones/public-hearing
+              hearing=(hash
+                disposition=(hash
+                  dcpDateofpublichearing=milestone.dcpReviewmeetingdate
+                )
+                hearingActions=milestone.project.actions
               )
-              hearingActions=milestone.project.actions
-            )
-          }}
-        </div>
-      </li>
-    </ul>
+            }}
+          </div>
+        </li>
+      </ul>
+    {{/if}}
   {{/if}}
 </div>
 


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
<!---
Try to keep this more non-technical, and provide a wide angle, simple explanation of the problem and solution.
   - What was wrong?
   - What is the fix?
   - Why?
     - What is the purpose?
     - How is it better?
   - Screenshots of the affected areas in the frontend are really nice!
-->

CPC meetings could theoretically be shown even if that milestone was "not started." This moves it into a conditional block that only shows it if it's in progress/completed. 

#### Tasks/Bug Numbers
 - Fixes [AB#2805](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/2805)


