### PR TITLE
1652 ZAP Updates Feedback - Update Subscription Page to Match Copy

### DIFF
--- a/client/app/templates/components/subscription-form.hbs
+++ b/client/app/templates/components/subscription-form.hbs
@@ -12,8 +12,7 @@
                     <Input @id="city-wide-checkbox" @type="checkbox" @checked={{isCityWide}} {{on "change" this.toggleCitywide}} @disabled={{this.args.isSubmitting}}/>
                     <div class="update-type-label">
                         <label for="city-wide-checkbox">Citywide Updates</label>
-                        <span class="text-small">You'll receive an email for all citywide projects, which are projects that aren’t
-                            associated with any Community District.</span>
+                        <span class="text-small">You'll receive an email for all citywide projects, which are projects that are associated with some or all community districts in two or more boroughs, depending on the project's applicability.</span>
                     </div>
                 </div>
             </li>

--- a/client/app/templates/subscribe.hbs
+++ b/client/app/templates/subscribe.hbs
@@ -25,7 +25,7 @@
                     </SubscriptionForm>
                 <div class="subscribe-footer">
                     <h5>Cancel Your Subscription</h5>
-                    <p class="text-small">You can unsubscribe to ZAP emails at the end of any email updates you receive.</p>
+                    <p class="text-small">You can unsubscribe to Zoning Application Portal emails at the end of any email updates you receive.</p>
 
                     <h5>Definition of ZAP Updates</h5>
                     <p class="text-small">Refer to <a href="/statuses">this page</a> for more information about what type of updates you will


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
[Current staging site says:](https://zap-staging.planninglabs.nyc/subscribe)

![Image](https://github.com/user-attachments/assets/ac242232-1eb8-43be-bd77-e5391331b26b)

Changes to make:

- [ ] `You'll receive an email for all citywide projects, which are projects that are associated with some or all community districts in two or more boroughs, depending on the project’s applicability. `


Staging Site:

![Image](https://github.com/user-attachments/assets/7b6e9c14-0022-4bf3-840c-6a7ad3478701)

Changes to make:

- [ ] `You can unsubscribe to Zoning Application Portal emails at the end of any email updates you receive.`

#### Tasks/Bug Numbers
 - Closes #1652 

