### PR TITLE
3600 Patch disposition statecode and statuscode

### DIFF
--- a/client/app/controllers/my-projects/assignment/recommendations/add.js
+++ b/client/app/controllers/my-projects/assignment/recommendations/add.js
@@ -14,6 +14,11 @@ import {
   boroughBoardDispositionValidations,
   boroughPresidentDispositionValidations,
 } from '../../../../validations/recommendation';
+import {
+  STATUSCODES as DISPO_STATUSCODES,
+  STATECODES as DISPO_STATECODES,
+} from '../../../../models/disposition/constants';
+
 
 const MINIMUM_VOTE_DATE = new Date(1990, 1, 1);
 
@@ -401,6 +406,8 @@ export default class MyProjectsProjectRecommendationsAddController extends Contr
           dcpDatereceived: new Date(), // time when user submits recommendation
           dcpVotelocation,
           dcpDateofvote,
+          statuscode: DISPO_STATUSCODES.SUBMITTED.label,
+          statecode: DISPO_STATECODES.INACTIVE.label,
         });
       });
 

--- a/client/app/models/disposition.js
+++ b/client/app/models/disposition.js
@@ -130,8 +130,6 @@ export default class DispositionModel extends Model {
 
   @attr() documents;
 
-  @attr() documents;
-
   // sourced from dcp_docketdescription
   @attr('string') dcpDocketdescription;
 

--- a/client/app/models/disposition/constants.js
+++ b/client/app/models/disposition/constants.js
@@ -7,3 +7,16 @@ export const DISPOSITION_VISIBILITY = {
   GENERAL_PUBLIC: 717170003,
   LUP: 717170004,
 };
+
+export const STATUSCODES = {
+  DRAFT: { label: 'Draft', value: 1 },
+  SAVED: { label: 'Saved', value: 717170000 },
+  SUBMITTED: { label: 'Submitted', value: 2 },
+  DEACTIVATED: { label: 'Deactivated', value: 717170001 },
+  NOT_SUBMITTED: { label: 'Not Submitted', value: 717170002 },
+};
+
+export const STATECODES = {
+  ACTIVE: { label: 'Active', value: 0 },
+  INACTIVE: { label: 'Inactive', value: 1 },
+};

--- a/server/src/disposition/disposition.controller.ts
+++ b/server/src/disposition/disposition.controller.ts
@@ -13,6 +13,19 @@ import { ConfigService } from "../config/config.service";
 import { CrmService } from "../crm/crm.service";
 import { defaultValueDispositionPipe as defaultValuePipe } from "./defaultValue.disposition.pipe";
 
+const STATUSCODES_LABEL_TO_VALUE = {
+  Draft: 1,
+  Saved: 717170000,
+  Submitted: 2,
+  Deactivated: 717170001,
+  "Not Submitted": 717170002
+};
+
+const STATECODES_LABEL_TO_VALUE = {
+  Active: 0,
+  Inactive: 1
+};
+
 // Only attrs in the whitelist get posted
 const ATTRS_WHITELIST = [
   "dcp_publichearinglocation",
@@ -34,7 +47,9 @@ const ATTRS_WHITELIST = [
   "dcp_votinginfavorrecommendation",
   "dcp_votingabstainingonrecommendation",
   "dcp_consideration",
-  "dcp_datereceived"
+  "dcp_datereceived",
+  "statecode",
+  "statuscode"
 ];
 const { deserialize } = new Deserializer({
   keyForAttribute: "underscore_case"
@@ -100,7 +115,9 @@ export class DispositionController {
             : null,
           dcp_boroughboardrecommendation: whitelistedAttrs.dcp_boroughboardrecommendation
             ? parseInt(whitelistedAttrs.dcp_boroughboardrecommendation, 10)
-            : null
+            : null,
+          statecode: STATECODES_LABEL_TO_VALUE[whitelistedAttrs.statecode],
+          statuscode: STATUSCODES_LABEL_TO_VALUE[whitelistedAttrs.statuscode]
         }
       };
 


### PR DESCRIPTION
### Summary
For some reason we need to now PATCH the disposition statecode and statuscode properties upon recommendation submission. 

This PR does so by modifiying the submitRecommendations() procedure in the client's `controllers/recommendation/add.js` to update those values before saving the disposition model. It assigns to the  statuscode and statecode the _labels_ "Submitted" and "Inactive", respectively.

The backend now "allowlists" the statecode and statuscode fields in the disposition controller (allows those fields to be patched). It also remap these to the appropriate Integer codes before sending them to CRM.

Note that this means that statecode and statuscode is now PATCHed upon hearing submission. However, we rely on the frontend to just send the original crm-provided label values during hearing submission. The client hearing interface does not modify statecode and statuscode.

#### Tasks/Bug Numbers
 - Fixes [AB#3600](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3600)

#### Misc
Deletes random duplicate `documents` property in client Disposition model.