### PR TITLE
3511 Write to dcp_ispublichearingrequired on hearing Opt Out or Submit

### DIFF
--- a/client/app/components/waive-hearings-popup.js
+++ b/client/app/components/waive-hearings-popup.js
@@ -9,7 +9,7 @@ export default class WaiveHearingsPopupComponent extends Component {
   @action
   async onConfirmOptOutHearing(assignment) {
     const { dispositions } = assignment;
-    dispositions.setEach('dcpIspublichearingrequired', 'No');
+    dispositions.setEach('dcpIspublichearingrequired', 717170001);
 
     try {
       await dispositions.save();

--- a/client/app/components/waive-hearings-popup.js
+++ b/client/app/components/waive-hearings-popup.js
@@ -1,5 +1,8 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
+import {
+  DCPISPUBLICHEARINGREQUIRED_OPTIONSET,
+} from '../models/disposition/constants';
 
 export default class WaiveHearingsPopupComponent extends Component {
   showPopup = false;
@@ -9,7 +12,7 @@ export default class WaiveHearingsPopupComponent extends Component {
   @action
   async onConfirmOptOutHearing(assignment) {
     const { dispositions } = assignment;
-    dispositions.setEach('dcpIspublichearingrequired', 717170001);
+    dispositions.setEach('dcpIspublichearingrequired', DCPISPUBLICHEARINGREQUIRED_OPTIONSET.NO);
 
     try {
       await dispositions.save();

--- a/client/app/controllers/my-projects/assignment/hearing/add.js
+++ b/client/app/controllers/my-projects/assignment/hearing/add.js
@@ -1,5 +1,8 @@
 import Controller from '@ember/controller';
 import EmberObject, { action } from '@ember/object';
+import {
+  DCPISPUBLICHEARINGREQUIRED_OPTIONSET,
+} from '../../../../models/disposition/constants';
 
 // object used for when allActions is true
 // user has decided to submit one hearing for ALL actions
@@ -106,7 +109,7 @@ export default class MyProjectsProjectHearingAddController extends Controller {
     }
 
     dispositions.forEach(function(disposition) {
-      disposition.set('dcpIspublichearingrequired', 717170000);
+      disposition.set('dcpIspublichearingrequired', DCPISPUBLICHEARINGREQUIRED_OPTIONSET.YES);
     });
 
     return Promise.all(dispositions.map(dispo => dispo.save())).then(() => {

--- a/client/app/controllers/my-projects/assignment/hearing/add.js
+++ b/client/app/controllers/my-projects/assignment/hearing/add.js
@@ -105,6 +105,10 @@ export default class MyProjectsProjectHearingAddController extends Controller {
       });
     }
 
+    dispositions.forEach(function(disposition) {
+      disposition.set('dcpIspublichearingrequired', 717170000);
+    });
+
     return Promise.all(dispositions.map(dispo => dispo.save())).then(() => {
       this.set('hearingSubmitted', false);
       this.set('checkIfMissing', false);

--- a/client/app/models/assignment.js
+++ b/client/app/models/assignment.js
@@ -6,6 +6,9 @@ import {
   REFERRAL_MILESTONEID_BY_ACRONYM_LOOKUP,
   REVIEW_MILESTONE_IDS,
 } from './milestone/constants';
+import {
+  DCPISPUBLICHEARINGREQUIRED_OPTIONSET,
+} from './disposition/constants';
 
 const {
   Model, belongsTo, hasMany, attr,
@@ -71,7 +74,7 @@ export default class AssignmentModel extends Model {
     // array of dcpIspublichearingrequired values
     const publicHearingRequiredArray = dispositions.map(disp => disp.dcpIspublichearingrequired);
     // check that each item in array equals 'No'
-    return publicHearingRequiredArray.every(req => req === 'No') && publicHearingRequiredArray.length > 0;
+    return publicHearingRequiredArray.every(req => req === DCPISPUBLICHEARINGREQUIRED_OPTIONSET.NO) && publicHearingRequiredArray.length > 0;
   }
 
   @computed('hearingsSubmitted', 'hearingsWaived')

--- a/client/app/models/disposition.js
+++ b/client/app/models/disposition.js
@@ -59,7 +59,7 @@ export default class DispositionModel extends Model {
   // sourced from dcp_dcpPublichearinglocation
   @attr('string', { defaultValue: null }) dcpPublichearinglocation;
 
-  @attr('string', { defaultValue: null }) dcpIspublichearingrequired;
+  @attr('number', { defaultValue: null }) dcpIspublichearingrequired;
 
   @attr('string', { defaultValue: null }) dcpRepresenting;
 

--- a/client/app/models/disposition/constants.js
+++ b/client/app/models/disposition/constants.js
@@ -1,0 +1,4 @@
+export const DCPISPUBLICHEARINGREQUIRED_OPTIONSET = { // eslint-disable-line
+  YES: 717170000,
+  NO: 717170001,
+};

--- a/client/tests/acceptance/930-recommendation-action-dropdown-bug-test.js
+++ b/client/tests/acceptance/930-recommendation-action-dropdown-bug-test.js
@@ -64,7 +64,7 @@ module('Acceptance | 930 recommendation action dropdown bug', function(hooks) {
             server.create('disposition', {
               id: 5,
               dcpRepresenting: label,
-              dcpIspublichearingrequired: 'No',
+              dcpIspublichearingrequired: 717170001, // No
               dcpPublichearinglocation: null,
               dcpDateofpublichearing: null,
               action: server.create('action'),

--- a/client/tests/acceptance/user-can-submit-recommendation-form-test.js
+++ b/client/tests/acceptance/user-can-submit-recommendation-form-test.js
@@ -101,7 +101,7 @@ function setUpProjectAndDispos(server, participantType) {
           server.create('disposition', {
             id: 5,
             dcpRepresenting,
-            dcpIspublichearingrequired: 'No',
+            dcpIspublichearingrequired: 717170001, // No
             dcpPublichearinglocation: null,
             dcpDateofpublichearing: null,
             dcpProjectaction: '1',
@@ -116,7 +116,7 @@ function setUpProjectAndDispos(server, participantType) {
             server.create('disposition', {
               id: 5,
               dcpRepresenting,
-              dcpIspublichearingrequired: 'No',
+              dcpIspublichearingrequired: 717170001, // No
               dcpPublichearinglocation: null,
               dcpDateofpublichearing: null,
               dcpProjectaction: '1',

--- a/client/tests/acceptance/user-can-waive-hearings-test.js
+++ b/client/tests/acceptance/user-can-waive-hearings-test.js
@@ -93,7 +93,8 @@ module('Acceptance | user can waive hearings', function(hooks) {
     assert.ok(find('[data-test-hearings-waived-message="4"]'));
     assert.ok(find('[data-test-button="submitRecommendation"]'));
 
-    assert.equal(this.server.db.dispositions.firstObject.dcpIspublichearingrequired, 'No');
+    // equals 'No'
+    assert.equal(this.server.db.dispositions.firstObject.dcpIspublichearingrequired, 717170001);
 
     await click('[data-test-button="submitRecommendation"]');
 
@@ -167,7 +168,7 @@ module('Acceptance | user can waive hearings', function(hooks) {
 
     assert.ok(find('[data-test-hearings-waived-message="4"]'));
 
-    assert.equal(this.server.db.dispositions.firstObject.dcpIspublichearingrequired, 'No');
+    assert.equal(this.server.db.dispositions.firstObject.dcpIspublichearingrequired, 717170001);
   });
 
   test('if there is a server error when running .save(), user will see error message on to-review tab', async function(assert) {

--- a/client/tests/integration/components/to-review-project-card-test.js
+++ b/client/tests/integration/components/to-review-project-card-test.js
@@ -153,21 +153,21 @@ module('Integration | Component | to-review-project-card', function(hooks) {
             id: 1,
             dcpPublichearinglocation: '',
             dcpDateofpublichearing: null,
-            dcpIspublichearingrequired: 'No',
+            dcpIspublichearingrequired: 717170001, // No
             dcpProjeaction: '1',
           }),
           this.server.create('disposition', {
             id: 2,
             dcpPublichearinglocation: '',
             dcpDateofpublichearing: null,
-            dcpIspublichearingrequired: 'No',
+            dcpIspublichearingrequired: 717170001, // No
             dcpProjeaction: '2',
           }),
           this.server.create('disposition', {
             id: 3,
             dcpPublichearinglocation: '',
             dcpDateofpublichearing: null,
-            dcpIspublichearingrequired: 'No',
+            dcpIspublichearingrequired: 717170001, // No
             dcpProjeaction: '3',
           }),
         ],

--- a/client/tests/unit/models/assignment-test.js
+++ b/client/tests/unit/models/assignment-test.js
@@ -80,7 +80,7 @@ module('Unit | Model | assignment', function(hooks) {
       dcpRepresenting: 'Community Board',
       dcpPublichearinglocation: '',
       dcpDateofpublichearing: null,
-      dcpIspublichearingrequired: 'No',
+      dcpIspublichearingrequired: 717170001, // No
     });
 
     const disp2 = store.createRecord('disposition', {
@@ -88,7 +88,7 @@ module('Unit | Model | assignment', function(hooks) {
       dcpRepresenting: 'Community Board',
       dcpPublichearinglocation: '',
       dcpDateofpublichearing: null,
-      dcpIspublichearingrequired: 'No',
+      dcpIspublichearingrequired: 717170001, // No
     });
 
     const disp3 = store.createRecord('disposition', {
@@ -96,7 +96,7 @@ module('Unit | Model | assignment', function(hooks) {
       dcpRepresenting: 'Community Board',
       dcpPublichearinglocation: '',
       dcpDateofpublichearing: null,
-      dcpIspublichearingrequired: 'No',
+      dcpIspublichearingrequired: 717170001, // No
     });
 
     const model = run(() => store.createRecord('assignment', {

--- a/server/src/disposition/disposition.controller.ts
+++ b/server/src/disposition/disposition.controller.ts
@@ -21,6 +21,7 @@ const ATTRS_WHITELIST = [
   "dcp_title",
   "dcp_dateofvote",
   "dcp_votelocation",
+  "dcp_ispublichearingrequired",
 
   // the sum of the other vote types must be equal to the
   // number in this column:


### PR DESCRIPTION
### Summary
When a Land Use Participant opts out of **or** submits hearings for an assignment we write to the disposition's CRM dcp_ispublichearingrequired field. We write "No" if they opted out, and "Yes" if they submitted hearings. 

![image](https://user-images.githubusercontent.com/3311663/122807849-14299c80-d29a-11eb-81e2-697835fa3feb.png)

After writing to this field, CRM should be able to automatically maintain the Status and Statecode fields on the dispositions.

#### Tasks/Bug Numbers
 - Fixes [AB#3511](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3511)

#### Technical Explanation
It turns out that frontend code already **attempted** to write "No" to the dcp_ispublichearingrequired field upon opt out. However, the field was not allowlisted in the server disposition PATCH endpoint. 

This PR also introduces the frontend line of code to write "Yes" upon hearing submission. 