### PR TITLE
1595/manage subscriptions front end

### DIFF
--- a/client/app/components/subscription-form.js
+++ b/client/app/components/subscription-form.js
@@ -12,10 +12,35 @@ export default class SubscriptionFormComponent extends Component {
 
     isSubmitting = false;
 
+    previousSubscriptions = {};
+
     constructor(...args) {
       super(...args);
 
       this.communityDistrictsByBorough = getCommunityDistrictsByBorough();
+      // console.log("this.model just model", model)
+      console.log("this.args", this.args)
+
+      // Extra steps to take for updates
+      if (this.args.isUpdate) {
+        // Determine value of CD checkbox
+        if (Object.entries(this.args.subscriptions).find(([key, value]) => ((key !== "CW") && value))) {
+// can I switch this to isAtLeastOneCommunityDistrictSelected?          
+          this.isCommunityDistrict = true;
+        }
+        // Copy subscriptions to compare for changes
+        this.previousSubscriptions = {...this.args.subscriptions}
+      }
+
+console.log("prevSubs", this.previousSubscriptions)      
+
+
+    }
+
+    @computed('args.subscriptions.CW')
+    get isCityWide() {
+console.log("this.args.subscriptions.CW", this.args.subscriptions.CW)      
+      return this.args.subscriptions.CW;
     }
 
     @computed('args.email')
@@ -47,6 +72,11 @@ export default class SubscriptionFormComponent extends Component {
     // eslint-disable-next-line ember/use-brace-expansion
     @computed('isCommunityDistrict', 'args.subscriptions', 'args.email')
     get canBeSubmitted() {
+      // If it's an update, subscriptions must be different
+      if(this.args.isUpdate && !(Object.entries(this.args.subscriptions).find(([key, value]) => (this.previousSubscriptions[key] !== value)))) {
+        return false;
+      }
+
       if ((this.isCommunityDistrict && !this.isAtLeastOneCommunityDistrictSelected)) return false;
       return this.isEmailValid
             && (this.args.subscriptions.CW
@@ -87,6 +117,16 @@ export default class SubscriptionFormComponent extends Component {
         }
       } else if (this.args.subscriptions.CW) {
         requestBody.subscriptions.CW = 1;
+      }
+
+      //TODO: Make form submittable if only change is unchecking CDs box
+      // If it's an update, unsubscribe from all CDs if they unchecked the box
+      if (this.args.isUpdate && !this.isCommunityDistrict) {
+        for (const [key, value] of Object.entries(this.previousSubscriptions)) {
+          if ((key !== "CW") && value) {
+            requestBody.subscriptions[key] = 0;
+          }
+        }
       }
 
       const response = await fetch(`${ENV.host}/subscribers`, {

--- a/client/app/components/subscription-form.js
+++ b/client/app/components/subscription-form.js
@@ -13,42 +13,37 @@ export default class SubscriptionFormComponent extends Component {
     isSubmitting = false;
 
     previousSubscriptions = {};
+    previousIsCommunityDistrict = false;
 
     constructor(...args) {
       super(...args);
 
       this.communityDistrictsByBorough = getCommunityDistrictsByBorough();
-      // console.log("this.model just model", model)
-      console.log("this.args", this.args)
 
       // Extra steps to take for updates
       if (this.args.isUpdate) {
         // Determine value of CD checkbox
-        if (Object.entries(this.args.subscriptions).find(([key, value]) => ((key !== "CW") && value))) {
-// can I switch this to isAtLeastOneCommunityDistrictSelected?          
+        if (this.isAtLeastOneCommunityDistrictSelected) {
           this.isCommunityDistrict = true;
+          this.previousIsCommunityDistrict = true;
         }
         // Copy subscriptions to compare for changes
         this.previousSubscriptions = {...this.args.subscriptions}
       }
-
-console.log("prevSubs", this.previousSubscriptions)      
-
-
     }
 
     @computed('args.subscriptions.CW')
     get isCityWide() {
-console.log("this.args.subscriptions.CW", this.args.subscriptions.CW)      
       return this.args.subscriptions.CW;
     }
 
     // eslint-disable-next-line ember/use-brace-expansion
     @computed('isCommunityDistrict', 'args.subscriptions', 'args.email')
     get canBeSubmitted() {
-      // If it's an update, subscriptions must be different
-      if(this.args.isUpdate && !(Object.entries(this.args.subscriptions).find(([key, value]) => (this.previousSubscriptions[key] !== value)))) {
-        return false;
+      // If it's an update, subscriptions must be different, or they must have unchecked CD Updates
+      if(this.args.isUpdate)  {
+        if (this.previousIsCommunityDistrict && !this.isCommunityDistrict) return true;
+        if (!(Object.entries(this.args.subscriptions).find(([key, value]) => (this.previousSubscriptions[key] !== value)))) return false;
       }
 
       if ((this.isCommunityDistrict && !this.isAtLeastOneCommunityDistrictSelected)) return false;
@@ -119,7 +114,6 @@ console.log("this.args.subscriptions.CW", this.args.subscriptions.CW)
         requestBody.subscriptions.CW = 1;
       }
 
-      //TODO: Make form submittable if only change is unchecking CDs box
       // If it's an update, unsubscribe from all CDs if they unchecked the box
       if (this.args.isUpdate && !this.isCommunityDistrict) {
         for (const [key, value] of Object.entries(this.previousSubscriptions)) {

--- a/client/app/components/subscription-form.js
+++ b/client/app/components/subscription-form.js
@@ -114,6 +114,13 @@ export default class SubscriptionFormComponent extends Component {
         requestBody.subscriptions.CW = 1;
       }
 
+      if (this.args.isUpdate) {
+        for (const [key, value] of Object.entries(this.previousSubscriptions)) {
+          if (value !== this.args.subscriptions[key]) {
+            requestBody.subscriptions[key] = value ? 0 : 1;
+          }
+        }
+      }
       // If it's an update, unsubscribe from all CDs if they unchecked the box
       if (this.args.isUpdate && !this.isCommunityDistrict) {
         for (const [key, value] of Object.entries(this.previousSubscriptions)) {
@@ -123,8 +130,9 @@ export default class SubscriptionFormComponent extends Component {
         }
       }
 
-      const response = await fetch(`${ENV.host}/subscribers`, {
-        method: 'POST',
+      console.log(requestBody);
+      const response = await fetch(`${ENV.host}/subscribers${this.args.isUpdate ? (`/`+ this.args.id) : ''}`, {
+        method: this.args.isUpdate ? 'PATCH' : 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -132,8 +140,11 @@ export default class SubscriptionFormComponent extends Component {
       });
 
       await response.json();
-      if (!response.ok) throw await response.json();
+      console.log("response", response);
 
-      window.location.pathname = '/subscribed';
+      if (!response.ok) throw await response.json();
+      if (!this.args.isUpdate) window.location.pathname = '/subscribed';
+
+      set(this, 'isSubmitting', false);
     }
 }

--- a/client/app/components/subscription-form.js
+++ b/client/app/components/subscription-form.js
@@ -12,6 +12,9 @@ export default class SubscriptionFormComponent extends Component {
 
     isSubmitting = false;
 
+    showSubscriptionUpdateConfirmationModal = false;
+    updateStatus = "none";
+
     previousSubscriptions = {};
     previousIsCommunityDistrict = false;
 
@@ -130,7 +133,6 @@ export default class SubscriptionFormComponent extends Component {
         }
       }
 
-      console.log(requestBody);
       const response = await fetch(`${ENV.host}/subscribers${this.args.isUpdate ? (`/`+ this.args.id) : ''}`, {
         method: this.args.isUpdate ? 'PATCH' : 'POST',
         headers: {
@@ -140,11 +142,21 @@ export default class SubscriptionFormComponent extends Component {
       });
 
       await response.json();
-      console.log("response", response);
 
-      if (!response.ok) throw await response.json();
+      if (!response.ok) {
+        set(this, 'showSubscriptionUpdateConfirmationModal', true);
+        set(this, 'updateStatus', "error");
+        throw await response.json();
+      }
+
       if (!this.args.isUpdate) window.location.pathname = '/subscribed';
 
       set(this, 'isSubmitting', false);
+
+      if(this.args.isUpdate) {
+        set(this, 'showSubscriptionUpdateConfirmationModal', true);
+        set(this, 'updateStatus', "success");
+      }
+
     }
 }

--- a/client/app/components/subscription-form.js
+++ b/client/app/components/subscription-form.js
@@ -43,6 +43,20 @@ console.log("this.args.subscriptions.CW", this.args.subscriptions.CW)
       return this.args.subscriptions.CW;
     }
 
+    // eslint-disable-next-line ember/use-brace-expansion
+    @computed('isCommunityDistrict', 'args.subscriptions', 'args.email')
+    get canBeSubmitted() {
+      // If it's an update, subscriptions must be different
+      if(this.args.isUpdate && !(Object.entries(this.args.subscriptions).find(([key, value]) => (this.previousSubscriptions[key] !== value)))) {
+        return false;
+      }
+
+      if ((this.isCommunityDistrict && !this.isAtLeastOneCommunityDistrictSelected)) return false;
+      return this.isEmailValid
+            && (this.args.subscriptions.CW
+            || (this.isCommunityDistrict && this.isAtLeastOneCommunityDistrictSelected));
+    }
+
     @computed('args.email')
     get isEmailValid() {
       // eslint-disable-next-line no-useless-escape
@@ -67,20 +81,6 @@ console.log("this.args.subscriptions.CW", this.args.subscriptions.CW)
     @computed('args.subscriptions')
     get isAtLeastOneCommunityDistrictSelected() {
       return !!Object.entries(this.args.subscriptions).find(([key, value]) => ((key !== 'CW') && value));
-    }
-
-    // eslint-disable-next-line ember/use-brace-expansion
-    @computed('isCommunityDistrict', 'args.subscriptions', 'args.email')
-    get canBeSubmitted() {
-      // If it's an update, subscriptions must be different
-      if(this.args.isUpdate && !(Object.entries(this.args.subscriptions).find(([key, value]) => (this.previousSubscriptions[key] !== value)))) {
-        return false;
-      }
-
-      if ((this.isCommunityDistrict && !this.isAtLeastOneCommunityDistrictSelected)) return false;
-      return this.isEmailValid
-            && (this.args.subscriptions.CW
-            || (this.isCommunityDistrict && this.isAtLeastOneCommunityDistrictSelected));
     }
 
     @action

--- a/client/app/components/subscription-form.js
+++ b/client/app/components/subscription-form.js
@@ -13,9 +13,11 @@ export default class SubscriptionFormComponent extends Component {
     isSubmitting = false;
 
     showSubscriptionUpdateConfirmationModal = false;
-    updateStatus = "none";
+
+    updateStatus = 'none';
 
     previousSubscriptions = {};
+
     previousIsCommunityDistrict = false;
 
     constructor(...args) {
@@ -31,7 +33,7 @@ export default class SubscriptionFormComponent extends Component {
           this.previousIsCommunityDistrict = true;
         }
         // Copy subscriptions to compare for changes
-        this.previousSubscriptions = {...this.args.subscriptions}
+        this.previousSubscriptions = { ...this.args.subscriptions };
       }
     }
 
@@ -44,7 +46,7 @@ export default class SubscriptionFormComponent extends Component {
     @computed('isCommunityDistrict', 'args.subscriptions', 'args.email')
     get canBeSubmitted() {
       // If it's an update, subscriptions must be different, or they must have unchecked CD Updates
-      if(this.args.isUpdate)  {
+      if (this.args.isUpdate) {
         if (this.previousIsCommunityDistrict && !this.isCommunityDistrict) return true;
         if (!(Object.entries(this.args.subscriptions).find(([key, value]) => (this.previousSubscriptions[key] !== value)))) return false;
       }
@@ -118,6 +120,7 @@ export default class SubscriptionFormComponent extends Component {
       }
 
       if (this.args.isUpdate) {
+        // eslint-disable-next-line no-restricted-syntax
         for (const [key, value] of Object.entries(this.previousSubscriptions)) {
           if (value !== this.args.subscriptions[key]) {
             requestBody.subscriptions[key] = value ? 0 : 1;
@@ -126,14 +129,15 @@ export default class SubscriptionFormComponent extends Component {
       }
       // If it's an update, unsubscribe from all CDs if they unchecked the box
       if (this.args.isUpdate && !this.isCommunityDistrict) {
+        // eslint-disable-next-line no-restricted-syntax
         for (const [key, value] of Object.entries(this.previousSubscriptions)) {
-          if ((key !== "CW") && value) {
+          if ((key !== 'CW') && value) {
             requestBody.subscriptions[key] = 0;
           }
         }
       }
 
-      const response = await fetch(`${ENV.host}/subscribers${this.args.isUpdate ? (`/`+ this.args.id) : ''}`, {
+      const response = await fetch(`${ENV.host}/subscribers${this.args.isUpdate ? (`/${this.args.id}`) : ''}`, {
         method: this.args.isUpdate ? 'PATCH' : 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -145,7 +149,7 @@ export default class SubscriptionFormComponent extends Component {
 
       if (!response.ok) {
         set(this, 'showSubscriptionUpdateConfirmationModal', true);
-        set(this, 'updateStatus', "error");
+        set(this, 'updateStatus', 'error');
         throw await response.json();
       }
 
@@ -153,10 +157,9 @@ export default class SubscriptionFormComponent extends Component {
 
       set(this, 'isSubmitting', false);
 
-      if(this.args.isUpdate) {
+      if (this.args.isUpdate) {
         set(this, 'showSubscriptionUpdateConfirmationModal', true);
-        set(this, 'updateStatus', "success");
+        set(this, 'updateStatus', 'success');
       }
-
     }
 }

--- a/client/app/components/subscription-update-confirmation-modal.js
+++ b/client/app/components/subscription-update-confirmation-modal.js
@@ -1,0 +1,4 @@
+import Component from '@ember/component';
+
+export default class SubscriptionUpdateConfirmationModalComponent extends Component {
+}

--- a/client/app/router.js
+++ b/client/app/router.js
@@ -31,6 +31,7 @@ Router.map(function() { // eslint-disable-line
   if (config.showAlerts) {
     this.route('statuses');
     this.route('subscribed');
+    this.route('subscription-update', { path: '/subscribers/:id' });
     this.route('subscription-confirmation', { path: '/subscribers/:id/confirm' });
     this.route('subscribe');
   }

--- a/client/app/routes/subscription-confirmation.js
+++ b/client/app/routes/subscription-confirmation.js
@@ -49,6 +49,6 @@ export default Route.extend({
     const body = await response.json();
     if (!response.ok) throw await response.json();
 
-    return this.convertSubscriptionsToHandlebars(body);
+    return this.convertSubscriptionsToHandlebars(body.subscriptions);
   },
 });

--- a/client/app/routes/subscription-update.js
+++ b/client/app/routes/subscription-update.js
@@ -21,6 +21,6 @@ console.log("body", body)
       }
     }
 console.log("model", { email: body.email, subscriptions })
-    return { email: body.email, subscriptions };
+    return { id, email: body.email, subscriptions };
   },
 });

--- a/client/app/routes/subscription-update.js
+++ b/client/app/routes/subscription-update.js
@@ -1,0 +1,26 @@
+import Route from '@ember/routing/route';
+import fetch from 'fetch';
+import ENV from 'labs-zap-search/config/environment';
+import { lookupCommunityDistrict } from '../helpers/lookup-community-district';
+
+export default Route.extend({
+  async model({ id }) {
+    const response = await fetch(`${ENV.host}/subscribers/${id}`);
+
+    const body = await response.json();
+    if (!response.ok) throw await response.json();
+console.log("body", body)
+
+    var subscriptions = { CW: (body.subscriptions["CW"] === 1) };
+    const districts = lookupCommunityDistrict();
+    for (const district of districts) {
+      if(body.subscriptions[district.code] && (body.subscriptions[district.code] === 1)) {
+        subscriptions[district.code] = true;  
+      } else {
+        subscriptions[district.code] = false;
+      }
+    }
+console.log("model", { email: body.email, subscriptions })
+    return { email: body.email, subscriptions };
+  },
+});

--- a/client/app/routes/subscription-update.js
+++ b/client/app/routes/subscription-update.js
@@ -9,7 +9,6 @@ export default Route.extend({
 
     const body = await response.json();
     if (!response.ok) throw await response.json();
-console.log("body", body)
 
     var subscriptions = { CW: (body.subscriptions["CW"] === 1) };
     const districts = lookupCommunityDistrict();
@@ -20,7 +19,6 @@ console.log("body", body)
         subscriptions[district.code] = false;
       }
     }
-console.log("model", { email: body.email, subscriptions })
     return { id, email: body.email, subscriptions };
   },
 });

--- a/client/app/routes/subscription-update.js
+++ b/client/app/routes/subscription-update.js
@@ -10,11 +10,12 @@ export default Route.extend({
     const body = await response.json();
     if (!response.ok) throw await response.json();
 
-    var subscriptions = { CW: (body.subscriptions["CW"] === 1) };
+    const subscriptions = { CW: (body.subscriptions.CW === 1) };
     const districts = lookupCommunityDistrict();
+    // eslint-disable-next-line no-restricted-syntax
     for (const district of districts) {
-      if(body.subscriptions[district.code] && (body.subscriptions[district.code] === 1)) {
-        subscriptions[district.code] = true;  
+      if (body.subscriptions[district.code] && (body.subscriptions[district.code] === 1)) {
+        subscriptions[district.code] = true;
       } else {
         subscriptions[district.code] = false;
       }

--- a/client/app/styles/modules/_m-subscription-form.scss
+++ b/client/app/styles/modules/_m-subscription-form.scss
@@ -166,3 +166,27 @@ input[type=checkbox] {
 .update-type-label {
     padding-left: 10px;
 }
+
+.subscription-update-confirmation-modal {
+    font-size: 1.25rem;
+    div > span.frown {
+        color: $red-muted;
+    }
+    span {
+    
+        color:#008e50;
+      }
+    p {
+        font-size: 1rem;
+    }
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.home-button {
+    display: flex;
+    width: 100%;
+    justify-content: center;
+    // padding-top: 200px;
+}

--- a/client/app/styles/modules/_m-subscription-form.scss
+++ b/client/app/styles/modules/_m-subscription-form.scss
@@ -188,5 +188,4 @@ input[type=checkbox] {
     display: flex;
     width: 100%;
     justify-content: center;
-    // padding-top: 200px;
 }

--- a/client/app/templates/components/subscription-form.hbs
+++ b/client/app/templates/components/subscription-form.hbs
@@ -20,7 +20,6 @@
             </li>
             <li>
                 <div class="update-type-item">
-{{log "isCommunityDistrict" isCommunityDistrict}}                    
                     <Input @id="community-district-checkbox" @type="checkbox" @checked={{isCommunityDistrict}}
                         {{on "change" this.closeAllAccordions}}/>
                     <div class="update-type-label">
@@ -75,3 +74,4 @@
         <a class="button primary no-margin {{if this.canBeSubmitted "" "disabled"}}" type="submit" {{action "subscribe"}}>{{if this.args.isUpdate "Update" "Subscribe"}}</a>
     </div>
 </form>
+<SubscriptionUpdateConfirmationModal @showSubscriptionUpdateConfirmationModal={{showSubscriptionUpdateConfirmationModal}} @updateStatus={{updateStatus}} />

--- a/client/app/templates/components/subscription-form.hbs
+++ b/client/app/templates/components/subscription-form.hbs
@@ -7,6 +7,7 @@
         <ul>
             <li>
                 <div class="update-type-item">
+{{log "isCityWide" isCityWide}}                    
                     <Input @id="city-wide-checkbox" @type="checkbox" @checked={{isCityWide}} {{on "change" this.toggleCitywide}}/>
                     <div class="update-type-label">
                         <label for="city-wide-checkbox">Citywide Updates</label>
@@ -17,6 +18,7 @@
             </li>
             <li>
                 <div class="update-type-item">
+{{log "isCommunityDistrict" isCommunityDistrict}}                    
                     <Input @id="community-district-checkbox" @type="checkbox" @checked={{isCommunityDistrict}}
                         {{on "change" this.closeAllAccordions}}/>
                     <div class="update-type-label">
@@ -68,6 +70,6 @@
         {{#if isSubmitting}}
             {{fa-icon icon='spinner' spin="true" size="5x" class="map-loading-spinner"}}
         {{/if}}
-        <a class="button primary no-margin {{if this.canBeSubmitted "" "disabled"}}" type="submit" {{action "subscribe"}}>Subscribe</a>
+        <a class="button primary no-margin {{if this.canBeSubmitted "" "disabled"}}" type="submit" {{action "subscribe"}}>{{if this.args.isUpdate "Update" "Subscribe"}}</a>
     </div>
 </form>

--- a/client/app/templates/components/subscription-form.hbs
+++ b/client/app/templates/components/subscription-form.hbs
@@ -46,8 +46,8 @@
                     <div class="accordion-content" data-tab-content>
                         <div>
                         <div>
-                        <Input id="all-brooklyn" type="checkbox" @value={{borough}} {{on "change" this.checkWholeBorough}} /><label
-                            for="all-brooklyn">Select all</label>
+                        <Input id="all-{{borough}}" type="checkbox" @value={{borough}} {{on "change" this.checkWholeBorough}} /><label
+                            for="all-{{borough}}">Select all</label>
                         </div>
                         {{#each districts as |district| }}
                         <div>

--- a/client/app/templates/components/subscription-form.hbs
+++ b/client/app/templates/components/subscription-form.hbs
@@ -2,6 +2,8 @@
         {{yield}}
     <div class="subscribe-section">
         <div class="update-type-section">
+        <div class="update-type-question">To subscribe to a Community District or Citywide, check one of the following options.</div>
+        <p></p>
         <div class="update-type-question">Which would you like to receive updates for?</div>
         
         <ul>
@@ -37,7 +39,7 @@
         <h5>If you chose CD Updates, please select which community districts you would like to receive updates
             for:</h5>
         <p>You can find the Community District to any New York City address <a
-                href="https://zola.planning.nyc.gov/">here</a>.</p>
+                href="https://zola.planning.nyc.gov/" target="_blank" ref="noopener noreferrer">here</a>.</p>
         {{#initialize_foundation}}
          {{#each-in this.communityDistrictsByBorough as |borough districts|}}
             <ul class="accordion" id="foo" data-accordion data-multi-expand="true" data-allow-all-closed="true">

--- a/client/app/templates/components/subscription-update-confirmation-modal.hbs
+++ b/client/app/templates/components/subscription-update-confirmation-modal.hbs
@@ -1,0 +1,26 @@
+{{#if this.showSubscriptionUpdateConfirmationModal}}
+<div class="reveal-overlay" style="display:block; background-color: rgba(241, 242, 244, 0.45)">
+  <div class="reveal-overlay-target"></div>
+  <div class="reveal info-modal" role="dialog" aria-hidden="false" tabindex="-1" style="display:block;"
+    data-test-info-modal>
+    <div class="subscription-update-confirmation-modal">
+      {{#if (eq this.updateStatus "success")}}
+      <div><span>{{fa-icon icon='check-circle' prefix='far' size='2x'}}</span></div>
+      <div>Your subscription settings have been updated.
+        <p>The changes will be reflected in the system in a few minutes.</p>
+      </div>
+      {{else if (eq this.updateStatus "error")}}
+      <div>
+        <span class="frown">{{fa-icon icon='frown' prefix='far' size='2x'}}</span>
+      </div>
+      <div> <p> There was an error with your submission. Please try again in a few minutes.</p>
+      </div>
+      {{/if}}
+    </div>
+
+    <div class="home-button">
+      <LinkTo class="button primary align-middle" @route="show-geography">Home</LinkTo>
+    </div>
+  </div>
+</div>
+{{/if}}

--- a/client/app/templates/subscribe.hbs
+++ b/client/app/templates/subscribe.hbs
@@ -5,7 +5,7 @@
                 <div class="subscribe-section">
                     <h1 class="header-xxl dcp-orange">Subscribe to ZAP Updates</h1>
                     <span class="text-small">Get updated on milestones for all projects in any community district (CD) by signing up to receive
-                        emails on Zoning Application Portal.</span>
+                        emails on Zoning Application Portal.</span>
                 </div>
                     <SubscriptionForm @subscriptions={{this.model.subscriptions}} @email={{this.model.email}} @isUpdate={{false}}>
                         <div class="subscribe-section">
@@ -24,7 +24,7 @@
                         be receiving.</p>
 
                     <h5>Privacy Policy</h5>
-                    <p class="text-small">For more information, refer to NYC.gov Privacy Policy and Terms of Use.</p>
+                    <p class="text-small">For more information, refer to NYC.gov <a href="https://www.nyc.gov/home/privacy-policy.page" target="_blank" ref="noopener noreferrer">Privacy Policy</a> and <a href="https://www.nyc.gov/home/terms-of-use.page" target="_blank" ref="noopener noreferrer">Terms of Use</a>.</p>
                 </div>
             </div>
         </div>

--- a/client/app/templates/subscription-update.hbs
+++ b/client/app/templates/subscription-update.hbs
@@ -3,10 +3,13 @@
         <div class="grid-x grid-padding-x grid-padding-y align-middle" style="justify-content: center;">
             <div class="cell large-8 subscribe-container">
                 <div class="subscribe-section">
-                    <h1 class="header-xxl dcp-orange">Subscribe to ZAP Updates</h1>
+                    <h1 class="header-xxl dcp-orange">Modify Subscriptions for ZAP Updates</h1>
                     <span class="text-small">Get updated on milestones for all projects in any community district (CD) by signing up to receive
-                        emails on Zoning Application Portal.</span>
+                        emails on Zoning Application Portal.</span>
+                        <p></p>
+                    <div class="update-type-question">To unsubscribe from a Community District or Citywide, uncheck the selected options below.</div>
                 </div>
+                
 {{log "this.model.subscriptions" this.model.subscriptions}}
 {{log "this.model.email" this.model.email}}                    
                     
@@ -21,15 +24,12 @@
                         </div>
                     </SubscriptionForm>
                 <div class="subscribe-footer">
-                    <h5>Cancel Your Subscription</h5>
-                    <p class="text-small">You can unsubscribe to ZAP emails at the end of any email updates you receive.</p>
-
                     <h5>Definition of ZAP Updates</h5>
                     <p class="text-small">Refer to <a href="/statuses">this page</a> for more information about what type of updates you will
                         be receiving.</p>
 
                     <h5>Privacy Policy</h5>
-                    <p class="text-small">For more information, refer to NYC.gov Privacy Policy and Terms of Use.</p>
+                    <p class="text-small">For more information, refer to NYC.gov <a href="https://www.nyc.gov/home/privacy-policy.page" target="_blank" ref="noopener noreferrer">Privacy Policy</a> and <a href="https://www.nyc.gov/home/terms-of-use.page" target="_blank" ref="noopener noreferrer">Terms of Use</a>.</p>
                 </div>
             </div>
         </div>

--- a/client/app/templates/subscription-update.hbs
+++ b/client/app/templates/subscription-update.hbs
@@ -7,11 +7,15 @@
                     <span class="text-small">Get updated on milestones for all projects in any community district (CD) by signing up to receive
                         emails on Zoning Application Portal.</span>
                 </div>
-                    <SubscriptionForm @subscriptions={{this.model.subscriptions}} @email={{this.model.email}} @isUpdate={{false}}>
+{{log "this.model.subscriptions" this.model.subscriptions}}
+{{log "this.model.email" this.model.email}}                    
+                    
+                    
+                    <SubscriptionForm @subscriptions={{this.model.subscriptions}} @email={{this.model.email}} @isUpdate={{true}}>
                         <div class="subscribe-section">
                             <div class="subscribe-input-group">
-                            <label class="email-label">Email Address</label>
-                            <Input class="input-group-field" type="text" @value={{this.model.email}}/>
+                                <label class="email-label">Email Address</label>
+                                <input class="input-group-field" type="text" value={{this.model.email}} disabled />
                             </div>
                         </div>
                     </SubscriptionForm>

--- a/client/app/templates/subscription-update.hbs
+++ b/client/app/templates/subscription-update.hbs
@@ -10,8 +10,9 @@
 {{log "this.model.subscriptions" this.model.subscriptions}}
 {{log "this.model.email" this.model.email}}                    
                     
+                    {{log "this.model.id" this.model.id}}
                     
-                    <SubscriptionForm @subscriptions={{this.model.subscriptions}} @email={{this.model.email}} @isUpdate={{true}}>
+                    <SubscriptionForm @subscriptions={{this.model.subscriptions}} @email={{this.model.email}} @isUpdate={{true}} @id={{this.model.id}}>
                         <div class="subscribe-section">
                             <div class="subscribe-input-group">
                                 <label class="email-label">Email Address</label>

--- a/client/app/templates/subscription-update.hbs
+++ b/client/app/templates/subscription-update.hbs
@@ -9,12 +9,6 @@
                         <p></p>
                     <div class="update-type-question">To unsubscribe from a Community District or Citywide, uncheck the selected options below.</div>
                 </div>
-                
-{{log "this.model.subscriptions" this.model.subscriptions}}
-{{log "this.model.email" this.model.email}}                    
-                    
-                    {{log "this.model.id" this.model.id}}
-                    
                     <SubscriptionForm @subscriptions={{this.model.subscriptions}} @email={{this.model.email}} @isUpdate={{true}} @id={{this.model.id}}>
                         <div class="subscribe-section">
                             <div class="subscribe-input-group">

--- a/server/src/subscriber/subscriber.controller.ts
+++ b/server/src/subscriber/subscriber.controller.ts
@@ -5,6 +5,7 @@ import { Request } from "express";
 import validateEmail from "../_utils/validate-email";
 import * as Sentry from "@sentry/nestjs";
 import crypto from 'crypto';
+import { isElement } from "underscore";
 
 const PAUSE_BETWEEN_CHECKS = 30000;
 const CHECKS_BEFORE_FAIL = 10;

--- a/server/src/subscriber/subscriber.controller.ts
+++ b/server/src/subscriber/subscriber.controller.ts
@@ -92,8 +92,8 @@ export class SubscriberController {
 
   @Get("/subscribers/:id")
   async subscriptions(@Param() params, @Res() response) {
-    const subscriptions = await this.subscriberService.getSubscriptions(params.id);
-    response.status(subscriptions.code).send(subscriptions.isError ? subscriptions : subscriptions["subscription_list"])
+    const userData = await this.subscriberService.getSubscriptions(params.id);
+    response.status(userData.code).send(userData.isError ? userData : { email: userData.email, subscriptions: userData["subscription_list"] })
     return;
   }
 

--- a/server/src/subscriber/subscriber.service.ts
+++ b/server/src/subscriber/subscriber.service.ts
@@ -109,6 +109,7 @@ export class SubscriberService {
    * @returns {object}
    */
   async checkCreate(importId: string, @Res() response, counter: number = 0, checksBeforeFail: number, pauseBetweenChecks: number, errorInfo: any) {
+    console.log("checking again");
     if(counter >= checksBeforeFail) {
       console.error({
         code: 408,
@@ -262,9 +263,12 @@ export class SubscriberService {
       }
     }
 
+    console.log("request", request);
+
     // https://www.twilio.com/docs/sendgrid/api-reference/contacts/add-or-update-a-contact
     try {
       const result = await this.client.request(request);
+      console.log(result);
       return { isError: false, result: result };
     } catch (error) {
       return { isError: true, ...error };

--- a/server/src/subscriber/subscriber.service.ts
+++ b/server/src/subscriber/subscriber.service.ts
@@ -109,8 +109,7 @@ export class SubscriberService {
    * @returns {object}
    */
   async checkCreate(importId: string, @Res() response, counter: number = 0, checksBeforeFail: number, pauseBetweenChecks: number, errorInfo: any) {
-    console.log("checking again");
-    if(counter >= checksBeforeFail) {
+     if(counter >= checksBeforeFail) {
       console.error({
         code: 408,
         message: `Polling limit of ${checksBeforeFail} checks with a ${pauseBetweenChecks/1000} second delay between each has been reached.`,
@@ -263,13 +262,10 @@ export class SubscriberService {
       }
     }
 
-    console.log("request", request);
-
     // https://www.twilio.com/docs/sendgrid/api-reference/contacts/add-or-update-a-contact
     try {
       const result = await this.client.request(request);
-      console.log(result);
-      return { isError: false, result: result };
+       return { isError: false, result: result };
     } catch (error) {
       return { isError: true, ...error };
     }

--- a/server/src/subscriber/subscriber.service.ts
+++ b/server/src/subscriber/subscriber.service.ts
@@ -196,17 +196,17 @@ export class SubscriberService {
     // https://www.twilio.com/docs/sendgrid/api-reference/contacts/search-contacts
     // https://www.twilio.com/docs/sendgrid/for-developers/sending-email/segmentation-query-language
     try {
-      const subscriptions = await this.client.request(request);
-      if(subscriptions[0].body["contact_count"] === 0) {
+      const userData = await this.client.request(request);
+      if(userData[0].body["contact_count"] === 0) {
         return {isError: true, code: 404, message: "No users found."};
       }
       var subscriptionList = {};
-      for (const [key, value] of Object.entries(subscriptions[0].body["result"][0]["custom_fields"])) {
+      for (const [key, value] of Object.entries(userData[0].body["result"][0]["custom_fields"])) {
         if(key.startsWith(`zap_${this.environment}_`) && validCustomFieldNames.includes(key.replace(`zap_${this.environment}_`, "") as CustomFieldName)) {
           subscriptionList[key.replace(`zap_${this.environment}_`, "")] = value;
         }
       }
-      return {isError: false, code: subscriptions[0].statusCode, "subscription_list": subscriptionList};
+      return {isError: false, code: userData[0].statusCode, "subscription_list": subscriptionList, email: userData[0].body["result"][0].email};
     } catch(error) {
       return {isError: true, ...error};
     }


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->



### Summary
Create new page for managing subscriptions, pre-populated with existing user subscriptions:

- [x] Create new page at route `/subscribers/<id>`
- [x] Page implements designs found [here](https://www.figma.com/design/1HrOm1tkJ3lowQhrSRkPLs/ZAP-Listserv%3A-Wireframes-and-User-Stories?node-id=678-385&node-type=frame&m=dev)
- [x] Pre-populate checkboxes by querying for user's current subscriptions using the `id` route param.
- [x] "Update" button should be disabled until selected subscriptions are different from existing values.
- [x] When user updates subscriptions and clicks "Update", call endpoint to update subscriptions for the user.

#### Tasks/Bug Numbers
Closes https://github.com/NYCPlanning/labs-zap-search/issues/1595 and https://github.com/NYCPlanning/labs-zap-search/issues/1599

### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
