### PR TITLE
9499 use bracket notation to get array item, then get length of that item

### DIFF
--- a/client/app/helpers/center-lengthy-text.js
+++ b/client/app/helpers/center-lengthy-text.js
@@ -1,7 +1,7 @@
 import { helper } from '@ember/component/helper';
 
 export function centerLengthyText(text) {
-  return (text.length > 22) ? 'center-content' : '';
+  return (text[0].length > 22) ? 'center-content' : '';
 }
 
 export default helper(centerLengthyText);


### PR DESCRIPTION
### Summary
Turns out that the `action.dcpName` text is in an array with a length of 1 so the centerLengthyTextMethod will always return false and not apply the `center-content` class.

#### Tasks/Bug Numbers
 - Fixes [AB#9499](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/9499)


![Screen Shot 2022-07-06 at 12 14 03 PM](https://user-images.githubusercontent.com/11340947/177596357-c3be21b9-ad1f-4694-ba81-ea693ea37fad.png)

