### PR TITLE
3789 3788 Fix need to double submit hearings

### DIFF
--- a/client/app/components/waive-hearings-popup.js
+++ b/client/app/components/waive-hearings-popup.js
@@ -2,7 +2,11 @@ import Component from '@ember/component';
 import { action } from '@ember/object';
 import {
   DCPISPUBLICHEARINGREQUIRED_OPTIONSET,
+
+  STATUSCODES as DISPO_STATUSCODES,
+  STATECODES as DISPO_STATECODES,
 } from '../models/disposition/constants';
+
 
 export default class WaiveHearingsPopupComponent extends Component {
   showPopup = false;
@@ -12,13 +16,21 @@ export default class WaiveHearingsPopupComponent extends Component {
   @action
   async onConfirmOptOutHearing(assignment) {
     const { dispositions } = assignment;
+    const dispoOriginalStatus = dispositions.firstObject.get('statuscode');
+    const dispoOriginalState = dispositions.firstObject.get('statecode');
+
     dispositions.setEach('dcpIspublichearingrequired', DCPISPUBLICHEARINGREQUIRED_OPTIONSET.NO);
+    dispositions.setEach('statuscode', DISPO_STATUSCODES.SAVED.label);
+    dispositions.setEach('statecode', DISPO_STATECODES.ACTIVE.label);
 
     try {
       await dispositions.save();
       this.set('showPopup', false);
     } catch (e) {
       dispositions.setEach('dcpIspublichearingrequired', null);
+      dispositions.setEach('statuscode', dispoOriginalStatus);
+      dispositions.setEach('statecode', dispoOriginalState);
+
       this.set('error', e);
     }
   }

--- a/client/app/controllers/my-projects/assignment/hearing/add.js
+++ b/client/app/controllers/my-projects/assignment/hearing/add.js
@@ -2,7 +2,11 @@ import Controller from '@ember/controller';
 import EmberObject, { action } from '@ember/object';
 import {
   DCPISPUBLICHEARINGREQUIRED_OPTIONSET,
+
+  STATUSCODES as DISPO_STATUSCODES,
+  STATECODES as DISPO_STATECODES,
 } from '../../../../models/disposition/constants';
+
 
 // object used for when allActions is true
 // user has decided to submit one hearing for ALL actions
@@ -110,6 +114,8 @@ export default class MyProjectsProjectHearingAddController extends Controller {
 
     dispositions.forEach(function(disposition) {
       disposition.set('dcpIspublichearingrequired', DCPISPUBLICHEARINGREQUIRED_OPTIONSET.YES);
+      disposition.set('statuscode', DISPO_STATUSCODES.SAVED.label);
+      disposition.set('statecode', DISPO_STATECODES.ACTIVE.label);
     });
 
     return Promise.all(dispositions.map(dispo => dispo.save())).then(() => {

--- a/server/src/assignment/assignment.service.ts
+++ b/server/src/assignment/assignment.service.ts
@@ -53,7 +53,6 @@ const FIELD_LABEL_REPLACEMENT_WHITELIST = [
   "_dcp_action_value",
   "_dcp_zoningresolution_value",
   "dcp_lupteammemberrole",
-  "dcp_ispublichearingrequired",
   "statecode"
 ];
 


### PR DESCRIPTION
### Technical Summary

Upon hearing waive or submission, explicitly patch the statuscode and statecode fields (with values 'Saved' and 'Active', explicitly).

We were observing behavior where user needed to double submit/waive in order for the hearing info to be saved to CRM. This was likely because CRM also automatically changes the statuscode value from 'Draft' to 'Saved', and previously the frontend was writing 'Draft' to CRM. This maybe was giving CRM conflicting instructions. 

This PR also makes sure to send code values for `dcp_ispublichearinginforequired` to the frontend. Previously we added `dcp_ispublichearinginforequired` to the list of properties to be replaced by their label value before sent to the frontend. Apparently this field may not have an Odata label associated with it, so Ember Data showed `null` for the value. This prevented the frontend from computing whether an assignment had hearings waived. 

From testing, it seems that [AB#3789](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3789) may also be resolved after these patches. It maybe that previously temporary values in Ember Data was hiding the real CRM state of the dispositions. So the frontend showed that disposition hearing data should have posted to CRM, but never did. 

#### Tasks/Bug Numbers
- Fixes  [AB#3788](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3788)
- Potentially fixes/related to [AB#3789](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/3789)

