### PR TITLE
1525/document only pdf

### DIFF
--- a/server/src/document/document.service.ts
+++ b/server/src/document/document.service.ts
@@ -81,6 +81,9 @@ function throwNoDocumentError(errorMessage) {
   );
 }
 
+// Only PDF files are officially supported.
+// Other formats, especially xml-based microsoft formats like .pptx,
+// may cause download errors
 @Injectable()
 export class DocumentService {
   constructor(


### PR DESCRIPTION
Comment that files other than pdf may cause download errors
closes #1525
