### PR TITLE
3414 fix dispo statuscode and statecode

### DIFF
--- a/client/app/models/disposition.js
+++ b/client/app/models/disposition.js
@@ -121,50 +121,9 @@ export default class DispositionModel extends Model {
 
   @attr('string', { defaultValue: '' }) dcpBoroughpresidentrecommendation;
 
-  // sourced from statuscode
-  // Label: 'Draft', 'Value': 1
-  // Label: 'Saved', 'Value': 717170000
-  // Label: 'Submitted', 'Value': 2
-  // Label: 'Deactivated', 'Value': 717170001
-  // Label: 'Not Submitted', 'Value': 717170002
-  @attrComputed(
-    // recommendations
-    'dcpDateofvote',
-    'dcpBoroughpresidentrecommendation',
-    'dcpBoroughboardrecommendation',
-    'dcpCommunityboardrecommendation',
-    'dcpIspublichearingrequired',
+  @attr('string', { defaultValue: '' }) statuscode;
 
-    // hearings
-    'dcpPublichearinglocation',
-    'dcpDateofpublichearing',
-  )
-  get statuscode() {
-    if (this.dcpBoroughpresidentrecommendation !== null
-      || this.dcpBoroughboardrecommendation !== null
-      || this.dcpCommunityboardrecommendation !== null
-    ) return STATUSCODES.findBy('Label', 'Submitted').Value;
-
-    if (
-      this.dcpIspublichearingrequired !== null
-    ) return STATUSCODES.findBy('Label', 'Saved').Value;
-
-    if (this.dcpPublichearinglocation
-      || this.dcpDateofpublichearing
-    ) return STATUSCODES.findBy('Label', 'Saved').Value;
-
-    return STATUSCODES.findBy('Label', 'Draft').Value;
-  }
-
-  @attrComputed('statuscode')
-  get statecode() {
-    if (
-      STATUSCODES.findBy('Value', this.statuscode).Label === 'Saved'
-      || STATUSCODES.findBy('Value', this.statuscode).Label === 'Draft'
-    ) return STATECODES.findBy('Label', 'Active').Value;
-
-    return STATECODES.findBy('Label', 'Inactive').Value;
-  }
+  @attr('string', { defaultValue: '' }) statecode;
 
   // sourced from dcp_docketdescription
   @attr('string') dcpDocketdescription;

--- a/client/tests/unit/models/disposition-test.js
+++ b/client/tests/unit/models/disposition-test.js
@@ -1,7 +1,5 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
-import { STATUSCODES, STATECODES } from 'labs-zap-search/models/disposition';
-import { RECOMMENDATION_OPTIONSET_BY_PARTICIPANT_TYPE_LOOKUP } from 'labs-zap-search/controllers/my-projects/assignment/recommendations/add';
 
 module('Unit | Model | disposition', function(hooks) {
   setupTest(hooks);
@@ -12,62 +10,6 @@ module('Unit | Model | disposition', function(hooks) {
     const model = store.createRecord('disposition', {});
 
     assert.ok(model);
-  });
-
-  test('when participant opts out/submits, statuscode becomes "saved"/"submitted"', async function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = store.createRecord('disposition', {
-      dcpBoroughpresidentrecommendation: null,
-      dcpBoroughboardrecommendation: null,
-      dcpCommunityboardrecommendation: null,
-      dcpIspublichearingrequired: null,
-    });
-
-    assert.equal(model.statuscode, STATUSCODES.findBy('Label', 'Draft').Value);
-
-    model.setProperties({
-      dcpIspublichearingrequired: 'No',
-    });
-
-    assert.equal(model.statuscode, STATUSCODES.findBy('Label', 'Saved').Value);
-
-    model.setProperties({
-      dcpBoroughboardrecommendation: RECOMMENDATION_OPTIONSET_BY_PARTICIPANT_TYPE_LOOKUP.BB.findBy('label', 'Favorable').code,
-      dcpIspublichearingrequired: 'No',
-    });
-
-    assert.equal(model.statuscode, STATUSCODES.findBy('Label', 'Submitted').Value);
-  });
-
-  test('when statuscode is draft or saved, statecode is "active"', async function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = store.createRecord('disposition', {
-      dcpPublichearinglocation: 'foo',
-      dcpDateofpublichearing: 'bar',
-
-      dcpBoroughpresidentrecommendation: null,
-      dcpBoroughboardrecommendation: null,
-      dcpCommunityboardrecommendation: null,
-      dcpIspublichearingrequired: 'No',
-    });
-
-    assert.equal(model.statecode, STATECODES.findBy('Label', 'Active').Value);
-  });
-
-  test('when hearing info is submitted, but nothing else, statecode is "active"', async function(assert) {
-    const store = this.owner.lookup('service:store');
-    const model = store.createRecord('disposition', {
-      dcpDateofvote: null,
-      dcpBoroughpresidentrecommendation: null,
-      dcpBoroughboardrecommendation: null,
-      dcpCommunityboardrecommendation: null,
-      dcpIspublichearingrequired: null,
-
-      dcpPublichearinglocation: 'foo',
-      dcpDateofpublichearing: 'bar',
-    });
-
-    assert.equal(model.statuscode, STATUSCODES.findBy('Label', 'Saved').Value);
   });
 
   test('when fullNameLongFormat inputs are non-standard, gracefully fail', async function(assert) {

--- a/server/src/project/project.service.ts
+++ b/server/src/project/project.service.ts
@@ -69,6 +69,7 @@ export const FIELD_LABEL_REPLACEMENT_WHITELIST = [
   "dcp_publicstatus",
   "dcp_borough",
   "statuscode",
+  "statecode",
   "dcp_ulurp_nonulurp",
   "_dcp_keyword_value",
   "dcp_ceqrtype",


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Fixes issue where disposition statuscodes and statecodes were set to incorrect values on the front-end.

#### Tasks/Bug Numbers
 - Fixes [AB#3414](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3414)
 
### Technical Explanation
Removes complex logic to figure out the statuscode and statecode which wasn't working, and simply uses the values that we already received from the server.

### Any other info you think would help a reviewer understand this PR?
