### PR TITLE
1559 Add informational modal to ZAP Search homepage

### DIFF
--- a/client/app/components/info-modal.js
+++ b/client/app/components/info-modal.js
@@ -1,0 +1,16 @@
+import Component from '@ember/component';
+import { action } from '@ember/object';
+
+export default class InfoModalComponent extends Component {
+  open = !window.localStorage.hideMessage;
+
+  dontShowModalAgain = false;
+
+  @action
+  closeModal() {
+    this.set('open', false);
+    if (this.dontShowModalAgain) {
+      window.localStorage.hideMessage = true;
+    }
+  }
+}

--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -65,6 +65,7 @@ $completed-color: #a6cee3;
 @import 'modules/_m-noui';
 @import 'modules/_m-project-filters';
 @import 'modules/_m-reveal-modal';
+@import 'modules/_m-info-modal';
 @import 'modules/_m-search';
 @import 'modules/_m-site-header';
 @import 'modules/_m-statuses';

--- a/client/app/styles/modules/_m-info-modal.scss
+++ b/client/app/styles/modules/_m-info-modal.scss
@@ -1,0 +1,42 @@
+// --------------------------------------------------
+// Module: Info Modal
+// --------------------------------------------------
+
+#info-modal-container {
+  z-index: 3;
+}
+
+.info-overlay {
+  padding: 1rem;
+
+  @include breakpoint(medium) {
+    padding: 4rem 1rem;
+    position: absolute;
+  }
+}
+
+.info-overlay-target {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.info-modal {
+  border: 3px solid $dcp-orange;
+  border-radius: 10px;
+  box-shadow: 0 0 0 rem-calc(4) rgba(0,0,0,0.1);
+  top: 30%;
+  background-color: $orange-white;
+  height: unset;
+  min-height: unset;
+  @include breakpoint(medium) {
+    height: unset;
+    padding: 4rem;
+  }
+
+  &:focus {
+    outline: none;
+  }
+}

--- a/client/app/styles/modules/_m-info-modal.scss
+++ b/client/app/styles/modules/_m-info-modal.scss
@@ -27,7 +27,9 @@
   border: 3px solid $dcp-orange;
   border-radius: 10px;
   box-shadow: 0 0 0 rem-calc(4) rgba(0,0,0,0.1);
-  top: 30%;
+  top: 50%;
+  -ms-transform: translateY(-50%);
+  transform: translateY(-50%);
   background-color: #FBF0E9;
   height: unset;
   min-height: unset;

--- a/client/app/styles/modules/_m-info-modal.scss
+++ b/client/app/styles/modules/_m-info-modal.scss
@@ -28,7 +28,7 @@
   border-radius: 10px;
   box-shadow: 0 0 0 rem-calc(4) rgba(0,0,0,0.1);
   top: 30%;
-  background-color: $orange-white;
+  background-color: #FBF0E9;
   height: unset;
   min-height: unset;
   @include breakpoint(medium) {

--- a/client/app/styles/modules/_m-info-modal.scss
+++ b/client/app/styles/modules/_m-info-modal.scss
@@ -26,7 +26,7 @@
 .info-modal {
   border: 3px solid $dcp-orange;
   border-radius: 10px;
-  box-shadow: 0 0 0 rem-calc(4) rgba(0,0,0,0.1);
+  box-shadow: 0 4px 4px 0 rgba(0,0,0,0.1);
   top: 50%;
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);

--- a/client/app/templates/application.hbs
+++ b/client/app/templates/application.hbs
@@ -56,9 +56,11 @@
   {{/if}}
 </div>
 
+
 <div id="info-modal-container">
 </div>
-
+<div id="reveal-modal-container">
+</div>
 {{#ember-wormhole to="info-modal-container"}}
   {{info-modal}}
 {{/ember-wormhole}}

--- a/client/app/templates/application.hbs
+++ b/client/app/templates/application.hbs
@@ -56,8 +56,13 @@
   {{/if}}
 </div>
 
-<div id="reveal-modal-container">
+<div id="info-modal-container">
 </div>
+
+{{#ember-wormhole to="info-modal-container"}}
+  {{info-modal}}
+{{/ember-wormhole}}
+
 
 {{#if (string-includes currentRouteName "my-projects")}}
   <script type="text/javascript">!function(e,t,n){function a(){var e=t.getElementsByTagName("script")[0],n=t.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://beacon-v2.helpscout.net",e.parentNode.insertBefore(n,e)}if(e.Beacon=n=function(t,n,a){e.Beacon.readyQueue.push({method:t,options:n,data:a})},n.readyQueue=[],"complete"===t.readyState)return a();e.attachEvent?e.attachEvent("onload",a):e.addEventListener("load",a,!1)}(window,document,window.Beacon||function(){});</script><script type="text/javascript">window.Beacon('init', '9a027170-0976-46ac-afba-8d1322ef19d6')</script>

--- a/client/app/templates/components/info-modal.hbs
+++ b/client/app/templates/components/info-modal.hbs
@@ -13,7 +13,7 @@
 
       {{!-- Once the subscribe route exists, uncomment the row below and delete the row below that one --}}
       {{!-- <h4>Subscribe to <LinkTo @route="subscribe">ZAP Email notifications</LinkTo>. Get updates about community district and citywide projects.</h4> --}}
-      <h4>Subscribe to <LinkTo @route="statuses">ZAP Email notifications</LinkTo>. Get updates about community district and citywide projects.</h4>
+      <h4>Subscribe to <LinkTo @route="show-geography">ZAP Email notifications</LinkTo>. Get updates about community district and citywide projects.</h4>
       {{input type="checkbox" checked=this.dontShowModalAgain}}
       Don't show this message again
       <button {{action closeModal}} class="close-button" aria-label="Close modal" type="button">

--- a/client/app/templates/components/info-modal.hbs
+++ b/client/app/templates/components/info-modal.hbs
@@ -1,5 +1,5 @@
 {{#if open}}
-  <div class="reveal-overlay" style="display:block;">
+  <div class="reveal-overlay" style="display:block; background-color: rgba(241, 242, 244, 0.45)">
     <div class="reveal-overlay-target" {{action closeModal}}></div>
     <div
       class="reveal info-modal"

--- a/client/app/templates/components/info-modal.hbs
+++ b/client/app/templates/components/info-modal.hbs
@@ -1,0 +1,24 @@
+{{#if open}}
+  <div class="reveal-overlay" style="display:block;">
+    <div class="reveal-overlay-target" {{action closeModal}}></div>
+    <div
+      class="reveal info-modal"
+      role="dialog"
+      aria-hidden="false"
+      tabindex="-1"
+      style="display:block;"
+      data-test-info-modal
+    >
+      <h1>Subscribe and Get Notified.</h1>
+
+      {{!-- Once the subscribe route exists, uncomment the row below and delete the row below that one --}}
+      {{!-- <h4>Subscribe to <LinkTo @route="subscribe">ZAP Email notifications</LinkTo>. Get updates about community district and citywide projects.</h4> --}}
+      <h4>Subscribe to <LinkTo @route="statuses">ZAP Email notifications</LinkTo>. Get updates about community district and citywide projects.</h4>
+      {{input type="checkbox" checked=this.dontShowModalAgain}}
+      Don't show this message again
+      <button {{action closeModal}} class="close-button" aria-label="Close modal" type="button">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </div>
+  </div>
+{{/if}}

--- a/client/app/templates/components/info-modal.hbs
+++ b/client/app/templates/components/info-modal.hbs
@@ -11,9 +11,8 @@
     >
       <h1>Subscribe and Get Notified.</h1>
 
-      {{!-- Once the subscribe route exists, uncomment the row below and delete the row below that one --}}
-      {{!-- <h4>Subscribe to <LinkTo @route="subscribe">ZAP Email notifications</LinkTo>. Get updates about community district and citywide projects.</h4> --}}
-      <h4>Subscribe to <LinkTo @route="show-geography">ZAP Email notifications</LinkTo>. Get updates about community district and citywide projects.</h4>
+      <h4>Subscribe to <LinkTo @route="subscribe">ZAP Email notifications</LinkTo>. Get updates about community district and citywide projects.</h4>
+
       {{input type="checkbox" checked=this.dontShowModalAgain}}
       Don't show this message again
       <button {{action closeModal}} class="close-button" aria-label="Close modal" type="button">


### PR DESCRIPTION
- [x] Add a modal that users see when they visit ZAP Search that directs them to the new subscriptions page
- [x] Designs can be found [here](https://www.figma.com/design/1HrOm1tkJ3lowQhrSRkPLs/ZAP-Listserv%3A-Wireframes-and-User-Stories?node-id=353-74&node-type=frame&t=U8AKDO14tXxrlzv8-0) but we don't need to follow designs exactly if there is an existing modal component in ZAP Search we can use. However, copy should be as seen in designs
- [x] User can dismiss the modal and it doesn't reappear when navigating between pages in the app
- [x] Modal has "Do not show this message again" checkbox. If checked, the user should not see the message again when they visit the app again in the same browser.
- [x] Link to `/subscribe" page

The route to the subscribe page does not exist, and so linking to the subscribe route completely breaks the site.  Once subscribe route exists, I can switch the link, and it will complete #1559 
