### PR TITLE
8728 fix distorted status tags on smaller viewports

### DIFF
--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -70,6 +70,11 @@ $completed-color: #a6cee3;
 @import 'modules/_m-project-summary-cards';
 @import 'modules/_m-tooltipster';
 
+// Media query for project tags in templates/show-project.hbs
+@import 'modules/_m-status_tags_styles';
+
+
 // Addons
 @import "ember-power-select";
 @import "ember-content-placeholders";
+

--- a/client/app/styles/modules/_m-status_tags_styles.scss
+++ b/client/app/styles/modules/_m-status_tags_styles.scss
@@ -1,0 +1,83 @@
+// desktop view with map displayed to the right of Milestones
+.site-main {
+  .tag-wrapper {
+    column-gap: 0.5rem;
+
+    .tag-child-left ,
+    .tag-child-center,
+    .tag-child-right {
+      flex: 1 1 auto;
+    }
+
+    .tag-child-left  {
+      text-align: left;
+      display: flex;
+
+      .publicstatus-noticed {
+        margin-left: .2rem;
+      }
+    }
+
+    .tag-child-center {
+      text-align: right;
+    }
+
+    .tag-child-right {
+      text-align: right;
+      flex: 1 1 4rem;
+    }
+  }
+}
+
+// desktop view with map displayed below Milestones
+@media screen and (min-width: 41.313rem) and (max-width: 63.938rem) { // 661px to 1023px
+  .site-main {
+    .tag-wrapper {
+      width: auto;
+
+      .tag-child-center {
+        max-width: fit-content;
+      }
+
+      .tag-child-right {
+        flex-basis: 0;
+        max-width: fit-content;
+      }
+    }
+  }
+}
+
+@media screen and (max-width: 41.25rem) { // 660px
+  .site-main {
+    .tag-wrapper {
+      flex-flow: column nowrap;
+
+      .tag-child-left ,
+      .tag-child-center,
+      .tag-child-right {
+        margin-bottom: 8px;
+        flex-basis: auto;
+      }
+
+      .tag-child-center,
+      .tag-child-right {
+        text-align: left;
+      }
+
+      .tag-child-left {
+        display: flex;
+        flex-direction: column;
+
+        .publicstatus-noticed {
+          width: fit-content;
+          margin-left: 0;
+        }
+      }
+
+      .tag-child-right {
+        display: flex;
+        justify-content: flex-start;
+      }
+    }
+  }
+}

--- a/client/app/templates/show-project.hbs
+++ b/client/app/templates/show-project.hbs
@@ -58,8 +58,8 @@
           @dispositions={{this.model.dispositions}}
         />
         {{#if (or model.dcpPublicstatusSimp model.dcpUlurpNonulurp model.dcpApplicability)}}
-          <div class="grid-x">
-            <p class="cell auto">
+          <div class="grid-x tag-wrapper">
+            <p class="cell auto tag-child-left">
               {{#if model.dcpPublicstatusSimp}}
                 <strong>Status:</strong>
                   <span class="label dark-gray publicstatus-{{dasherize model.dcpPublicstatusSimp}}">
@@ -71,17 +71,19 @@
               {{/if}}
             </p>
             {{#if (or model.dcpUlurpNonulurp model.dcpApplicability)}}
-              <p class="cell small-8 text-right">
-                {{#if model.dcpApplicability}}          
-                  <span class="label dark-gray">
+              <p class="cell auto tag-child-center">
+                {{#if model.dcpApplicability}}
+                  <span class="label dark-gray tag-span">
                     {{model.dcpApplicabilitySimp}}
                     <sup>
                       {{icon-tooltip tip='As of June 1, 2022, <a href="https://www1.nyc.gov//assets/planning/download/pdf/data-maps/edde/racial-equity-report-applicability-chart.pdf" target="blank" style="text-decoration: underline;">certain property owners</a> applying for land use changes must produce a Racial Equity Report using information pulled from the Community Data in the <a href="https://equitableexplorer.planning.nyc.gov/map/data/district" target="blank" style="text-decoration: underline;">Equitable Development Data Explorer</a>.'}}
                     </sup>
                   </span>
                 {{/if}}
-                {{#if model.dcpUlurpNonulurp}}  
-                <span class="label dark-gray">
+              </p>
+              <p class="cell auto tag-child-right">
+                {{#if model.dcpUlurpNonulurp}}
+                <span class="label dark-gray tag-span">
                   {{~model.dcpUlurpNonulurp~}}
                   <sup>
                     {{icon-tooltip tip='Uniform Land Use Review Procedure (ULURP) is a procedure whereby applications affecting the land use of the city are publicly reviewed within mandated time frames. Key participants in the process are the Department of City Planning (DCP), the City Planning Commission (CPC), Community Boards, the Borough Presidents, the Borough Boards, the City Council and the Mayor.'}}


### PR DESCRIPTION
### Summary
 - rebuild html in templates/show-project.hbs
 - add/adjust styles for tags on desktop and mobile viewports

#### NOTE: Design team approved.


#### Tasks/Bug Numbers
 - Fixes [AB#8728](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8728)

E

### Technical Explanation
The three status tags consisted on 2 `p`  tags wrapped by one div with `display: flex`.  The ULURP and Racial Equity  tags were two spans wrapped by the same `p` tag making it difficult to adjust their position via flexbox, as well as not responding well to smaller viewports as seen below.

![Screen Shot 2022-05-23 at 10 21 10 AM](https://user-images.githubusercontent.com/11340947/169841014-282f6eab-302c-4b11-a695-bd751b2d8741.png)

I broke out each tag into its own `p` tag and added 75 lines of CSS to adjust the appearance of the tags on 3 viewports, particularly the mobile/tablet viewports as seen below:

![Screen Shot 2022-05-23 at 10 10 26 AM](https://user-images.githubusercontent.com/11340947/169841275-457cce70-69dc-4d89-a3a9-f8ba311a8d96.png)



