### PR TITLE
Add timeout and test environment app.import call

### DIFF
--- a/client/app/components/info-modal.js
+++ b/client/app/components/info-modal.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import { action } from '@ember/object';
 
 export default class InfoModalComponent extends Component {
+  // We have manually overridden this to hide the modal by default when running tests in tests/index.html
   open = !window.localStorage.hideMessage;
 
   dontShowModalAgain = false;

--- a/client/app/templates/application.hbs
+++ b/client/app/templates/application.hbs
@@ -57,13 +57,13 @@
 </div>
 
 
-{{!-- <div id="info-modal-container">
-</div> --}}
+<div id="info-modal-container">
+</div>
 <div id="reveal-modal-container">
 </div>
-{{!-- {{#ember-wormhole to="info-modal-container"}}
+{{#ember-wormhole to="info-modal-container"}}
   {{info-modal}}
-{{/ember-wormhole}} --}}
+{{/ember-wormhole}}
 
 
 {{#if (string-includes currentRouteName "my-projects")}}

--- a/client/app/templates/application.hbs
+++ b/client/app/templates/application.hbs
@@ -57,13 +57,13 @@
 </div>
 
 
-<div id="info-modal-container">
-</div>
+{{!-- <div id="info-modal-container">
+</div> --}}
 <div id="reveal-modal-container">
 </div>
-{{#ember-wormhole to="info-modal-container"}}
+{{!-- {{#ember-wormhole to="info-modal-container"}}
   {{info-modal}}
-{{/ember-wormhole}}
+{{/ember-wormhole}} --}}
 
 
 {{#if (string-includes currentRouteName "my-projects")}}

--- a/client/ember-cli-build.js
+++ b/client/ember-cli-build.js
@@ -46,11 +46,18 @@ module.exports = function(defaults) {
       },
     },
   });
-
+  if (app.env === 'development') {
+    // Only import when in development mode
+    app.import('node_modules/foundation-sites/dist/js/foundation.min.js', {type: "vendor"});
+  }
+  if (app.env === 'test') {
+    // Only import in test mode and place in test-support.js
+    app.import('node_modules/foundation-sites/dist/js/foundation.js', {type: "test"});
+  }
   // Use `app.import` to add additional libraries to the generated
   // output files.
   //
-  app.import('node_modules/foundation-sites/dist/js/foundation.min.js', { type: 'vendor' });
+  // app.import('node_modules/foundation-sites/dist/js/foundation.min.js');
   // If you need to use different assets in different
   // environments, specify an object as the first parameter. That
   // object's keys should be the environment name and the values

--- a/client/ember-cli-build.js
+++ b/client/ember-cli-build.js
@@ -46,18 +46,13 @@ module.exports = function(defaults) {
       },
     },
   });
-  if (app.env === 'development') {
-    // Only import when in development mode
-    app.import('node_modules/foundation-sites/dist/js/foundation.min.js', {type: "vendor"});
-  }
-  if (app.env === 'test') {
-    // Only import in test mode and place in test-support.js
-    app.import('node_modules/foundation-sites/dist/js/foundation.js', {type: "test"});
-  }
   // Use `app.import` to add additional libraries to the generated
   // output files.
-  //
-  // app.import('node_modules/foundation-sites/dist/js/foundation.min.js');
+  if (app.env === 'test') {
+    app.import('node_modules/foundation-sites/dist/js/foundation.js', {type: "test"});
+  } else {
+    app.import('node_modules/foundation-sites/dist/js/foundation.min.js', {type: "vendor"});
+  }
   // If you need to use different assets in different
   // environments, specify an object as the first parameter. That
   // object's keys should be the environment name and the values

--- a/client/testem.js
+++ b/client/testem.js
@@ -9,6 +9,7 @@ module.exports = {
   launch_in_dev: [
     'Chrome',
   ],
+  browser_start_timeout: 120,
   browser_args: {
     Chrome: {
       mode: 'ci',

--- a/client/tests/index.html
+++ b/client/tests/index.html
@@ -7,8 +7,9 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script>
+      // The below hides the default modal from showing when running tests
       window.localStorage.hideMessage = true;
-      
+
       window['_fs_host'] = 'fullstory.com';
       window['_fs_script'] = 'edge.fullstory.com/s/fs.js';
       window['_fs_org'] = 'o-19S9J2-na1';

--- a/client/tests/index.html
+++ b/client/tests/index.html
@@ -7,6 +7,8 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script>
+      window.localStorage.hideMessage = true;
+      
       window['_fs_host'] = 'fullstory.com';
       window['_fs_script'] = 'edge.fullstory.com/s/fs.js';
       window['_fs_org'] = 'o-19S9J2-na1';


### PR DESCRIPTION
These changes are intended to resolve two different errors we've been having with running tests for this repo.

1. The change to `testem.js` fix an error seen sporadically referring to a timeout being reached. This error would manifest with a reference to Testem not being loaded
2. The change to `ember-cli-build` is meant to fix the error seen since #1563 was merged in. As far as I can tell, this error was due to foundation not being imported when the app was run in `test` mode. This seems to have fixed that but not 100% sure.

Tests now execute successfully but fail. The error I'm seeing says "Assertion Failed: Attempted to register a view with an id already in use". My working theory is that this is due to use of Foundations modal component introduced in #1559, based on a [similar Issue](https://github.com/emberjs/ember.js/issues/13026) found in Ember's repo.

I'd like to merge this in to fix the existing issues, knowing the tests still fail, then have @dhochbaum-dcp investigate the new error.