### PR TITLE
1499 Map Shows Multiple Markers for a Single BBL

### DIFF
--- a/server/src/project/geometry/geometry.service.ts
+++ b/server/src/project/geometry/geometry.service.ts
@@ -18,7 +18,7 @@ const METERS_TO_FEET_FACTOR = 3.28084;
 const QUERIES = {
   DTM_BLOCK_CENTROIDS: `
     SELECT the_geom, the_geom_webmercator, cartodb_id, concat(borocode, LPAD(block::text, 5, '0')) as block 
-    FROM dtm_block_centroids_v20201106
+    FROM dof_dtm_block_centroids_deduped_by_boroblock
   `,
 
   centroidsFor(blocks) {


### PR DESCRIPTION
I have created a [new table in Carto](https://nycplanning-web.carto.com/u/planninglabs/dataset/dof_dtm_block_centroids_deduped_by_boroblock) which has the contents of the `dof_dtm_block_centroids` table, with the following changes:
 - Any duplicate combinations of Boro and Block have been removed
 - `boro` has been renamed `borocode` to match the naming conventions of the previously used table

This fixes #1499, where the map showed multiple markers to represent the same block.
