### PR TITLE
931: Radius filter quick fix

### DIFF
--- a/server/src/project/project.service.ts
+++ b/server/src/project/project.service.ts
@@ -189,7 +189,11 @@ const QUERY_TEMPLATES = {
           childEntity: "dcp_dcp_project_dcp_projectaction_project"
         }
       )
-    )
+    ),
+  blocks_in_radius: queryParamValue =>
+    containsAnyOf("dcp_validatedblock", queryParamValue, {
+      childEntity: "dcp_dcp_project_dcp_projectbbl_project"
+    })
 };
 
 export const ALLOWED_FILTERS = [
@@ -224,7 +228,6 @@ function generateProjectsFilterString(query) {
   // optional params
   // apply only those that appear in the query object
   const requestedFiltersQuery = generateFromTemplate(query, QUERY_TEMPLATES);
-
   return all(
     // defaults
     comparisonOperator(
@@ -522,12 +525,11 @@ export class ProjectService {
 
     const [x, y] = distance_from_point;
 
-    const blocks = await this.geometryService.getBlocksFromRadiusQuery(
+    return await this.geometryService.getBlocksFromRadiusQuery(
       x,
       y,
       radius_from_point
     );
-    return { blocks };
   }
 
   async queryProjects(query, itemsPerPage = ITEMS_PER_PAGE) {
@@ -536,10 +538,7 @@ export class ProjectService {
     // adds in the blocks filter for use across various query types
     const normalizedQuery = {
       ...query,
-
-      // this information is sent as separate filters but must be represented as one
-      // to work correctly with the query template system.
-      ...blocks
+      blocks_in_radius: blocks
     };
 
     const queryObject = generateQueryObject(normalizedQuery);


### PR DESCRIPTION
### Summary
Radius filter appears on the map, but does not actually filter the results in the list view

#### Tasks/Bug Numbers
 - Fixes https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/931

### Technical Explanation
The radius + point from client were used to look up blocks within the radius that _could_ be used to filter the results, but were never used. They were being added to the query as "blocks" prop, but there was no corresponding "blocks" query in the query map. Now, they're added to the query as more clearly named "blocks_in_radius", and a corresponding "blocks_in_radius" query was added to the filter QUERY_TEMPLATE map. Thus the filtering of point/radius is now applied to the projects query.

### Any other info you think would help a reviewer understand this PR?
I have a more extensive re-write of the projects service/filter situation, but I'm not sure how best to validate it. A) because I'm just overall not sure how this team goes about extensive validation of this app, and B) because currently on develop the projects query is failing due to a 400 response from the CRM. It's possible this is a configuration issue or something on my local dev set up, but app at top of develop was working on my local last week. Seeking input! 