### PR TITLE
1653 ZAP Updates Feedback - Update Status Page to Match Copy

### DIFF
--- a/client/app/templates/statuses.hbs
+++ b/client/app/templates/statuses.hbs
@@ -7,11 +7,11 @@
           <ol class="status-options">
             <li class="numbered-option">
               <h4>Filed</h4>
-              <p>A Land Use or Environmental Review Application has been submitted to DCP. The minimum fees have been paid.</p>
+              <p>A Land Use or Environmental Review Application has been submitted to NYC Planning. The applicant(s) paid a fee requirement.</p>
             </li>
             <li class="numbered-option">
               <h4>Noticed</h4>
-              <p>An application is notified that it will be certified within 30 days per City Charter requirements.</p>
+              <p>Land Use Participants (Community Boards, Borough Presidents, and Borough Boards) have been notified that a project could possibly certify in at least 30-days per City Charter ULURP requirements (197-c(c)).</p>
             </li>
             <li class="numbered-option">
               <h4>In Public Review</h4>
@@ -28,8 +28,8 @@
               </ul>
             </li>
           </ol>
-          <p>When you sign up for ZAP updates, you will only be notified when a project's public status is changed to "<b>Filed</b>" or "<b>In public review</b>"</p>
-          <p class="status-updates">To sign up for ZAP updates, please visit <LinkTo @route="subscribe">here</LinkTo>.</p>
+          <p>When you sign up for Zoning Application Portal updates, you will only be notified when a project's public status is changed to "<b>Filed</b>" or "<b>In public review</b>"</p>
+          <p class="status-updates">To sign up for Zoning Application Portal updates, please visit <LinkTo @route="subscribe">here</LinkTo>.</p>
           <ZapAlertsContact />
       </div>
     </div>


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
[Staging Site:](https://zap-staging.planninglabs.nyc/statuses)

![Image](https://github.com/user-attachments/assets/678dc32f-1abc-4f95-8463-b4f3e0be85cc)

Changes to make:
- [ ] `A Land Use or Environmental Review Application has been submitted to NYC Planning. The applicant(s) paid a fee requirement.`
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
![Image](https://github.com/user-attachments/assets/548ea4f6-5ee1-4650-86ec-b268f4df7eac)

Changes to make:

- [ ] `Land Use Participants (Community Boards, Borough Presidents, and Borough Boards) have been notified that a project could possibly certify in at least 30-days per City Charter ULURP requirements (197-c(c)).`
--------------------------------------------------------------------------------------------------------------------------------------------------------------------

![Image](https://github.com/user-attachments/assets/a1ccbbe3-f7e8-4bea-9390-4766798fb429)

Changes to make:
- [ ] `When you sign up for Zoning Application Portal updates, you will only be notified when a project's public status is changed to "Filed" or "In Public Review."` 
- [ ] `To sign up for Zoning Application Portal updates, please visit [here](https://zap-staging.planninglabs.nyc/subscribe).`
#### Tasks/Bug Numbers
 - Closes #1653 

