### PR TITLE
965 – Remove map tooltip on hover

### DIFF
--- a/client/app/templates/components/projects-map-data.hbs
+++ b/client/app/templates/components/projects-map-data.hbs
@@ -11,11 +11,6 @@
   {{map.on 'click' (action 'handleMapClick')}}
   {{map.on 'mousemove' (action 'handleMouseMove')}}
 
-  {{#if highlightedFeature}}
-    <div class='map-tooltip' style="top:{{tooltipPoint.y}}px;left:{{tooltipPoint.x}}px;">
-      {{highlightedFeature.properties.dcp_projectname}} (<DateDisplay @date={{highlightedFeature.properties.dcpLastmilestonedate}} @outputFormat="MMMM, YYYY" />)
-    </div>
-  {{/if}}
 
   {{#if tilesLoading}}
     {{fa-icon icon='spinner' spin="true" size="5x" class="map-loading-spinner"}}

--- a/client/tests/integration/components/projects-map-data-test.js
+++ b/client/tests/integration/components/projects-map-data-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, triggerEvent, find } from '@ember/test-helpers';
+import { render, triggerEvent } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import Service from '@ember/service';
 import Evented from '@ember/object/evented';
@@ -34,29 +34,29 @@ module('Integration | Component | projects-map-data', function(hooks) {
     await triggerEvent('.mapbox-gl', 'click');
   });
 
-  test('it handles a mousemove event, sets tooltip', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    await render(hbs`
-      {{projects-map-data}}
-    `);
+  // test('it handles a mousemove event, sets tooltip', async function(assert) {
+  //   // Set any properties with this.set('myProperty', 'value');
+  //   await render(hbs`
+  //     {{projects-map-data}}
+  //   `);
 
-    this.mapboxEventStub = {
-      target: {
-        queryRenderedFeatures: () => [{
-          type: 'Feature',
-          geometry: {
-            type: 'Point',
-            coordinates: [0, 0],
-          },
-        }],
-      },
-      point: { x: 0, y: 0 },
-    };
+  //   this.mapboxEventStub = {
+  //     target: {
+  //       queryRenderedFeatures: () => [{
+  //         type: 'Feature',
+  //         geometry: {
+  //           type: 'Point',
+  //           coordinates: [0, 0],
+  //         },
+  //       }],
+  //     },
+  //     point: { x: 0, y: 0 },
+  //   };
 
-    await triggerEvent('.mapbox-gl', 'mousemove');
+  //   await triggerEvent('.mapbox-gl', 'mousemove');
 
-    assert.ok(find('.map-tooltip'));
-  });
+  //   assert.ok(find('.map-tooltip'));
+  // });
 
   test('it handles event actions', async function(assert) {
     this.owner.register('service:result-map-events', Service.extend(Evented));


### PR DESCRIPTION
Resolves AB[#965](https://dev.azure.com/NYCPlanning/ITD/_workitems/edit/965) by removing the tooltip when hovering over points on the map. The tooltip previously displayed the project name and last milestone date by making references to columns on Carto (source layer: project-centroids, pic related) which appear to have since been removed.

<img width="1237" alt="Screen Shot 2022-09-09 at 9 03 15 AM" src="https://user-images.githubusercontent.com/43344288/189356129-649069f9-e95f-40ea-b330-5aa9538367f6.png">
