### PR TITLE
14356 Inaccurate AM/PM time designation when scheduling a Borough President Hearing

### DIFF
--- a/client/app/components/date-time-picker.js
+++ b/client/app/components/date-time-picker.js
@@ -90,6 +90,8 @@ export default class DateTimePickerComponent extends Component {
       if (this.timeOfDay === 'PM') {
         const pmHour = parseInt(this.hour, 10) === 12 ? 12 : parseInt(this.hour, 10) + 12;
         numberHour = pmHour;
+      } else if (parseInt(this.hour, 10) === 12) {
+        numberHour = 0;
       } else {
         numberHour = this.hour;
       }


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Should actually fix the issue this time.

#### Tasks/Bug Numbers
 - Fixes [AB#14356](https://dev.azure.com/NYCPlanning/cc280b0d-40a0-4689-b852-2e6247f1af50/_workitems/edit/14356)
