### PR TITLE
9499 rebuilt markup to wrap extra long ULURP names to prevent from overlapping BBLs

### DIFF
--- a/client/app/helpers/center-lengthy-text.js
+++ b/client/app/helpers/center-lengthy-text.js
@@ -1,7 +1,0 @@
-import { helper } from '@ember/component/helper';
-
-export function centerLengthyText(text) {
-  return (text.length > 22) ? 'center-content' : '';
-}
-
-export default helper(centerLengthyText);

--- a/client/app/styles/layouts/_l-default.scss
+++ b/client/app/styles/layouts/_l-default.scss
@@ -343,8 +343,19 @@ h5.clickable-header {
   }
 }
 
-// fixes for the extra long ULURP name & numbers to prevent bleeding into the BBL numbers
-.text-tiny .center-content {
-  display: flex;
-  justify-content: center;
+// enables text wrapping for the extra long ULURP name & numbers to prevent obscuring the BBL numbers
+
+.wrap-content {
+  max-width: fit-content;
+  margin:0px;
+  padding:0px;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  font-size: 0.7rem;
+}
+
+.wrap-content {
+  .label{
+    white-space: normal;
+  }
 }

--- a/client/app/templates/components/milestones/public-hearing.hbs
+++ b/client/app/templates/components/milestones/public-hearing.hbs
@@ -11,13 +11,13 @@
 <div class="text-tiny">
   {{#each @hearing.hearingActions as |action index|}}
     {{#if action.dcpName}}
-      <span class="{{center-lengthy-text action.dcpName}}">
-        <span class="label light-gray tiny-margin-bottom tiny-margin-right"
+      <div class="wrap-content">
+        <div class="label light-gray tiny-margin-bottom tiny-margin-right"
           data-test-hearing-actions-list="{{@hearing.disposition.id}}{{index}}">
           {{action.dcpName}}
           <small>{{action.dcpUlurpnumber}}</small>
-        </span>
-      </span>
+        </div>
+      </div>
     {{/if}}
   {{/each}}
 </div>

--- a/client/app/templates/components/project-milestone.hbs
+++ b/client/app/templates/components/project-milestone.hbs
@@ -44,7 +44,11 @@
     </p>
 
     {{#if milestone.outcome}}
-      <span class="label dark-gray" style="font-size: 0.7rem;">{{milestone.outcome}}</span>
+      <div class="wrap-content">
+        <div class="label dark-gray">
+          {{milestone.outcome}}
+        </div>
+      </div>
     {{/if}}
 
     <ul class="milestone-links">
@@ -125,13 +129,13 @@
                         <div class="text-tiny">
                           {{#each vote.voteActions as |action index|}}
                             {{#if action.dcpName}}
-                              <span class="{{center-lengthy-text action.dcpName}}">
-                                <span class="label light-gray tiny-margin-bottom tiny-margin-right"
+                              <div class="wrap-content">
+                                <div class="label light-gray tiny-margin-bottom tiny-margin-right"
                                   data-test-vote-actions-list="{{vote.disposition.id}}{{index}}">
                                   {{action.dcpName}}
                                   <small>{{action.dcpUlurpnumber}}</small>
-                                </span>
-                              </span>
+                                </div>
+                              </div>
                             {{/if}}
                           {{/each}}
                         </div>
@@ -161,13 +165,13 @@
                         <div class="text-tiny">
                           {{#each vote.voteActions as |action index|}}
                             {{#if action.dcpName}}
-                              <span class="{{center-lengthy-text action.dcpName}}">
-                                <span class="label light-gray tiny-margin-bottom tiny-margin-right"
+                              <div class="wrap-content">
+                                <div class="label light-gray tiny-margin-bottom tiny-margin-right"
                                   data-test-vote-actions-list="{{vote.disposition.id}}{{index}}">
                                   {{action.dcpName}}
                                   <small>{{action.dcpUlurpnumber}}</small>
-                                </span>
-                              </span>
+                                </div>
+                              </div>
                             {{/if}}
                           {{/each}}
                         </div>

--- a/client/app/templates/components/to-review-project-card.hbs
+++ b/client/app/templates/components/to-review-project-card.hbs
@@ -131,12 +131,12 @@
                     <small data-test-hearing-actions-list="{{hearing.disposition.id}}">
                       {{#each hearing.hearingActions as |action index| ~}}
                         {{#if action.dcpName}}
-                          <span class="{{center-lengthy-text action.dcpName}}">
-                            <span class="label light-gray tiny-margin-bottom tiny-margin-right">
+                          <div class="wrap-content">
+                            <div class="label light-gray tiny-margin-bottom tiny-margin-right">
                               {{action.dcpName}}
                               <small>{{action.dcpUlurpnumber}}</small>
-                            </span>
-                          </span>
+                            </div>
+                          </div>
                         {{/if}}
                       {{~/each}}
                     </small>

--- a/client/app/templates/components/upcoming-project-card.hbs
+++ b/client/app/templates/components/upcoming-project-card.hbs
@@ -118,12 +118,12 @@
                     <small data-test-hearing-actions-list="{{hearing.disposition.id}}">
                       {{#each hearing.hearingActions as |action index| ~}}
                         {{#if action.dcpName}}
-                          <span class="{{center-lengthy-text action.dcpName}}">
-                            <span class="label light-gray tiny-margin-bottom tiny-margin-right">
+                          <div class="wrap-content">
+                            <div class="label light-gray tiny-margin-bottom tiny-margin-right">
                               {{action.dcpName}}
                               <small>{{action.dcpUlurpnumber}}</small>
-                            </span>
-                          </span>
+                            </div>
+                          </div>
                         {{/if}}
                       {{~/each}}
                     </small>

--- a/client/app/templates/my-projects/assignment/hearing/add.hbs
+++ b/client/app/templates/my-projects/assignment/hearing/add.hbs
@@ -161,12 +161,12 @@
                       <div class="text-tiny" data-test-hearing-actions-list="{{hearing.disposition.id}}">
                         {{#each hearing.hearingActions as |action index| ~}}
                           {{#if action.dcpName}}
-                            <span class="{{center-lengthy-text action.dcpName}}">
-                              <span class="label light-gray tiny-margin-bottom tiny-margin-right">
+                            <div class="wrap-content">
+                              <div class="label light-gray tiny-margin-bottom tiny-margin-right">
                                 {{action.dcpName}}
                                 <small>{{action.dcpUlurpnumber}}</small>
-                              </span>
-                            </span>
+                              </div>
+                            </div>
                           {{/if}}
                         {{~/each}}
                       </div>

--- a/client/app/templates/my-projects/assignment/recommendations/add.hbs
+++ b/client/app/templates/my-projects/assignment/recommendations/add.hbs
@@ -61,12 +61,12 @@
                       <small data-test-hearing-actions-list="{{hearing.disposition.id}}">
                         {{#each hearing.hearingActions as |action index| ~}}
                           {{#if action.dcpName}}
-                            <span class="{{center-lengthy-text action.dcpName}}">
-                              <span class="label light-gray tiny-margin-bottom tiny-margin-right">
+                            <div class="wrap-content">
+                              <div class="label light-gray tiny-margin-bottom tiny-margin-right">
                                 {{action.dcpName}}
                                 <small>{{action.dcpUlurpnumber}}</small>
-                              </span>
-                            </span>
+                              </div>
+                            </div>
                           {{/if}}
                         {{~/each}}
                       </small>
@@ -558,12 +558,12 @@
                           <small data-test-hearing-actions-list="{{hearing.disposition.id}}">
                             {{#each hearing.hearingActions as |action index| ~}}
                               {{#if action.dcpName}}
-                                <span class="{{center-lengthy-text action.dcpName}}">
-                                  <span class="label light-gray tiny-margin-bottom tiny-margin-right">
+                                <div class="wrap-content">
+                                  <div class="label light-gray tiny-margin-bottom tiny-margin-right">
                                     {{action.dcpName}}
                                     <small>{{action.dcpUlurpnumber}}</small>
-                                  </span>
-                                </span>
+                                  </div>
+                                </div>
                               {{/if}}
                             {{~/each}}
                           </small>

--- a/client/app/templates/show-project.hbs
+++ b/client/app/templates/show-project.hbs
@@ -62,12 +62,12 @@
             <p class="cell auto tag-child-left">
               {{#if model.dcpPublicstatusSimp}}
                 <strong>Status:</strong>
-                  <span class="label dark-gray publicstatus-{{dasherize model.dcpPublicstatusSimp}}">
-                    {{model.dcpPublicstatusSimp}}
-                    <sup>
-                      {{icon-tooltip tip='“Status” identifies a project’s stage in the application process. "Noticed" refers to applications where notice has been given that an application will certify no sooner than 30 days per the City Charter requirement. In "Public Review” refers to applications that have graduated to the public review process. “Completed” refers to applications that have been Approved, Disapproved, Withdrawn or Terminated.'}}
-                    </sup>
-                  </span>
+                <span class="label dark-gray publicstatus-{{dasherize model.dcpPublicstatusSimp}}">
+                  {{model.dcpPublicstatusSimp}}
+                  <sup>
+                    {{icon-tooltip tip='“Status” identifies a project’s stage in the application process. "Noticed" refers to applications where notice has been given that an application will certify no sooner than 30 days per the City Charter requirement. In "Public Review” refers to applications that have graduated to the public review process. “Completed” refers to applications that have been Approved, Disapproved, Withdrawn or Terminated.'}}
+                  </sup>
+                </span>
               {{/if}}
             </p>
             {{#if (or model.dcpUlurpNonulurp model.dcpApplicability)}}
@@ -83,12 +83,12 @@
               </p>
               <p class="cell auto tag-child-right">
                 {{#if model.dcpUlurpNonulurp}}
-                <span class="label dark-gray tag-span">
-                  {{~model.dcpUlurpNonulurp~}}
-                  <sup>
-                    {{icon-tooltip tip='Uniform Land Use Review Procedure (ULURP) is a procedure whereby applications affecting the land use of the city are publicly reviewed within mandated time frames. Key participants in the process are the Department of City Planning (DCP), the City Planning Commission (CPC), Community Boards, the Borough Presidents, the Borough Boards, the City Council and the Mayor.'}}
-                  </sup>
-                </span>
+                  <span class="label dark-gray tag-span">
+                    {{~model.dcpUlurpNonulurp~}}
+                    <sup>
+                      {{icon-tooltip tip='Uniform Land Use Review Procedure (ULURP) is a procedure whereby applications affecting the land use of the city are publicly reviewed within mandated time frames. Key participants in the process are the Department of City Planning (DCP), the City Planning Commission (CPC), Community Boards, the Borough Presidents, the Borough Boards, the City Council and the Mayor.'}}
+                    </sup>
+                  </span>
                 {{/if}}
               </p>
             {{/if}}


### PR DESCRIPTION
### Summary
Previously, a helper method was used to prevent the ULURP names from obscuring the BBLs list but this did nto work effectively in all cases. Instead, I rebuilt part of the markup to enable word wrapping.

#### Tasks/Bug Numbers
 - Fixes [AB#9499](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/9499)

#### Before
![overlapping](https://user-images.githubusercontent.com/11340947/178323810-abed6e76-c6d6-44d8-bfb1-3472ccac26e5.png)

#### After
<img width="1046" alt="Screen Shot 2022-07-11 at 1 30 23 PM" src="https://user-images.githubusercontent.com/11340947/178323835-eaaf3f40-6fbc-4e9c-85a4-b40df670f1f7.png">
