### PR TITLE
1628 & 1629 Info Modal Visibility

### DIFF
--- a/client/app/routes/subscribe.js
+++ b/client/app/routes/subscribe.js
@@ -5,7 +5,7 @@ export default class SubscribeRoute extends Route {
   model() {
     // If a user visits the subscribe page, we should stop showing them the subscribe modal
     window.localStorage.hideMessage = true;
-    
+
     const subscriptions = { CW: false };
     const districts = lookupCommunityDistrict();
     // eslint-disable-next-line no-restricted-syntax

--- a/client/app/routes/subscribe.js
+++ b/client/app/routes/subscribe.js
@@ -3,6 +3,9 @@ import { lookupCommunityDistrict } from '../helpers/lookup-community-district';
 
 export default class SubscribeRoute extends Route {
   model() {
+    // If a user visits the subscribe page, we should stop showing them the subscribe modal
+    window.localStorage.hideMessage = true;
+    
     const subscriptions = { CW: false };
     const districts = lookupCommunityDistrict();
     // eslint-disable-next-line no-restricted-syntax

--- a/client/app/templates/components/info-modal.hbs
+++ b/client/app/templates/components/info-modal.hbs
@@ -11,7 +11,7 @@
     >
       <h1>Subscribe and Get Notified.</h1>
 
-      <h4>Subscribe to <LinkTo @route="subscribe">ZAP Email notifications</LinkTo>. Get updates about community district and citywide projects.</h4>
+      <h4>Subscribe to <LinkTo @route="subscribe" {{action closeModal}}>ZAP Email notifications</LinkTo>. Get updates about community district and citywide projects.</h4>
 
       {{input type="checkbox" checked=this.dontShowModalAgain}}
       Don't show this message again


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
Once a user has clicked the link in the info modal, the info modal will no longer appear for that session; once the subscribe page loads, it stops showing the modal (as if the user had checked "Don't show this message again").

#### Tasks/Bug Numbers
 - Closes #1628
 - Closes #1629


### Technical Explanation
<!---
  a. In technical terms, what was wrong, what is the fix, and why does it make things better? 
  b. If you can point to a specific line or file exhibiting the original problem, that would be great!
  c. Provide entrypoint of new solution, if different than (b).
  d. Provide overview of any new architecture.
       - How are components stringed together?
       - What is the new hierarchy? 
       - Any new components?
  e. Provide links and explanations for any new technical concepts, APIs and terms.
      Especially if you had to do some research yourself.
   List any ad-hoc, miscellaneous updates included
-->

### Any other info you think would help a reviewer understand this PR?
