### PR TITLE
854 updated copy for no results message on filtered searches

### DIFF
--- a/client/app/templates/components/applied-filters-list.hbs
+++ b/client/app/templates/components/applied-filters-list.hbs
@@ -1,6 +1,6 @@
 <div class="no-results-message text-center dark-gray">
   <p class="medium-gray">{{fa-icon icon='search' size='4x'}}</p>
-  <h4>No results. The following filters are applied, which may be too specific or contradictory:</h4>
+  <h4>No Results. Please adjust your filters:</h4>
   {{#each currentFiltersNames as |name|}}
     <p>{{name}}</p>
   {{/each}}


### PR DESCRIPTION
### Summary
Updated messaging on filtered results that return no matches to be more general. The current messaging, `No results. The following filters are applied, which may be too specific or contradictory`, can confuse users. Changing the copy to a more general message, `No Results. Please adjust your filters:`, would address the issue.

#### Tasks/Bug Numbers
 - Fixes [AB#854](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/854)
