### PR TITLE
Update netlify.toml to make sure deployments are kicked off

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,7 @@
   base = "client/"
   publish = "dist/"
   command = "yarn build --environment=production"
+  ignore = "false"
 
 [context.develop]
   environment = { HOST="https://zap-api-staging.herokuapp.com", NYCID_CLIENT_ID="lup-portal-staging", NYC_ID_HOST="https://accounts-nonprd.nyc.gov/account", MAINTENANCE_START='06/01/22 15:00', MAINTENANCE_END='06/01/22 16:00' }


### PR DESCRIPTION
### Summary
This adds a flag to netlify.toml that should fix issues we're having where deployments are being canceled because Netlify doesn't think there are any changes.
