### PR TITLE
Fix class name in to-review-project-card.hbs

### DIFF
--- a/client/app/templates/components/to-review-project-card.hbs
+++ b/client/app/templates/components/to-review-project-card.hbs
@@ -4,7 +4,7 @@
 >
   <div class="grid-x grid-x-small-gutters">
     <div class="cell large-4 xlarge-5">
-      <h3 class="tiny-margin-bottxrom">
+      <h3 class="tiny-margin-bottom">
         {{#link-to 'show-project' assignment.project.id}}<span data-test-project-profile-button="{{assignment.project.id}}">{{assignment.project.dcpProjectname}}</span>{{/link-to}}
         <small class="dark-gray">{{assignment.project.dcpUlurpNonulurp}}</small>
       </h3>


### PR DESCRIPTION
Addresses AB#3233. Just fixing a typo in a classname. The class that should now be applied is just a small margin used elsewhere so impact should be minimal and improve visual consistency.