### PR TITLE
11696 Identify Logged-In Users with No Projects

### DIFF
--- a/client/app/authenticators/zap-api-authenticator.js
+++ b/client/app/authenticators/zap-api-authenticator.js
@@ -36,6 +36,7 @@ export default class ZAPAuthenticator extends OAuth2ImplicitGrantAuthenticator {
       FS.identify(NYCIDUser.GUID, {
         displayName,
         email: mail,
+        zapSearchHasLoggedIn: true,
       });
     } catch (e) {
       throw new InvalidError([{ detail: e, message: 'FS.identify failed.' }]);

--- a/client/app/controllers/my-projects/archive.js
+++ b/client/app/controllers/my-projects/archive.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
+import { fsSetUserVars } from 'labs-zap-search/helpers/fs-set-user-vars';
 
 export default class MyProjectsReviewedController extends Controller {
   @service
@@ -9,6 +10,7 @@ export default class MyProjectsReviewedController extends Controller {
   // sort projects by `dcpProjectCompleted` descending
   @computed('model')
   get sortedAssignments() {
+    fsSetUserVars({ loggedInZapSearchUserHasProjects: true });
     return this.model.sortBy('project.dcpProjectcompleted').reverseObjects();
   }
 }

--- a/client/app/controllers/my-projects/reviewed.js
+++ b/client/app/controllers/my-projects/reviewed.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
+import { fsSetUserVars } from 'labs-zap-search/helpers/fs-set-user-vars';
 
 export default class MyProjectsReviewedController extends Controller {
   @service
@@ -11,6 +12,7 @@ export default class MyProjectsReviewedController extends Controller {
   get sortedAssignments() {
     const assignments = this.get('model');
     const assignmentsWithSortingProperty = [];
+    fsSetUserVars({ loggedInZapSearchUserHasProjects: true });
 
     // create new array of assignments
     assignments.forEach(function(assignment) {

--- a/client/app/controllers/my-projects/to-review.js
+++ b/client/app/controllers/my-projects/to-review.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
+import { fsSetUserVars } from 'labs-zap-search/helpers/fs-set-user-vars';
 
 export default class MyProjectsToReviewController extends Controller {
   @service
@@ -10,6 +11,7 @@ export default class MyProjectsToReviewController extends Controller {
   @computed('model')
   get sortedProjects() {
     const assignments = this.get('model');
+    fsSetUserVars({ loggedInZapSearchUserHasProjects: true });
     return assignments.sortBy('toReviewMilestonePlannedCompletionDate');
   }
 }

--- a/client/app/controllers/my-projects/upcoming.js
+++ b/client/app/controllers/my-projects/upcoming.js
@@ -1,6 +1,7 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
+import { fsSetUserVars } from 'labs-zap-search/helpers/fs-set-user-vars';
 
 export default class MyProjectsUpcomingController extends Controller {
   @service
@@ -10,6 +11,7 @@ export default class MyProjectsUpcomingController extends Controller {
   @computed('model')
   get sortedProjects() {
     const assignments = this.get('model');
+    fsSetUserVars({ loggedInZapSearchUserHasProjects: true });
     return assignments.sortBy('publicReviewPlannedStartDate');
   }
 }

--- a/client/app/helpers/fs-set-user-vars.js
+++ b/client/app/helpers/fs-set-user-vars.js
@@ -1,0 +1,13 @@
+import { helper } from '@ember/component/helper';
+import { InvalidError } from '@ember-data/adapter/error';
+
+export function fsSetUserVars(uservars) {
+  try {
+    // eslint-disable-next-line no-undef
+    FS.setUserVars(uservars);
+  } catch (e) {
+    throw new InvalidError([{ detail: e, message: 'FS.setUserVars failed.' }]);
+  }
+}
+
+export default helper(fsSetUserVars);


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
This adds a variable to record that a user has logged in to ZAP Search, and another variable to record that a logged in user has projects assigned to them.  It then sends this data to Fullstory.

#### Tasks/Bug Numbers
 - Completes [AB#11696](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/11696)


### Technical Explanation
Adds a helper function, which is triggered when get sortedProjects or sortedAssignments run, as they are only triggered when a user has projects assigned to them.

### Any other info you think would help a reviewer understand this PR?
