### PR TITLE
1566 Send confirmation email to new subscriber

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -38,6 +38,7 @@
     "@sentry/nestjs": "^8.35.0",
     "@sentry/profiling-node": "^8.35.0",
     "@sentry/wizard": "^3.34.2",
+    "@sendgrid/mail": "^8.1.4",
     "@turf/bbox": "^6.0.1",
     "@turf/buffer": "^5.1.5",
     "@turf/helpers": "^6.1.4",

--- a/server/src/subscriber/subscriber.controller.ts
+++ b/server/src/subscriber/subscriber.controller.ts
@@ -82,8 +82,10 @@ export class SubscriberController {
     const importConfirmation = await this.subscriberService.checkCreate(addToQueue.result[1]["job_id"], response, 0, CHECKS_BEFORE_FAIL, PAUSE_BETWEEN_CHECKS, errorInfo);
     
     // Send the confirmation email
-    await this.subscriberService.sendConfirmationEmail(request.body.email, this.sendgridEnvironment, request.body.subscriptions, id)
-
+    if (!importConfirmation.isError) { 
+      await this.subscriberService.sendConfirmationEmail(request.body.email, this.sendgridEnvironment, request.body.subscriptions, id);
+    }
+    
     return;
 
   }

--- a/server/src/subscriber/subscriber.module.ts
+++ b/server/src/subscriber/subscriber.module.ts
@@ -3,10 +3,11 @@ import { SubscriberController } from "./subscriber.controller";
 import { SubscriberService } from "./subscriber.service";
 import { ConfigModule } from "../config/config.module";
 import { Client } from "@sendgrid/client";
+import { MailService } from "@sendgrid/mail";
 
 @Module({
   imports: [ConfigModule],
-  providers: [SubscriberService, Client],
+  providers: [SubscriberService, Client, MailService],
   exports: [SubscriberService],
   controllers: [SubscriberController]
 })

--- a/server/src/subscriber/subscriber.service.ts
+++ b/server/src/subscriber/subscriber.service.ts
@@ -13,6 +13,8 @@ const validCustomFieldValues = [1] as const;
 export type CustomFieldValueTuple = typeof validCustomFieldValues;
 type CustomFieldValue = CustomFieldValueTuple[number];
 
+type ValidSubscriptionSet = {"K01": CustomFieldValue; "K02": CustomFieldValue; "K03": CustomFieldValue; "K04": CustomFieldValue; "K05": CustomFieldValue; "K06": CustomFieldValue; "K07": CustomFieldValue; "K08": CustomFieldValue; "K09": CustomFieldValue; "K10": CustomFieldValue; "K11": CustomFieldValue; "K12": CustomFieldValue; "K13": CustomFieldValue; "K14": CustomFieldValue; "K15": CustomFieldValue; "K16": CustomFieldValue; "K17": CustomFieldValue; "K18": CustomFieldValue; "X01": CustomFieldValue; "X02": CustomFieldValue; "X03": CustomFieldValue; "X04": CustomFieldValue; "X05": CustomFieldValue; "X06": CustomFieldValue; "X07": CustomFieldValue; "X08": CustomFieldValue; "X09": CustomFieldValue; "X10": CustomFieldValue; "X11": CustomFieldValue; "X12": CustomFieldValue; "M01": CustomFieldValue; "M02": CustomFieldValue; "M03": CustomFieldValue; "M04": CustomFieldValue; "M05": CustomFieldValue; "M06": CustomFieldValue; "M07": CustomFieldValue; "M08": CustomFieldValue; "M09": CustomFieldValue; "M10": CustomFieldValue; "M11": CustomFieldValue; "M12": CustomFieldValue; "Q01": CustomFieldValue; "Q02": CustomFieldValue; "Q03": CustomFieldValue; "Q04": CustomFieldValue; "Q05": CustomFieldValue; "Q06": CustomFieldValue; "Q07": CustomFieldValue; "Q08": CustomFieldValue; "Q09": CustomFieldValue; "Q10": CustomFieldValue; "Q11": CustomFieldValue; "Q12": CustomFieldValue; "Q13": CustomFieldValue; "Q14": CustomFieldValue; "R01": CustomFieldValue; "R02": CustomFieldValue; "R03": CustomFieldValue; "CW": CustomFieldValue}
+
 
 type HttpMethod = 'get'|'GET'|'post'|'POST'|'put'|'PUT'|'patch'|'PATCH'|'delete'|'DELETE';
 
@@ -155,7 +157,7 @@ export class SubscriberService {
    * @param {string} id - The id needed for confirmation
    * @returns {object}
    */
-   async sendConfirmationEmail(email: string, environment: string, subscriptions: object, id: string) {
+   async sendConfirmationEmail(email: string, environment: string, subscriptions: ValidSubscriptionSet, id: string) {
       // https://github.com/sendgrid/sendgrid-nodejs/blob/main/docs/use-cases/transactional-templates.md
       const msg = {
         to: email,
@@ -182,7 +184,7 @@ export class SubscriberService {
    * @param {object} subscriptions - The subscriptions to validate.
    * @returns {boolean}
    */
-  validateSubscriptions(subscriptions: object) {
+  validateSubscriptions(subscriptions: ValidSubscriptionSet) {
     if (!subscriptions)
       return false;
       
@@ -220,7 +222,7 @@ export class SubscriberService {
    * @param {object} subscriptions - The set of CDs the user is subscribing to
    * @returns {boolean}
    */
-  private convertSubscriptionsToHandlebars(subscriptions: object) {
+  private convertSubscriptionsToHandlebars(subscriptions: ValidSubscriptionSet) {
     var handlebars = { "citywide": false, "boroughs": [] }
     const boros = {
       "K": "Brooklyn",

--- a/server/src/subscriber/subscriber.service.ts
+++ b/server/src/subscriber/subscriber.service.ts
@@ -126,7 +126,6 @@ export class SubscriberService {
 
     const confirmationRequest = {
       url: `/v3/marketing/contacts/imports/${importId}`,
-      // method:<HttpMethod> 'GET',
       method:<HttpMethod> 'GET',
     }
 
@@ -214,6 +213,40 @@ export class SubscriberService {
    */
   private validateSubscriptionValue(value: number): value is CustomFieldValue {
     return validCustomFieldValues.includes(value as CustomFieldValue);
+  }
+
+  /**
+   * Convert the uploaded subscriptions object into a format for Handlebars to use in the confirmation email
+   * @param {object} subscriptions - The set of CDs the user is subscribing to
+   * @returns {boolean}
+   */
+  private convertSubscriptionsToHandlebars(subscriptions: object) {
+    var handlebars = { "citywide": false, "boroughs": [] }
+    const boros = {
+      "K": "Brooklyn",
+      "X": "Bronx",
+      "M": "Manhattan",
+      "Q": "Queens",
+      "R": "Staten Island"
+    }
+    for (const [key, value] of Object.entries(subscriptions)) {
+      if (value === 1) {
+        if (key === "CW") {
+          handlebars.citywide = true;
+        } else if (boros[key[0]]) {
+          const i = handlebars.boroughs.findIndex((boro) => boro.name === boros[key[0]]);
+            if (i === -1) {
+              handlebars.boroughs.push({
+                "name": boros[key[0]],
+                "communityBoards": [parseInt(key.slice(-2))]
+              })
+            } else {
+              handlebars.boroughs[i]["communityBoards"].push(parseInt(key.slice(-2)))
+            }
+        }
+      }
+    }
+    return handlebars;
   }
 
 }

--- a/server/src/subscriber/subscriber.service.ts
+++ b/server/src/subscriber/subscriber.service.ts
@@ -13,8 +13,7 @@ const validCustomFieldValues = [1] as const;
 export type CustomFieldValueTuple = typeof validCustomFieldValues;
 type CustomFieldValue = CustomFieldValueTuple[number];
 
-type ValidSubscriptionSet = {"K01": CustomFieldValue; "K02": CustomFieldValue; "K03": CustomFieldValue; "K04": CustomFieldValue; "K05": CustomFieldValue; "K06": CustomFieldValue; "K07": CustomFieldValue; "K08": CustomFieldValue; "K09": CustomFieldValue; "K10": CustomFieldValue; "K11": CustomFieldValue; "K12": CustomFieldValue; "K13": CustomFieldValue; "K14": CustomFieldValue; "K15": CustomFieldValue; "K16": CustomFieldValue; "K17": CustomFieldValue; "K18": CustomFieldValue; "X01": CustomFieldValue; "X02": CustomFieldValue; "X03": CustomFieldValue; "X04": CustomFieldValue; "X05": CustomFieldValue; "X06": CustomFieldValue; "X07": CustomFieldValue; "X08": CustomFieldValue; "X09": CustomFieldValue; "X10": CustomFieldValue; "X11": CustomFieldValue; "X12": CustomFieldValue; "M01": CustomFieldValue; "M02": CustomFieldValue; "M03": CustomFieldValue; "M04": CustomFieldValue; "M05": CustomFieldValue; "M06": CustomFieldValue; "M07": CustomFieldValue; "M08": CustomFieldValue; "M09": CustomFieldValue; "M10": CustomFieldValue; "M11": CustomFieldValue; "M12": CustomFieldValue; "Q01": CustomFieldValue; "Q02": CustomFieldValue; "Q03": CustomFieldValue; "Q04": CustomFieldValue; "Q05": CustomFieldValue; "Q06": CustomFieldValue; "Q07": CustomFieldValue; "Q08": CustomFieldValue; "Q09": CustomFieldValue; "Q10": CustomFieldValue; "Q11": CustomFieldValue; "Q12": CustomFieldValue; "Q13": CustomFieldValue; "Q14": CustomFieldValue; "R01": CustomFieldValue; "R02": CustomFieldValue; "R03": CustomFieldValue; "CW": CustomFieldValue}
-
+type ValidSubscriptionSet = Record<CustomFieldName, CustomFieldValue>;
 
 type HttpMethod = 'get'|'GET'|'post'|'POST'|'put'|'PUT'|'patch'|'PATCH'|'delete'|'DELETE';
 

--- a/server/src/subscriber/subscriber.service.ts
+++ b/server/src/subscriber/subscriber.service.ts
@@ -164,13 +164,12 @@ export class SubscriberService {
         templateId: 'd-3684647ef2b242d8947b65b20497baa0',
         dynamicTemplateData: {
           "id": id,
+          "domain": environment === "production" ? "zap.planning.nyc.gov" : "zap-staging.planninglabs.nyc",
           "subscriptions": this.convertSubscriptionsToHandlebars(subscriptions)
         }
       }
       this.mailer.send(msg)
         .then((response) => {
-          // console.log(response[0].statusCode)
-          // console.log(response[0].headers)
           return {isError: false, statusCode: response[0].statusCode}
         })
         .catch((error) => {

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1265,6 +1265,14 @@
     "@sendgrid/helpers" "^8.0.0"
     axios "^1.6.8"
 
+"@sendgrid/client@^8.1.4":
+  version "8.1.4"
+  resolved "https://registry.yarnpkg.com/@sendgrid/client/-/client-8.1.4.tgz#4db39e49d8ed732169d73b5d5c94d2b11907970d"
+  integrity sha512-VxZoQ82MpxmjSXLR3ZAE2OWxvQIW2k2G24UeRPr/SYX8HqWLV/8UBN15T2WmjjnEb5XSmFImTJOKDzzSeKr9YQ==
+  dependencies:
+    "@sendgrid/helpers" "^8.0.0"
+    axios "^1.7.4"
+
 "@sendgrid/helpers@^8.0.0":
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/@sendgrid/helpers/-/helpers-8.0.0.tgz#f74bf9743bacafe4c8573be46166130c604c0fc1"
@@ -1449,6 +1457,13 @@
     xcode "3.0.1"
     xml-js "^1.6.11"
     yargs "^16.2.0"
+"@sendgrid/mail@^8.1.4":
+  version "8.1.4"
+  resolved "https://registry.yarnpkg.com/@sendgrid/mail/-/mail-8.1.4.tgz#0ba72906685eae1a1ef990cca31e962f1ece6928"
+  integrity sha512-MUpIZykD9ARie8LElYCqbcBhGGMaA/E6I7fEcG7Hc2An26QJyLtwOaKQ3taGp8xO8BICPJrSKuYV4bDeAJKFGQ==
+  dependencies:
+    "@sendgrid/client" "^8.1.4"
+    "@sendgrid/helpers" "^8.0.0"
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
@@ -3666,7 +3681,7 @@ axios@^0.21.1:
   dependencies:
     follow-redirects "^1.10.0"
 
-axios@^1.6.8:
+axios@^1.6.8, axios@^1.7.4:
   version "1.7.7"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.7.tgz#2f554296f9892a72ac8d8e4c5b79c14a91d0a47f"
   integrity sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Send confirmation email to new subscribers when they are successfully signed up.

- [x] Once SendGrid contact import job is completed, send confirmation email to new subscriber
- [x] Email should follow [designs in Figma](https://www.figma.com/design/1HrOm1tkJ3lowQhrSRkPLs/ZAP-Listserv%3A-Wireframes-and-User-Stories?node-id=660-232&node-type=frame&t=anCCmmEHN6kABnCM-0)
- [x] Email content should list what user selected - All CDs grouped by borough as well as citywide
- [x] "Confirm" button should link back to page in ZAP Search for confirming subscription. Path will be `/subscribers/<uuid>/confirm`.
 
* Dependent on #1564 

#### Tasks/Bug Numbers
Completes #1566 

Email link needs to be updated once we have a URL for "Modify Subscriptions".

Code for the email is currently not in the repo, can be seen/edited here: https://mc.sendgrid.com/dynamic-templates/d-3684647ef2b242d8947b65b20497baa0/version/62d2fdea-926f-4443-970d-bf8c5f88474d/editor