### PR TITLE
13953 Non-public projects showing up in ZAP Search

### DIFF
--- a/server/src/project/project.service.ts
+++ b/server/src/project/project.service.ts
@@ -132,12 +132,12 @@ const QUERY_TEMPLATES = {
     }),
 
   "zoning-resolutions": queryParamValue =>
-    queryParamValue
+    "(" + queryParamValue
       .map(
         value =>
           `dcp_dcp_project_dcp_projectaction_project/any(o:o/_dcp_zoningresolution_value eq '${value}')`
       )
-      .join(" or "),
+      .join(" or ") + ")",
 
   boroughs: queryParamValue =>
     equalsAnyOf(


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->


### Summary
Zoning Resolutions filter uses 'or' but was not properly enclosed in parentheses, meaning any ZR after the first would show all results that matched that ZR, regardless if it met the other filters.

#### Tasks/Bug Numbers
 - Fixes [AB#13953](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/13953)

### Technical Explanation
I put in parenthesis.

### Any other info you think would help a reviewer understand this PR?
