### PR TITLE
1664 Invalid subscribe form submittable with enter key

### DIFF
--- a/client/app/controllers/subscribe.js
+++ b/client/app/controllers/subscribe.js
@@ -65,6 +65,11 @@ export default class SubscribeController extends Controller {
   }
 
   @action
+  stopSubscribeOnEnter(event) {
+    if (event.key === "Enter") { event.preventDefault(); }
+  }
+
+  @action
   continuouslyCheckEmail(event) {
     if ((this.startContinuouslyChecking) || (validateEmail(event.target.value))) { this.checkExistingEmail(event); }
   }

--- a/client/app/templates/subscribe.hbs
+++ b/client/app/templates/subscribe.hbs
@@ -10,7 +10,7 @@
                         <div class="subscribe-section">
                             <div class="subscribe-input-group">
                             <label class="email-label">Email Address</label>
-                            <Input class="input-group-field" type="text" @value={{this.model.email}} onkeyup={{action 'continuouslyCheckEmail'}} onchange={{action 'checkExistingEmail'}} @disabled={{this.isSubmitting}}/>
+                            <Input class="input-group-field" type="text" @value={{this.model.email}} onkeydown={{action 'stopSubscribeOnEnter'}} onkeyup={{action 'continuouslyCheckEmail'}} onchange={{action 'checkExistingEmail'}} @disabled={{this.isSubmitting}}/>
                             </div>
                             {{#if this.emailAlreadyExists}}
                                 <p class="email-exists">This email already is subscribed to ZAP Updates. <a onclick={{action 'sendEmail'}} style="text-decoration: underline;">Click here to receive an email to modify subscriptions.</a></p>


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
The subscribe form is submittable by pressing the `enter` key even when the button is disabled due to invalid form state.

- [ ] User can only submit form with enter key when button is enabled.


#### Tasks/Bug Numbers
 - Completes #1664

### Technical Explanation
This solution disables submission on Enter completely.  It would be an extremely rare occurrence for a user to have a valid submission while in the email input field and attempt to submit with Enter, and they will still be able to submit using the button.  The action which validates whether the form data is valid for submission, as well as much of the form data, are stored in a sub-component, meaning allowing the form to submit on Enter only when valid would require significant refactoring.

### Any other info you think would help a reviewer understand this PR?
