### PR TITLE
1550 confirm patch endpoint

### DIFF
--- a/server/src/subscriber/subscriber.controller.ts
+++ b/server/src/subscriber/subscriber.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Req, Res } from "@nestjs/common";
+import { Controller, Post, Patch, Req, Res, Param, Get } from "@nestjs/common";
 import { ConfigService } from "../config/config.service";
 import { SubscriberService } from "./subscriber.service";
 import { Request } from "express";
@@ -88,5 +88,30 @@ export class SubscriberController {
     
     return;
 
+  }
+
+  @Patch("/subscribers/:id")
+  async update(@Param("id") id, @Req() request: Request, @Res() response) {
+    const email = await this.subscriberService.getUserById(id);
+    // get user email by id
+    
+    if(email.isError){ 
+      response.status(email.code).send({errors: email.response.body.errors})
+      return;
+    }
+    // if error, send error back
+
+    const updatedContact = await this.subscriberService.update(
+      this.sendgridEnvironment,
+      email.email,
+      {
+        "confirmed": 1
+      }
+    );
+    // send update request to confirm
+
+
+      // based on that success or return error
+    response.send(updatedContact);
   }
 }

--- a/server/src/subscriber/subscriber.service.ts
+++ b/server/src/subscriber/subscriber.service.ts
@@ -5,11 +5,11 @@ import { MailService } from "@sendgrid/mail";
 import crypto from 'crypto';
 import * as Sentry from "@sentry/nestjs";
 
-const validCustomFieldNames = ["K01", "K02", "K03", "K04", "K05", "K06", "K07", "K08", "K09", "K10", "K11", "K12", "K13", "K14", "K15", "K16", "K17", "K18", "X01", "X02", "X03", "X04", "X05", "X06", "X07", "X08", "X09", "X10", "X11", "X12", "M01", "M02", "M03", "M04", "M05", "M06", "M07", "M08", "M09", "M10", "M11", "M12", "Q01", "Q02", "Q03", "Q04", "Q05", "Q06", "Q07", "Q08", "Q09", "Q10", "Q11", "Q12", "Q13", "Q14", "R01", "R02", "R03", "CW"] as const;
+const validCustomFieldNames = ["confirmed", "K01", "K02", "K03", "K04", "K05", "K06", "K07", "K08", "K09", "K10", "K11", "K12", "K13", "K14", "K15", "K16", "K17", "K18", "X01", "X02", "X03", "X04", "X05", "X06", "X07", "X08", "X09", "X10", "X11", "X12", "M01", "M02", "M03", "M04", "M05", "M06", "M07", "M08", "M09", "M10", "M11", "M12", "Q01", "Q02", "Q03", "Q04", "Q05", "Q06", "Q07", "Q08", "Q09", "Q10", "Q11", "Q12", "Q13", "Q14", "R01", "R02", "R03", "CW"] as const;
 export type CustomFieldNameTuple = typeof validCustomFieldNames;
 type CustomFieldName = CustomFieldNameTuple[number];
 
-const validCustomFieldValues = [1] as const;
+const validCustomFieldValues = [0, 1] as const;
 export type CustomFieldValueTuple = typeof validCustomFieldValues;
 type CustomFieldValue = CustomFieldValueTuple[number];
 
@@ -215,15 +215,20 @@ export class SubscriberService {
    * @returns {object}
    */
   async update(environment: string, email: string, custom_fields: object) {
-
     var updated_custom_fields = Object.entries(custom_fields).reduce((acc, curr) => ({ ...acc, [`zap_${environment}_${curr[0]}`]: curr[1] }), {})
 
     const request = {
       url: `/v3/marketing/contacts`,
       method: <HttpMethod>'PUT',
-      body: { "contacts": [{ "email": email, "custom_fields": updated_custom_fields }] }
+      body: {
+        "contacts": [{
+          "email": email,
+          "custom_fields": updated_custom_fields
+        }]
+      }
     }
 
+    // https://www.twilio.com/docs/sendgrid/api-reference/contacts/add-or-update-a-contact
     try {
       const result = await this.client.request(request);
       return { isError: false, result: result };

--- a/server/src/subscriber/subscriber.service.ts
+++ b/server/src/subscriber/subscriber.service.ts
@@ -215,7 +215,7 @@ export class SubscriberService {
    * @returns {object}
    */
   async update(environment: string, email: string, custom_fields: object) {
-    var updated_custom_fields = Object.entries(custom_fields).reduce((acc, curr) => ({ ...acc, [`zap_${environment}_${curr[0]}`]: curr[1] }), {})
+    const updatedCustomFields = Object.entries(custom_fields).reduce((acc, curr) => ({ ...acc, [`zap_${environment}_${curr[0]}`]: curr[1] }), {})
 
     const request = {
       url: `/v3/marketing/contacts`,
@@ -223,7 +223,7 @@ export class SubscriberService {
       body: {
         "contacts": [{
           "email": email,
-          "custom_fields": updated_custom_fields
+          "custom_fields": updatedCustomFields
         }]
       }
     }


### PR DESCRIPTION
Closes https://github.com/NYCPlanning/labs-zap-search/issues/1550

I tested it with the following request body in Postman:

```
{ 
    "subscriptions": {
        "confirmed": 1
    }
}
```

and with a `zap_staging_id` pulled from Sendgrid contacts. 