### PR TITLE
Bug/1693 public meeting field overlaps bbl list

### DIFF
--- a/client/app/helpers/center-content.js
+++ b/client/app/helpers/center-content.js
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+
+export function centerContent(text) {
+  return (text.length && text.offsetWidth > 200) ? 'center-text-tiny' : '';
+}
+
+export default helper(centerContent);

--- a/client/app/styles/layouts/_l-default.scss
+++ b/client/app/styles/layouts/_l-default.scss
@@ -342,3 +342,9 @@ h5.clickable-header {
     box-shadow: 0 0 0 4px rgba(0,0,0,0.1);
   }
 }
+
+// fixes for the extra long ULURP name & numbers to prevent bleeding into the BBL numbers
+.text-tiny #center-text-tiny {
+  display: flex;
+  justify-content: center;
+}

--- a/client/app/templates/components/milestones/public-hearing.hbs
+++ b/client/app/templates/components/milestones/public-hearing.hbs
@@ -8,7 +8,7 @@
   {{~moment-format @hearing.disposition.dcpDateofpublichearing "LLLL"~}}
 </small>
 
-<div class="text-tiny">
+<div class="text-tiny" id="{{center-content action.dcpName}}">
   {{#each @hearing.hearingActions as |action index|}}
     {{#if action.dcpName}}
       <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-hearing-actions-list="{{@hearing.disposition.id}}{{index}}">

--- a/client/app/templates/components/project-milestone.hbs
+++ b/client/app/templates/components/project-milestone.hbs
@@ -122,7 +122,7 @@
                         <small class="display-inline-block" data-test-vote-date="{{vote.disposition.id}}">
                           Vote:&nbsp;{{~moment-format vote.disposition.dcpDateofvote "LL"~}}
                         </small>
-                        <div class="text-tiny">
+                        <div class="text-tiny" id="{{center-content action.dcpName}}">
                           {{#each vote.voteActions as |action index|}}
                             {{#if action.dcpName}}
                               <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-vote-actions-list="{{vote.disposition.id}}{{index}}">
@@ -155,7 +155,7 @@
                         <small class="display-inline-block" data-test-vote-date="{{vote.disposition.id}}">
                           Vote:&nbsp;{{~moment-format vote.disposition.dcpDatereceived "LL"~}}
                         </small>
-                        <div class="text-tiny">
+                        <div class="text-tiny" id="{{center-content action.dcpName}}">
                           {{#each vote.voteActions as |action index|}}
                             {{#if action.dcpName}}
                               <span class="label light-gray tiny-margin-bottom tiny-margin-right" data-test-vote-actions-list="{{vote.disposition.id}}{{index}}">

--- a/client/app/templates/components/to-review-project-card.hbs
+++ b/client/app/templates/components/to-review-project-card.hbs
@@ -128,7 +128,8 @@
                       </span>
                     </span>
 
-                    <small data-test-hearing-actions-list="{{hearing.disposition.id}}">
+                    <small id="{{center-content action.dcpName}}"
+                      data-test-hearing-actions-list="{{hearing.disposition.id}}">
                       {{#each hearing.hearingActions as |action index| ~}}
                         {{#if action.dcpName}}
                           <span class="label light-gray tiny-margin-bottom tiny-margin-right">

--- a/client/app/templates/components/upcoming-project-card.hbs
+++ b/client/app/templates/components/upcoming-project-card.hbs
@@ -115,7 +115,8 @@
                       </span>
                     </span>
 
-                    <small data-test-hearing-actions-list="{{hearing.disposition.id}}">
+                    <small id="{{center-content action.dcpName}}"
+                      data-test-hearing-actions-list="{{hearing.disposition.id}}">
                       {{#each hearing.hearingActions as |action index| ~}}
                         {{#if action.dcpName}}
                           <span class="label light-gray tiny-margin-bottom tiny-margin-right">

--- a/client/app/templates/my-projects/assignment/hearing/add.hbs
+++ b/client/app/templates/my-projects/assignment/hearing/add.hbs
@@ -158,7 +158,9 @@
                     --}}</span>
                       </span>
 
-                      <div class="text-tiny" data-test-hearing-actions-list="{{hearing.disposition.id}}">
+                      <div class="text-tiny"
+                        id="{{center-content action.dcpName}}"
+                        data-test-hearing-actions-list="{{hearing.disposition.id}}">
                         {{#each hearing.hearingActions as |action index| ~}}
                           {{#if action.dcpName}}
                             <span class="label light-gray tiny-margin-bottom tiny-margin-right">

--- a/client/app/templates/my-projects/assignment/recommendations/add.hbs
+++ b/client/app/templates/my-projects/assignment/recommendations/add.hbs
@@ -58,7 +58,8 @@
                         <span class="light-gray">|</span>
                         <strong>{{hearing.disposition.dcpPublichearinglocation}}</strong>
                       </span>
-                      <small data-test-hearing-actions-list="{{hearing.disposition.id}}">
+                      <small id="{{center-content action.dcpName}}"
+                        data-test-hearing-actions-list="{{hearing.disposition.id}}">
                         {{#each hearing.hearingActions as |action index| ~}}
                           {{#if action.dcpName}}
                             <span class="label light-gray tiny-margin-bottom tiny-margin-right">
@@ -553,7 +554,8 @@
                             <span class="light-gray">|</span>
                             <strong>{{hearing.disposition.dcpPublichearinglocation}}</strong>
                           </span>
-                          <small data-test-hearing-actions-list="{{hearing.disposition.id}}">
+                          <small id="{{center-content action.dcpName}}"
+                            data-test-hearing-actions-list="{{hearing.disposition.id}}">
                             {{#each hearing.hearingActions as |action index| ~}}
                               {{#if action.dcpName}}
                                 <span class="label light-gray tiny-margin-bottom tiny-margin-right">


### PR DESCRIPTION
### Summary
If the light gray div containing the dcp action name and ULURP number is too long, it can possibly overlap and obscur the BBL numbers as shown in the example below:
[Project# 2020M0408](https://zap.planning.nyc.gov/projects/2020M0408)

<img width="918" alt="Screen Shot 2022-06-29 at 11 11 34 AM" src="https://user-images.githubusercontent.com/11340947/176545409-91aec7cb-ab81-4d99-9c15-e88cd85b12da.png">

My solution, which I can't yet test locally bc I don't know how to recreate/duplicate the specific project locally, it to have the parent div wrapper display flex and center the child span. The results shown below. I am not sure of how this would visually affect shorter grey dics as yet.

<img width="1243" alt="Screen Shot 2022-06-29 at 5 11 54 PM" src="https://user-images.githubusercontent.com/11340947/176545730-41d71905-50aa-420e-881a-d05d06a4d8c2.png">


#### Tasks/Bug Numbers
 - Fixes [AB#1693](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/1693)
