### PR TITLE
8729 - adjust NOTICED DATE to reflect EST.

### DIFF
--- a/client/app/models/project.js
+++ b/client/app/models/project.js
@@ -1,6 +1,7 @@
 import DS from 'ember-data';
 import { computed } from '@ember/object';
 import { sort, alias } from '@ember/object/computed';
+import moment from 'moment';
 import { DCP_APPLICABILITY_OPTIONSET } from './project/constants';
 import {
   STATUSCODE_OPTIONSET,
@@ -124,6 +125,14 @@ export default class ProjectModel extends Model {
   @attr() dcpApplicability;
 
   @attr() dcpNoticeddate;
+
+  @computed('dcpNoticeddate')
+  get formattedNoticedDate() {
+    if (moment(this.dcpNoticeddate).isDST()) {
+      return moment(this.dcpNoticeddate).utcOffset(240).format('M/D/YYYY');
+    }
+    return moment(this.dcpNoticeddate).utcOffset(300).format('M/D/YYYY');
+  }
 
   @computed('dcpApplicability')
   get dcpApplicabilitySimp() {

--- a/client/app/templates/show-project.hbs
+++ b/client/app/templates/show-project.hbs
@@ -100,10 +100,8 @@
             <strong>Noticed Date:</strong>
             {{#if model.dcpNoticeddate}}
               <DateDisplay
-                @date={{model.dcpNoticeddate}}
-                @outputFormat="M/D/YYYY"
+                @date={{model.formattedNoticedDate}}
               />
-              {{!-- {{model.dcpNoticeddate}} --}}
             {{else}}
               Not yet noticed
             {{/if}}


### PR DESCRIPTION
### Summary
Adjusted for the time offset from GMT to EST so that the CRM and ZAP portal both displayed the same date as show in the screen grab below:

https://user-images.githubusercontent.com/11340947/170326647-78274ce7-f9a4-4167-965b-2018990a01d6.mov

#### Tasks/Bug Numbers
 - Fixes [AB#8729](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/8729)

### Technical Explanation
formatted `dcpNoticeddate` with a  computed function to reflect the offset from GMT to EST in the project js file

[Moment Usage](https://momentjs.com/docs/#/use-it/)

[UTC offset](https://momentjs.com/docs/#/manipulating/utc-offset/)
