### PR TITLE
14356 Inaccurate AM/PM time designation when scheduling a Borough President Hearing

### DIFF
--- a/client/app/components/date-time-picker.js
+++ b/client/app/components/date-time-picker.js
@@ -88,7 +88,7 @@ export default class DateTimePickerComponent extends Component {
       let numberHour;
 
       if (this.timeOfDay === 'PM') {
-        const pmHour = parseInt(this.hour, 10) + 12;
+        const pmHour = parseInt(this.hour, 10) === 12 ? 12 : parseInt(this.hour, 10) + 12;
         numberHour = pmHour;
       } else {
         numberHour = this.hour;


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Updated timeofday to not add 12 + 12

#### Tasks/Bug Numbers
 - Fixes [AB#14356](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/14356)
