### PR TITLE
1572 Subscription Confirmation Page

### DIFF
--- a/client/app/router.js
+++ b/client/app/router.js
@@ -29,6 +29,7 @@ Router.map(function() { // eslint-disable-line
   this.route('show-geography', { path: '/projects' });
   this.route('disclaimer');
   if (config.showAlerts) { this.route('statuses'); }
+  this.route('subscription-confirmation', { path: '/subscribers/:id/confirm' });
   this.route('not-found', { path: '/*path' });
   this.route('oops');
   this.route('my-projects', function() {

--- a/client/app/routes/subscription-confirmation.js
+++ b/client/app/routes/subscription-confirmation.js
@@ -1,0 +1,53 @@
+import Route from '@ember/routing/route';
+import fetch from 'fetch';
+import ENV from 'labs-zap-search/config/environment';
+
+export default Route.extend({
+  convertSubscriptionsToHandlebars(subscriptions) {
+    var handlebars = { "citywide": false, "boroughs": [] }
+    const boros = {
+      "K": "Brooklyn",
+      "X": "Bronx",
+      "M": "Manhattan",
+      "Q": "Queens",
+      "R": "Staten Island"
+    }
+    for (const [key, value] of Object.entries(subscriptions)) {
+      if (value === 1) {
+        if (key === "CW") {
+          handlebars.citywide = true;
+        } else if (boros[key[0]]) {
+          const i = handlebars.boroughs.findIndex((boro) => boro.name === boros[key[0]]);
+            if (i === -1) {
+              handlebars.boroughs.push({
+                "name": boros[key[0]],
+                "communityBoards": [parseInt(key.slice(-2))]
+              })
+            } else {
+              handlebars.boroughs[i]["communityBoards"].push(parseInt(key.slice(-2)))
+            }
+        }
+      }
+    }
+    return handlebars;
+  },
+  
+  async model({ id }) {
+    // No need to await for this to finish before making the next request
+    fetch(`${ENV.host}/subscribers/${id}`, {
+      method: 'PATCH',
+      headers: {
+      'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ subscriptions: { confirmed: 1 } }),
+    })
+
+    // Go directly into getting the subscriptions
+    const response = await fetch(`${ENV.host}/subscribers/${id}`);
+
+    const body = await response.json();
+    if (!response.ok) throw await response.json();
+
+    return this.convertSubscriptionsToHandlebars(body);
+  }
+});

--- a/client/app/templates/subscription-confirmation.hbs
+++ b/client/app/templates/subscription-confirmation.hbs
@@ -1,0 +1,29 @@
+<div class="cell">
+  <div class="grid-container">
+    <div class="grid-x grid-padding-x grid-padding-y align-middle" style="justify-content: center;">
+      <div class="cell large-8" style="padding-top: 4rem">
+        <h1 class="header-xxl dcp-orange">Thank You For Subscribing To ZAP Updates.</h1>
+        <p style="font-size: 27px; font-weight: 500;">You are currently subscribed to:</p>
+        {{#if this.model.citywide}}
+          <p style="font-size: 21px; font-weight: 500;">Citywide</p>
+        {{/if}}
+        {{#each this.model.boroughs as |boro|}}
+          <p style="font-size: 21px; font-weight: 500;">{{boro.name}}:</p>
+          <ul>
+            {{#each boro.communityBoards as |district|}}
+              <li style="font-size: 16px; font-weight: 500;">Community District {{district}}</li>
+            {{/each}}
+          </ul>
+        {{/each}}
+        <p>To modify subscriptions, <LinkTo @route="show-geography">click here NEEDS TO BE CHANGED TO /subscribers/:id/subscriptions</LinkTo>.</p>
+        <LinkTo @route="show-geography">
+          <button style="text-decoration: none; color:#F1F2F4; font-size: 1.25rem; font-weight: 500;background:#AE551D; border-radius: 1rem; padding: 20px;">
+            Go to Home
+          </button>
+        </LinkTo>
+      </div>
+    </div>
+  </div>
+</div>
+
+{{outlet}}


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Create page users will be sent to via a link in the confirmation email.

- [x] Page implements designs seen [here](https://www.figma.com/design/1HrOm1tkJ3lowQhrSRkPLs/ZAP-Listserv%3A-Wireframes-and-User-Stories?node-id=1009-114&node-type=frame&m=dev).
- [x] Route for new page should be `/subscribers/<id>/confirm`
- [x] When page is loaded, call endpoint to update user's confirmation custom property to `1`
- [ ] Text "To modify subscriptions, click here" should link to `/subscribers/<id>/subscriptions` (page does not exist yet.)
- [x] "Go to Home" button should link to `/` route.

#### Tasks/Bug Numbers
 - Completes #1572 


### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
