### PR TITLE
8417 ZAP Search - Add Noticed Date field to project page

### DIFF
--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -123,6 +123,8 @@ export default class ProjectModel extends Model {
 
   @attr() dcpApplicability;
 
+  @attr() dcpNoticeddate;
+
   @computed('dcpApplicability')
   get dcpApplicabilitySimp() {
     const option = Object.values(DCP_APPLICABILITY_OPTIONSET).find(applicability => applicability.label === this.dcpApplicability);

--- a/client/app/templates/show-project.hbs
+++ b/client/app/templates/show-project.hbs
@@ -92,6 +92,22 @@
             {{/if}}
           </div>
         {{/if}}
+
+        {{#if (eq model.dcpUlurpNonulurp "ULURP")}}
+          <p class="cell auto">
+            <strong>Noticed Date:</strong>
+            {{#if model.dcpNoticeddate}}
+              <DateDisplay
+                @date={{model.dcpNoticeddate}}
+                @outputFormat="M/D/YYYY"
+              />
+              {{!-- {{model.dcpNoticeddate}} --}}
+            {{else}}
+              Not yet noticed
+            {{/if}}
+          </p>
+        {{/if}}
+        
         <hr>
 
         {{#if model.videoLinks}}

--- a/server/src/project/project.entity.ts
+++ b/server/src/project/project.entity.ts
@@ -37,6 +37,7 @@ export const KEYS = [
   "lastmilestonedate",
   "video_links",
   "dcp_applicability",
+  "dcp_noticeddate",
 
   "_dcp_applicant_customer_value",
   "_dcp_applicantadministrator_customer_value",

--- a/server/src/project/project.service.ts
+++ b/server/src/project/project.service.ts
@@ -286,6 +286,7 @@ function generateQueryObject(query, overrides?) {
     "dcp_nydospermitnumber",
     "dcp_lastmilestonedate",
     "dcp_applicability",
+    "dcp_noticeddate",
     "_dcp_applicant_customer_value",
     "_dcp_applicantadministrator_customer_value"
   ];
@@ -393,6 +394,7 @@ export class ProjectService {
       "dcp_nydospermitnumber",
       "dcp_lastmilestonedate",
       "dcp_applicability",
+      "dcp_noticeddate",
       "_dcp_applicant_customer_value",
       "_dcp_applicantadministrator_customer_value"
     ];


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Add a new field titled "Noticed Date" to the project page on ZAP Search.
Add the field under Status tag.
Populate the "Noticed Date" field with the [CRM] Noticed Date [dcp_noticeddate] = Not Null and ULURP / Non-ULURP [dcp_ulurp_nonulurp] = ULURP.
When the [CRM] Noticed Date = Null, display “Not yet noticed” in place of a date.
NOTE: The date is editable on the CRM so the Noticed Date field data should display the new date if the project Public Status is changed to another status then changed back to "Noticed". 

#### Tasks/Bug Numbers
 - Completes task [AB#8417](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8417) and user story [AB#8308](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8308)
