### PR TITLE
2793 group milestones

### DIFF
--- a/client/app/components/project-milestone.js
+++ b/client/app/components/project-milestone.js
@@ -13,10 +13,6 @@ export default class ProjectMilestoneComponent extends Component {
   get getClassNames() {
     let style = '';
 
-    if (this.milestone.statuscode === 'Not Started') style = 'gray';
-
-    if (this.milestone.statuscode === 'In Progress') style = 'green-glow';
-
     return `grid-x grid-padding-small milestone ${style}`;
   }
 }

--- a/client/app/components/project-milestone.js
+++ b/client/app/components/project-milestone.js
@@ -11,7 +11,7 @@ export default class ProjectMilestoneComponent extends Component {
 
   @computed('milestone.statuscode')
   get getClassNames() {
-    let style = '';
+    const style = '';
 
     return `grid-x grid-padding-small milestone ${style}`;
   }

--- a/client/app/components/show-project/milestone-list.js
+++ b/client/app/components/show-project/milestone-list.js
@@ -1,0 +1,12 @@
+import Component from '@ember/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+
+export default class MilestoneListComponent extends Component {
+  @tracked showMilestoneList = true;
+
+  @action
+  toggleShowMilestoneList() {
+    this.showMilestoneList = !this.showMilestoneList;
+  }
+}

--- a/client/app/models/milestone.js
+++ b/client/app/models/milestone.js
@@ -106,9 +106,12 @@ export default class MilestoneModel extends Model {
   // In list of milestones with same displayName,
   // each milestone AFTER the first will have `Revised` before the name (isRevised === true)
   // milestones are already sorted in the backend by date
-  @computed()
+  @computed('project.sortedFilteredMilestones', 'id', 'displayName')
   get isRevised() {
-    return false;
+    const projectMilestones = this.get('project.sortedFilteredMilestones');
+    const sameNameMilestones = projectMilestones.filter(m => m.displayName === this.displayName);
+    // check if the current milestone id matches the first in the list
+    return this.id !== sameNameMilestones.firstObject.id;
   }
 
   // New milestone name based on isRevised

--- a/client/app/models/milestone.js
+++ b/client/app/models/milestone.js
@@ -106,12 +106,9 @@ export default class MilestoneModel extends Model {
   // In list of milestones with same displayName,
   // each milestone AFTER the first will have `Revised` before the name (isRevised === true)
   // milestones are already sorted in the backend by date
-  @computed('project.sortedMilestones', 'id', 'displayName')
+  @computed()
   get isRevised() {
-    const projectMilestones = this.get('project.sortedMilestones');
-    const currentMilestoneList = projectMilestones.filter(m => m.displayName === this.displayName);
-    // check if the current milestone id matches the first in the list
-    return this.id !== currentMilestoneList.firstObject.id;
+    return false;
   }
 
   // New milestone name based on isRevised

--- a/client/app/models/milestone/constants.js
+++ b/client/app/models/milestone/constants.js
@@ -121,13 +121,13 @@ export const REFERRAL_MILESTONEID_BY_ACRONYM_LOOKUP = {
 export const STATUSCODE_OPTIONSET = {
   COMPLETED: {
     code: 2,
-    label: "Completed"
+    label: 'Completed',
   },
   IN_PROGRESS: {
     code: 717170000,
-    label: "In Progress",
+    label: 'In Progress',
   },
   NOT_STARTED: {
-    label: "Not Started"
-  }
+    label: 'Not Started',
+  },
 };

--- a/client/app/models/milestone/constants.js
+++ b/client/app/models/milestone/constants.js
@@ -119,6 +119,15 @@ export const REFERRAL_MILESTONEID_BY_ACRONYM_LOOKUP = {
 };
 
 export const STATUSCODE_OPTIONSET = {
-  COMPLETED: 2,
-  IN_PROGRESS: 717170000,
+  COMPLETED: {
+    code: 2,
+    label: "Completed"
+  },
+  IN_PROGRESS: {
+    code: 717170000,
+    label: "In Progress",
+  },
+  NOT_STARTED: {
+    label: "Not Started"
+  }
 };

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -2,6 +2,9 @@ import DS from 'ember-data';
 import { computed } from '@ember/object';
 import { sort, alias } from '@ember/object/computed';
 import { PREPARE_FILED_EAS } from './milestone/constants';
+import {
+  STATUSCODE_OPTIONSET,
+} from './milestone/constants';
 
 const {
   Model, attr, hasMany,
@@ -134,18 +137,67 @@ export default class ProjectModel extends Model {
       .filter(pMilestone => pMilestone.dcpMilestone !== PREPARE_FILED_EAS);
   }
 
-  @sort('filteredMilestones', function(prev, next) {
-    const milestoneSequenceDifference = prev.dcpMilestonesequence - next.dcpMilestonesequence;
+  @computed('filteredMilestones')
+  get completedMilestones() {
+    return this.get('filteredMilestones')
+      .filter(pMilestone => pMilestone.statuscode === STATUSCODE_OPTIONSET.COMPLETED.label);
+  }
 
-    if (milestoneSequenceDifference === 0) {
-      if (!prev.displayDate) return 1;
+  @computed('filteredMilestones')
+  get inProgressMilestones() {
+    return this.get('milestones')
+    .filter(pMilestone => pMilestone.statuscode === STATUSCODE_OPTIONSET.IN_PROGRESS.label);
+  }
 
-      if (!next.displayDate) return -1;
+  @computed('filteredMilestones')
+  get notStartedMilestones() {
+    return this.get('milestones')
+    .filter(pMilestone => (pMilestone.statuscode !== STATUSCODE_OPTIONSET.COMPLETED.label && pMilestone.statuscode !== STATUSCODE_OPTIONSET.IN_PROGRESS.label));
+  }
 
-      return prev.displayDate - next.displayDate;
-    }
+  // @sort('filteredMilestones', function(prev, next) {
+  //   const milestoneSequenceDifference = prev.dcpMilestonesequence - next.dcpMilestonesequence;
 
-    return milestoneSequenceDifference;
-  })
-  sortedMilestones;
+  //   if (milestoneSequenceDifference === 0) {
+  //     if (!prev.displayDate) return 1;
+
+  //     if (!next.displayDate) return -1;
+
+  //     return prev.displayDate - next.displayDate;
+  //   }
+
+  //   return milestoneSequenceDifference;
+  // })
+  // sortedCompletedMilestones;
+
+  // @sort('filteredMilestones', function(prev, next) {
+  //   const milestoneSequenceDifference = prev.dcpMilestonesequence - next.dcpMilestonesequence;
+
+  //   if (milestoneSequenceDifference === 0) {
+  //     if (!prev.displayDate) return 1;
+
+  //     if (!next.displayDate) return -1;
+
+  //     return prev.displayDate - next.displayDate;
+  //   }
+
+  //   return milestoneSequenceDifference;
+  // })
+  // sortedInProgressMilestones;
+
+  // @sort('filteredMilestones', function(prev, next) {
+  //   const milestoneSequenceDifference = prev.dcpMilestonesequence - next.dcpMilestonesequence;
+
+  //   if (milestoneSequenceDifference === 0) {
+  //     if (!prev.displayDate) return 1;
+
+  //     if (!next.displayDate) return -1;
+
+  //     return prev.displayDate - next.displayDate;
+  //   }
+
+  //   return milestoneSequenceDifference;
+  // })
+  // sortedNotStartedMilestones;
+
 }

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -22,6 +22,9 @@ const EmptyFeatureCollection = {
 };
 
 const milestoneDateCompare = function(prev, next) {
+  if (prev.dcpActualstartdate && !next.dcpActualstartdate) return -1;
+  if (!prev.dcpActualstartdate && next.dcpActualstartdate) return 1;
+
   const prevMilestoneDate = new Date(prev.dcpActualstartdate);
   const nextMilestoneDate = new Date(next.dcpActualstartdate);
 
@@ -159,7 +162,7 @@ export default class ProjectModel extends Model {
   @computed('filteredMilestones')
   get notStartedMilestones() {
     return this.get('milestones')
-    .filter(pMilestone => (pMilestone.statuscode !== STATUSCODE_OPTIONSET.COMPLETED.label && pMilestone.statuscode !== STATUSCODE_OPTIONSET.IN_PROGRESS.label));
+    .filter(pMilestone => ((pMilestone.statuscode !== STATUSCODE_OPTIONSET.COMPLETED.label) && (pMilestone.statuscode !== STATUSCODE_OPTIONSET.IN_PROGRESS.label)));
   }
 
   @sort('completedMilestones', milestoneDateCompare)
@@ -171,4 +174,6 @@ export default class ProjectModel extends Model {
   @sort('filteredMilestones', milestoneDateCompare)
   sortedNotStartedMilestones;
 
+  @sort('filteredMilestones', milestoneDateCompare)
+  sortedFilteredMilestones;
 }

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -1,10 +1,11 @@
 import DS from 'ember-data';
 import { computed } from '@ember/object';
 import { sort, alias } from '@ember/object/computed';
-import { PREPARE_FILED_EAS } from './milestone/constants';
 import {
+  PREPARE_FILED_EAS,
   STATUSCODE_OPTIONSET,
 } from './milestone/constants';
+
 
 const {
   Model, attr, hasMany,
@@ -29,7 +30,7 @@ const milestoneDateCompare = function(prev, next) {
   const nextMilestoneDate = new Date(next.dcpActualstartdate);
 
   return prevMilestoneDate.getTime() - nextMilestoneDate.getTime();
-}
+};
 
 export default class ProjectModel extends Model {
   @hasMany('action', { async: false }) actions;
@@ -156,13 +157,13 @@ export default class ProjectModel extends Model {
   @computed('filteredMilestones')
   get inProgressMilestones() {
     return this.get('milestones')
-    .filter(pMilestone => pMilestone.statuscode === STATUSCODE_OPTIONSET.IN_PROGRESS.label);
+      .filter(pMilestone => pMilestone.statuscode === STATUSCODE_OPTIONSET.IN_PROGRESS.label);
   }
 
   @computed('filteredMilestones')
   get notStartedMilestones() {
     return this.get('milestones')
-    .filter(pMilestone => ((pMilestone.statuscode !== STATUSCODE_OPTIONSET.COMPLETED.label) && (pMilestone.statuscode !== STATUSCODE_OPTIONSET.IN_PROGRESS.label)));
+      .filter(pMilestone => ((pMilestone.statuscode !== STATUSCODE_OPTIONSET.COMPLETED.label) && (pMilestone.statuscode !== STATUSCODE_OPTIONSET.IN_PROGRESS.label)));
   }
 
   @sort('completedMilestones', milestoneDateCompare)

--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -21,6 +21,13 @@ const EmptyFeatureCollection = {
   }],
 };
 
+const milestoneDateCompare = function(prev, next) {
+  const prevMilestoneDate = new Date(prev.dcpActualstartdate);
+  const nextMilestoneDate = new Date(next.dcpActualstartdate);
+
+  return prevMilestoneDate.getTime() - nextMilestoneDate.getTime();
+}
+
 export default class ProjectModel extends Model {
   @hasMany('action', { async: false }) actions;
 
@@ -155,49 +162,13 @@ export default class ProjectModel extends Model {
     .filter(pMilestone => (pMilestone.statuscode !== STATUSCODE_OPTIONSET.COMPLETED.label && pMilestone.statuscode !== STATUSCODE_OPTIONSET.IN_PROGRESS.label));
   }
 
-  // @sort('filteredMilestones', function(prev, next) {
-  //   const milestoneSequenceDifference = prev.dcpMilestonesequence - next.dcpMilestonesequence;
+  @sort('completedMilestones', milestoneDateCompare)
+  sortedCompletedMilestones;
 
-  //   if (milestoneSequenceDifference === 0) {
-  //     if (!prev.displayDate) return 1;
+  @sort('inProgressMilestones', milestoneDateCompare)
+  sortedInProgressMilestones;
 
-  //     if (!next.displayDate) return -1;
-
-  //     return prev.displayDate - next.displayDate;
-  //   }
-
-  //   return milestoneSequenceDifference;
-  // })
-  // sortedCompletedMilestones;
-
-  // @sort('filteredMilestones', function(prev, next) {
-  //   const milestoneSequenceDifference = prev.dcpMilestonesequence - next.dcpMilestonesequence;
-
-  //   if (milestoneSequenceDifference === 0) {
-  //     if (!prev.displayDate) return 1;
-
-  //     if (!next.displayDate) return -1;
-
-  //     return prev.displayDate - next.displayDate;
-  //   }
-
-  //   return milestoneSequenceDifference;
-  // })
-  // sortedInProgressMilestones;
-
-  // @sort('filteredMilestones', function(prev, next) {
-  //   const milestoneSequenceDifference = prev.dcpMilestonesequence - next.dcpMilestonesequence;
-
-  //   if (milestoneSequenceDifference === 0) {
-  //     if (!prev.displayDate) return 1;
-
-  //     if (!next.displayDate) return -1;
-
-  //     return prev.displayDate - next.displayDate;
-  //   }
-
-  //   return milestoneSequenceDifference;
-  // })
-  // sortedNotStartedMilestones;
+  @sort('filteredMilestones', milestoneDateCompare)
+  sortedNotStartedMilestones;
 
 }

--- a/client/app/styles/modules/_m-actions-milestones.scss
+++ b/client/app/styles/modules/_m-actions-milestones.scss
@@ -13,11 +13,13 @@
 .milestone-header {
   position: relative;
   box-shadow: inset rem-calc(28) 0 0 $body-background, inset rem-calc(30) 0 0 rgba(0,0,0,0);
+  cursor: pointer;
 }
 
 .milestone {
   position: relative;
   box-shadow: inset rem-calc(28) 0 0 $body-background, inset rem-calc(30) 0 0 $medium-gray;
+  margin-left: 7px;
 
   &.green-glow {
     background-color: $white;

--- a/client/app/styles/modules/_m-actions-milestones.scss
+++ b/client/app/styles/modules/_m-actions-milestones.scss
@@ -10,6 +10,11 @@
 
 }
 
+.milestone-header {
+  position: relative;
+  box-shadow: inset rem-calc(28) 0 0 $body-background, inset rem-calc(30) 0 0 rgba(0,0,0,0);
+}
+
 .milestone {
   position: relative;
   box-shadow: inset rem-calc(28) 0 0 $body-background, inset rem-calc(30) 0 0 $medium-gray;

--- a/client/app/templates/components/project-milestone.hbs
+++ b/client/app/templates/components/project-milestone.hbs
@@ -3,7 +3,7 @@
   </span>
 </div>
 
-<div class="cell auto {{if (eq milestone.statuscode "Not Started") 'gray'}}">
+<div class="cell auto">
   <h4 class="no-margin">
     <span data-test-milestone-name="{{milestone.id}}">
       {{milestone.orderSensitiveName}}

--- a/client/app/templates/components/project-milestone.hbs
+++ b/client/app/templates/components/project-milestone.hbs
@@ -1,20 +1,6 @@
 <div class="cell shrink">
-  {{#if (eq milestone.statuscode "Completed")}}
-    <span class="milestone-icon fa-layers fa-fw">
-      {{fa-icon icon='circle' fixedWidth=true class='dark-gray'}}
-      {{fa-icon icon='check' fixedWidth=true class='blue-light' transform='shrink-6'}}
-    </span>
-  {{else if (eq milestone.statuscode "In Progress")}}
-    <span class="milestone-icon fa-layers fa-fw">
-      {{fa-icon icon='circle' fixedWidth=true class='green-dark'}}
-      {{fa-icon icon='calendar' prefix='far' fixedWidth=true class='white-smoke' transform='shrink-8'}}
-    </span>
-  {{else}}{{!-- milestone.statuscode "Not Started" --}}
-    <span class="milestone-icon fa-layers fa-fw">
-      {{fa-icon icon='circle' fixedWidth=true class='light-gray'}}
-      {{fa-icon icon='calendar' prefix='far' fixedWidth=true class='off-white' transform='shrink-8'}}
-    </span>
-  {{/if}}
+  <span class="milestone-icon fa-layers fa-fw">
+  </span>
 </div>
 
 <div class="cell auto {{if (eq milestone.statuscode "Not Started") 'gray'}}">

--- a/client/app/templates/components/show-project/milestone-list.hbs
+++ b/client/app/templates/components/show-project/milestone-list.hbs
@@ -1,0 +1,36 @@
+<ul class="no-bullet milestones-list">
+  <li class="grid-x grid-padding-small milestone-header"
+    onClick={{this.toggleShowMilestoneList}}
+  >
+    <div class="cell shrink">
+      <FaIcon
+        @icon={{if this.showMilestoneList "caret-down" "caret-right"}}
+        style="margin-left: -10px; margin-top: 10px"
+      />
+    </div>
+    <div class="cell shrink">
+      <span class="milestone-icon fa-layers fa-fw">
+        {{yield}}
+      </span>
+    </div>
+    <div class="cell auto">
+      <h4
+        class="no-margin"
+      >
+        <span>
+          {{@listName}}
+        </span>
+      </h4>
+    </div>
+  </li>
+
+  {{#if this.showMilestoneList}}
+    {{#if @milestones}}
+      {{#each @milestones as | milestone |}}
+        {{project-milestone milestone=milestone}}
+      {{/each}}
+    {{else}}
+      No Milestones
+    {{/if}}
+  {{/if}}
+</ul>

--- a/client/app/templates/show-project.hbs
+++ b/client/app/templates/show-project.hbs
@@ -116,7 +116,7 @@
           </div>
           <div class="cell medium-6">
             <ul class="no-bullet milestones-list">
-              <li class="grid-x grid-padding-small milestone">
+              <li class="grid-x grid-padding-small milestone-header">
                 <div class="cell shrink">
                   <span class="milestone-icon fa-layers fa-fw">
                     {{fa-icon icon='circle' fixedWidth=true class='green-dark'}}
@@ -141,7 +141,7 @@
               {{/if}}
             </ul>
             <ul class="no-bullet milestones-list">
-              <li class="grid-x grid-padding-small milestone">
+              <li class="grid-x grid-padding-small milestone-header">
                 <div class="cell shrink">
                   <span class="milestone-icon fa-layers fa-fw">
                     {{fa-icon icon='circle' fixedWidth=true class='gold'}}
@@ -166,7 +166,7 @@
               {{/if}}
             </ul>
             <ul class="no-bullet milestones-list">
-              <li class="grid-x grid-padding-small milestone">
+              <li class="grid-x grid-padding-small milestone-header">
                 <div class="cell shrink">
                   <span class="milestone-icon fa-layers fa-fw">
                     {{fa-icon icon='circle' fixedWidth=true class='blue'}}

--- a/client/app/templates/show-project.hbs
+++ b/client/app/templates/show-project.hbs
@@ -115,10 +115,75 @@
             />
           </div>
           <div class="cell medium-6">
-            <h2>Milestones</h2>
             <ul class="no-bullet milestones-list">
-              {{#if model.sortedMilestones}}
-                {{#each model.sortedMilestones as | milestone |}}
+              <li class="grid-x grid-padding-small milestone">
+                <div class="cell shrink">
+                  <span class="milestone-icon fa-layers fa-fw">
+                    {{fa-icon icon='circle' fixedWidth=true class='green-dark'}}
+                    {{fa-icon icon='check' fixedWidth=true class='white-smoke' transform='shrink-6'}}
+                  </span>
+                </div>
+                <div class="cell auto">
+                  <h4 class="no-margin">
+                    <span>
+                      Completed
+                    </span>
+                  </h4>
+                </div>
+              </li>
+
+              {{#if model.completedMilestones}}
+                {{#each model.completedMilestones as | milestone |}}
+                  {{project-milestone milestone=milestone}}
+                {{/each}}
+              {{else}}
+                No Milestones
+              {{/if}}
+            </ul>
+            <ul class="no-bullet milestones-list">
+              <li class="grid-x grid-padding-small milestone">
+                <div class="cell shrink">
+                  <span class="milestone-icon fa-layers fa-fw">
+                    {{fa-icon icon='circle' fixedWidth=true class='gold'}}
+                    {{fa-icon icon='lightbulb' prefix='far' fixedWidth=true class='white-smoke' transform='shrink-8'}}
+                  </span>
+                </div>
+                <div class="cell auto">
+                  <h4 class="no-margin">
+                    <span>
+                      Completed
+                    </span>
+                  </h4>
+                </div>
+              </li>
+
+              {{#if model.inProgressMilestones}}
+                {{#each model.inProgressMilestones as | milestone |}}
+                  {{project-milestone milestone=milestone}}
+                {{/each}}
+              {{else}}
+                No Milestones
+              {{/if}}
+            </ul>
+            <ul class="no-bullet milestones-list">
+              <li class="grid-x grid-padding-small milestone">
+                <div class="cell shrink">
+                  <span class="milestone-icon fa-layers fa-fw">
+                    {{fa-icon icon='circle' fixedWidth=true class='blue'}}
+                    {{fa-icon icon='calendar' prefix='far' fixedWidth=true class='off-white' transform='shrink-8'}}
+                  </span>
+                </div>
+                <div class="cell auto">
+                  <h4 class="no-margin">
+                    <span>
+                      Completed
+                    </span>
+                  </h4>
+                </div>
+              </li>
+
+              {{#if model.notStartedMilestones}}
+                {{#each model.notStartedMilestones as | milestone |}}
                   {{project-milestone milestone=milestone}}
                 {{/each}}
               {{else}}

--- a/client/app/templates/show-project.hbs
+++ b/client/app/templates/show-project.hbs
@@ -115,81 +115,29 @@
             />
           </div>
           <div class="cell medium-6">
-            <ul class="no-bullet milestones-list">
-              <li class="grid-x grid-padding-small milestone-header">
-                <div class="cell shrink">
-                  <span class="milestone-icon fa-layers fa-fw">
-                    {{fa-icon icon='circle' fixedWidth=true class='green-dark'}}
-                    {{fa-icon icon='check' fixedWidth=true class='white-smoke' transform='shrink-6'}}
-                  </span>
-                </div>
-                <div class="cell auto">
-                  <h4 class="no-margin">
-                    <span>
-                      Completed
-                    </span>
-                  </h4>
-                </div>
-              </li>
+            <ShowProject::MilestoneList
+              @milestones={{model.sortedCompletedMilestones}}
+              @listName="Completed"
+            >
+              {{fa-icon icon='circle' fixedWidth=true class='green-dark'}}
+              {{fa-icon icon='check' fixedWidth=true class='white-smoke' transform='shrink-6'}}
+            </ShowProject::MilestoneList>
 
-              {{#if model.sortedCompletedMilestones}}
-                {{#each model.sortedCompletedMilestones as | milestone |}}
-                  {{project-milestone milestone=milestone}}
-                {{/each}}
-              {{else}}
-                No Milestones
-              {{/if}}
-            </ul>
-            <ul class="no-bullet milestones-list">
-              <li class="grid-x grid-padding-small milestone-header">
-                <div class="cell shrink">
-                  <span class="milestone-icon fa-layers fa-fw">
-                    {{fa-icon icon='circle' fixedWidth=true class='gold'}}
-                    {{fa-icon icon='lightbulb' prefix='far' fixedWidth=true class='white-smoke' transform='shrink-8'}}
-                  </span>
-                </div>
-                <div class="cell auto">
-                  <h4 class="no-margin">
-                    <span>
-                      In Progress
-                    </span>
-                  </h4>
-                </div>
-              </li>
+            <ShowProject::MilestoneList
+              @milestones={{model.sortedInProgressMilestones}}
+              @listName="In Progress"
+            >
+              {{fa-icon icon='circle' fixedWidth=true class='gold'}}
+              {{fa-icon icon='lightbulb' prefix='far' fixedWidth=true class='white-smoke' transform='shrink-8'}}
+            </ShowProject::MilestoneList>
 
-              {{#if model.sortedInProgressMilestones}}
-                {{#each model.sortedInProgressMilestones as | milestone |}}
-                  {{project-milestone milestone=milestone}}
-                {{/each}}
-              {{else}}
-                No Milestones
-              {{/if}}
-            </ul>
-            <ul class="no-bullet milestones-list">
-              <li class="grid-x grid-padding-small milestone-header">
-                <div class="cell shrink">
-                  <span class="milestone-icon fa-layers fa-fw">
-                    {{fa-icon icon='circle' fixedWidth=true class='blue'}}
-                    {{fa-icon icon='calendar' prefix='far' fixedWidth=true class='off-white' transform='shrink-8'}}
-                  </span>
-                </div>
-                <div class="cell auto">
-                  <h4 class="no-margin">
-                    <span>
-                      Not Started
-                    </span>
-                  </h4>
-                </div>
-              </li>
-
-              {{#if model.sortedNotStartedMilestones}}
-                {{#each model.sortedNotStartedMilestones as | milestone |}}
-                  {{project-milestone milestone=milestone}}
-                {{/each}}
-              {{else}}
-                No Milestones
-              {{/if}}
-            </ul>
+            <ShowProject::MilestoneList
+              @milestones={{model.sortedNotStartedMilestones}}
+              @listName="Not Started"
+            >
+              {{fa-icon icon='circle' fixedWidth=true class='blue'}}
+              {{fa-icon icon='calendar' prefix='far' fixedWidth=true class='off-white' transform='shrink-8'}}
+            </ShowProject::MilestoneList>
           </div>
         </div>
 

--- a/client/app/templates/show-project.hbs
+++ b/client/app/templates/show-project.hbs
@@ -132,8 +132,8 @@
                 </div>
               </li>
 
-              {{#if model.completedMilestones}}
-                {{#each model.completedMilestones as | milestone |}}
+              {{#if model.sortedCompletedMilestones}}
+                {{#each model.sortedCompletedMilestones as | milestone |}}
                   {{project-milestone milestone=milestone}}
                 {{/each}}
               {{else}}
@@ -151,14 +151,14 @@
                 <div class="cell auto">
                   <h4 class="no-margin">
                     <span>
-                      Completed
+                      In Progress
                     </span>
                   </h4>
                 </div>
               </li>
 
-              {{#if model.inProgressMilestones}}
-                {{#each model.inProgressMilestones as | milestone |}}
+              {{#if model.sortedInProgressMilestones}}
+                {{#each model.sortedInProgressMilestones as | milestone |}}
                   {{project-milestone milestone=milestone}}
                 {{/each}}
               {{else}}
@@ -176,14 +176,14 @@
                 <div class="cell auto">
                   <h4 class="no-margin">
                     <span>
-                      Completed
+                      Not Started
                     </span>
                   </h4>
                 </div>
               </li>
 
-              {{#if model.notStartedMilestones}}
-                {{#each model.notStartedMilestones as | milestone |}}
+              {{#if model.sortedNotStartedMilestones}}
+                {{#each model.sortedNotStartedMilestones as | milestone |}}
                   {{project-milestone milestone=milestone}}
                 {{/each}}
               {{else}}

--- a/client/ember-cli-build.js
+++ b/client/ember-cli-build.js
@@ -44,7 +44,7 @@ module.exports = function(defaults) {
           },
         ],
       },
-    }
+    },
   });
 
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
Fixes AB#1348

Ticket required us to group milestones into three categories based on milestone statuscode: Completed, In Progress, Not Started.

Also it required discarding statuscode based styling of milestones.

I made  a component representing each collapsible list. See show-project/milestone-list.

Milestone sorting also is now based on dcpActualstartdate, instead of dcpMilestonesequence.

This also required updating milestone.isRevised to depend on the new date-sorted milestone list. 