### PR TITLE
(Multiple Tickets - 3214, 3240, 3246) - Remove unwanted milestones from displaying

### DIFF
--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -141,21 +141,37 @@ export default class ProjectModel extends Model {
       .reverse();
   }
 
-  @computed('milestones')
-  get completedMilestones() {
+  /**
+   *    We need to filter out the following:
+   *    If the project id starts with a 'P' (this.dcpName[0]):
+   *       Then filter out "Review Filed EAS" and "Review Filed Land Use Application"
+   *    Otherwise:
+   *       Filter out "Prepare Filed EAS" and "Prepare Filed Land Use Application"
+   */
+  @computed('milestones', 'dcpName')
+  get filteredMilestones() {
     return this.get('milestones')
+      .filter(pMilestone => (
+        !((this.dcpName[0] === 'P') && (['Review Filed EAS', 'Review Filed Land Use Application'].includes(pMilestone.milestonename)))
+        && !((this.dcpName[0] !== 'P') && (['Prepare Filed EAS', 'Prepare Filed Land Use Application'].includes(pMilestone.milestonename)))
+      ));
+  }
+
+  @computed('filteredMilestones')
+  get completedMilestones() {
+    return this.get('filteredMilestones')
       .filter(pMilestone => pMilestone.statuscode === STATUSCODE_OPTIONSET.COMPLETED.label);
   }
 
-  @computed('milestones')
+  @computed('filteredMilestones')
   get inProgressMilestones() {
-    return this.get('milestones')
+    return this.get('filteredMilestones')
       .filter(pMilestone => pMilestone.statuscode === STATUSCODE_OPTIONSET.IN_PROGRESS.label);
   }
 
-  @computed('milestones')
+  @computed('filteredMilestones')
   get notStartedMilestones() {
-    return this.get('milestones')
+    return this.get('filteredMilestones')
       .filter(pMilestone => ((pMilestone.statuscode !== STATUSCODE_OPTIONSET.COMPLETED.label) && (pMilestone.statuscode !== STATUSCODE_OPTIONSET.IN_PROGRESS.label)));
   }
 


### PR DESCRIPTION
Edited project.js to filter out specific milestones so they are not displayed

### Summary
If the ProjectID starts with P {
 - For each instance of a Prepare Filed EAS milestone, display "Environmental Assessment Statement Filed" with the actual completion date of the Prepare Filed EAS milestone
 - Do nothing with any Review Filed EAS milestones
}

If the ProjectID does not start with P {
 - For each instance of a Review Filed EAS milestone, display "Environmental Assessment Statement Filed" with the actual 
start date of the Review Filed EAS milestone
 - Do nothing with any Prepare Filed EAS milestones
}

...and the same exact logic for Filed Land Use replacing Filed EAS.

This PR implements the "Do nothing" pieces.  Date setting has occurred in previous PRs.

#### Tasks/Bug Numbers
 - Fixes [AB#3214](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3214)
 - Fixes [AB#3246](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3246)
 - Fixes [AB#3240](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3240)


### Technical Explanation
Implements a filter to remove milestones that should not be displayed.

### Any other info you think would help a reviewer understand this PR?
