### PR TITLE
8363 ZAP Search - Add new Racial Equity Report Applicability filter to ZAP Search landing page

### DIFF
--- a/client/app/controllers/query-parameters/show-geography.js
+++ b/client/app/controllers/query-parameters/show-geography.js
@@ -95,13 +95,13 @@ export const projectParams = new QueryParams({
     },
   },
   dcp_applicability: {
-    defaultValue: '',
+    defaultValue: [],
     refresh: true,
     serialize(value) {
       return value.toString();
     },
     deserialize(value = '') {
-      return value;
+      return value.split(',');
     },
   },
   dcp_publicstatus: {

--- a/client/app/controllers/query-parameters/show-geography.js
+++ b/client/app/controllers/query-parameters/show-geography.js
@@ -94,6 +94,16 @@ export const projectParams = new QueryParams({
       return value.split(',');
     },
   },
+  dcp_applicability: {
+    defaultValue: '',
+    refresh: true,
+    serialize(value) {
+      return value.toString();
+    },
+    deserialize(value = '') {
+      return value;
+    },
+  },
   dcp_publicstatus: {
     defaultValue: ['Noticed', 'In Public Review'].sort(),
     refresh: true,

--- a/client/app/helpers/lookup-dcp-applicability.js
+++ b/client/app/helpers/lookup-dcp-applicability.js
@@ -1,0 +1,22 @@
+import { helper } from '@ember/component/helper';
+
+export const dcpApplicabilityLookup = [
+  {
+    code: 1,
+    searchField: 'Yes',
+  },
+  {
+    code: 2,
+    searchField: 'No',
+  },
+  {
+    code: null,
+    searchField: 'Unsure at this time',
+  },
+];
+
+export function lookupDcpApplicability() {
+  return dcpApplicabilityLookup;
+}
+
+export default helper(lookupDcpApplicability);

--- a/client/app/helpers/lookup-dcp-applicability.js
+++ b/client/app/helpers/lookup-dcp-applicability.js
@@ -3,11 +3,11 @@ import { helper } from '@ember/component/helper';
 export const dcpApplicabilityLookup = [
   {
     code: 1,
-    searchField: 'Yes',
+    searchField: 'Racial Equity Report Required',
   },
   {
     code: 2,
-    searchField: 'No',
+    searchField: 'Racial Equity Report Not Required',
   },
   {
     code: null,

--- a/client/app/templates/show-geography.hbs
+++ b/client/app/templates/show-geography.hbs
@@ -139,6 +139,36 @@
         {{/section.filter-wrapper}}
       {{/filters.section}}
 
+      {{!-- FILTER: RACIAL EQUITY REPORT APPLICABILITY --}}
+      {{#filters.section
+        filterNames='dcp_applicability'
+        as |section|}}
+        {{#section.filter-wrapper
+          filterTitle=(get-label-for 'filters.dcp_applicability')
+          tooltip='Identifies if applicant should submit a Racial Equity Report on Housing and Opportunity under Local Law 78 of 2021.'}}
+          <ul class="menu vertical medium-horizontal applicabile-checkbox">
+            <li {{action section.delegate-mutation (action 'mutateArray' 'dcp_applicability' 'Racial Equity Report Required')}}
+              data-test-applicabile-checkbox
+            >
+              <a>
+                {{filter-checkbox
+                  value='Racial Equity Report Required'
+                  currentValues=dcp_applicability}}
+              </a>
+            </li>
+            <li {{action section.delegate-mutation (action 'mutateArray' 'dcp_applicability' 'Racial Equity Report Not Required')}}
+              data-test-nonuapplicabile-checkbox
+            >
+              <a>
+                {{filter-checkbox
+                  value='Racial Equity Report Not Required'
+                  currentValues=dcp_applicability}}
+              </a>
+            </li>
+          </ul>
+        {{/section.filter-wrapper}}
+      {{/filters.section}}
+
       {{!-- FILTER: DISTANCE FROM POINT --}}
       {{#filters.section
         filterNames=(array 'distance_from_point' 'radius_from_point')
@@ -275,28 +305,7 @@
         {{/section.filter-wrapper}}
       {{/filters.section}}
 
-      {{!-- FILTER: RACIAL EQUITY REPORT APPLICABILITY --}}
-      {{#filters.section
-        filterNames='dcp_applicability'
-        as |section|}}
-        {{#section.filter-wrapper
-          filterTitle=(get-label-for 'filters.dcp_applicability')
-          tooltip='Identifies if applicant should submit a Racial Equity Report on Housing and Opportunity under Local Law 78 of 2021.'}}
-          {{#power-select-multiple
-            options=(lookup-dcp_applicability)
-            selected=(contains-keys
-              (lookup-dcp_applicability)
-              dcp_applicability
-              key='code')
-            placeholder="Select Racial Equity Report status..."
-            searchField='searchField'
-            onchange=(action section.delegate-mutation (action 'replaceProperty' 'dcp_applicability'))
-            as |applicability|
-          }}
-            {{applicability.searchField}}
-          {{/power-select-multiple}}
-        {{/section.filter-wrapper}}
-      {{/filters.section}}
+     
 
       {{!-- FILTER: ZONING RESOLUTION TYPE --}}
       {{#filters.section

--- a/client/app/templates/show-geography.hbs
+++ b/client/app/templates/show-geography.hbs
@@ -275,6 +275,29 @@
         {{/section.filter-wrapper}}
       {{/filters.section}}
 
+      {{!-- FILTER: RACIAL EQUITY REPORT APPLICABILITY --}}
+      {{#filters.section
+        filterNames='dcp_applicability'
+        as |section|}}
+        {{#section.filter-wrapper
+          filterTitle=(get-label-for 'filters.dcp_applicability')
+          tooltip='Identifies if applicant should submit a Racial Equity Report on Housing and Opportunity under Local Law 78 of 2021.'}}
+          {{#power-select-multiple
+            options=(lookup-dcp_applicability)
+            selected=(contains-keys
+              (lookup-dcp_applicability)
+              dcp_applicability
+              key='code')
+            placeholder="Select Racial Equity Report status..."
+            searchField='searchField'
+            onchange=(action section.delegate-mutation (action 'replaceProperty' 'dcp_applicability'))
+            as |applicability|
+          }}
+            {{applicability.searchField}}
+          {{/power-select-multiple}}
+        {{/section.filter-wrapper}}
+      {{/filters.section}}
+
       {{!-- FILTER: ZONING RESOLUTION TYPE --}}
       {{#filters.section
         filterNames='zoning-resolutions'

--- a/client/app/templates/show-geography.hbs
+++ b/client/app/templates/show-geography.hbs
@@ -145,7 +145,7 @@
         as |section|}}
         {{#section.filter-wrapper
           filterTitle=(get-label-for 'filters.dcp_applicability')
-          tooltip='Identifies if applicant should submit a Racial Equity Report on Housing and Opportunity under Local Law 78 of 2021.'}}
+          tooltip='As of June 1, 2022, certain property owners (https://www1.nyc.gov//assets/planning/download/pdf/data-maps/edde/racial-equity-report-applicability-chart.pdf) applying for land use changes must produce a Racial Equity Report using information pulled from the Community Data in the Equitable Development Data Explorer (https://equitableexplorer.planning.nyc.gov/map/data/district).'}}
           <ul class="menu vertical medium-horizontal applicabile-checkbox">
             <li {{action section.delegate-mutation (action 'mutateArray' 'dcp_applicability' 'Racial Equity Report Required')}}
               data-test-applicabile-checkbox

--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -99,6 +99,7 @@ module.exports = function(environment) {
         project_applicant_text: 'Text Match',
         radius_from_point: 'Radius Filter',
         'zoning-resolutions': 'Zoning Resolutions',
+        dcp_applicability: 'Racial Equity Report Applicability',
       },
     },
   };

--- a/server/src/project/project.service.ts
+++ b/server/src/project/project.service.ts
@@ -50,6 +50,10 @@ export const ULURP_LOOKUP = {
   "Non-ULURP": 717170000,
   ULURP: 717170001
 };
+export const APPLICABILITY_LOOKUP = {
+  "Racial Equity Report Required": 1,
+  "Racial Equity Report Not Required": 2
+};
 export const PROJECT_STATUS_LOOKUP = {
   Noticed: 717170005,
   Filed: 717170000,
@@ -155,7 +159,10 @@ const QUERY_TEMPLATES = {
     ),
 
   dcp_applicability: queryParamValue =>
-    comparisonOperator("dcp_applicability", "eq", parseInt(queryParamValue)),
+    equalsAnyOf(
+      "dcp_applicability",
+      coerceToNumber(mapInLookup(queryParamValue, APPLICABILITY_LOOKUP))
+    ),
 
   dcp_certifiedreferred: queryParamValue =>
     all(

--- a/server/src/project/project.service.ts
+++ b/server/src/project/project.service.ts
@@ -85,7 +85,8 @@ export const FIELD_LABEL_REPLACEMENT_WHITELIST = [
   "_dcp_applicant_customer_value",
   "_dcp_applicantadministrator_customer_value",
   "_dcp_action_value",
-  "_dcp_zoningresolution_value"
+  "_dcp_zoningresolution_value",
+  "dcp_applicability"
 ];
 
 export const PACKAGE_VISIBILITY = {
@@ -153,6 +154,9 @@ const QUERY_TEMPLATES = {
       coerceToNumber(mapInLookup(queryParamValue, PROJECT_STATUS_LOOKUP))
     ),
 
+  dcp_applicability: queryParamValue =>
+    comparisonOperator("dcp_applicability", "eq", parseInt(queryParamValue)),
+
   dcp_certifiedreferred: queryParamValue =>
     all(
       comparisonOperator(
@@ -217,7 +221,8 @@ export const ALLOWED_FILTERS = [
   "block",
   "distance_from_point",
   "radius_from_point",
-  "zoning-resolutions"
+  "zoning-resolutions",
+  "dcp_applicability"
 ];
 
 export const generateFromTemplate = (query, template) => {


### PR DESCRIPTION
### Summary
Adds the filter, as shown below:
<img width="720" alt="image" src="https://user-images.githubusercontent.com/61206501/167504802-c4ba6f49-e763-4a0d-8af4-46c1893f13bc.png">


#### Tasks/Bug Numbers
 - Completes task AB#8363 and user story AB#8122

