### PR TITLE
1667 Add `dcp_easeis` filter option to `/projects` endpoint

### DIFF
--- a/server/src/_utils/constants.ts
+++ b/server/src/_utils/constants.ts
@@ -13,6 +13,12 @@ const CEQRTYPE = {
   Unlisted: 717170002
 };
 
+const EASEIS = {
+  EAS: 717170000,
+  EIS: 717170001,
+  "Technical Memorandum": 717170002
+};
+
 const STATUSCODE = {
   MISTAKE: 717170003,
   OVERRIDDEN: 717170001
@@ -296,6 +302,7 @@ export default {
   VISIBILITY,
   ULURP,
   CEQRTYPE,
+  EASEIS,
   STATUSCODE,
   STATECODE,
   PUBLICSTATUS,

--- a/server/src/assignment/assignment.service.ts
+++ b/server/src/assignment/assignment.service.ts
@@ -250,7 +250,7 @@ function generateAssignmentsQueryObject(contact) {
 
   return {
     $select:
-      "dcp_name,statecode,dcp_applicanttype,dcp_borough,dcp_ceqrnumber,dcp_ceqrtype,dcp_certifiedreferred,dcp_easeis,dcp_femafloodzonea,dcp_femafloodzoneshadedx,dcp_sisubdivision,dcp_sischoolseat,dcp_projectbrief,dcp_additionalpublicinformation,dcp_projectname,dcp_publicstatus,dcp_projectcompleted,dcp_hiddenprojectmetrictarget,dcp_ulurp_nonulurp,dcp_validatedcommunitydistricts,dcp_bsanumber,dcp_wrpnumber,dcp_lpcnumber,dcp_name,dcp_nydospermitnumber,dcp_lastmilestonedate,_dcp_applicant_customer_value,_dcp_applicantadministrator_customer_value",
+      "dcp_name,statecode,dcp_applicanttype,dcp_borough,dcp_ceqrnumber,dcp_ceqrtype,dcp_certifiedreferred,dcp_femafloodzonea,dcp_femafloodzoneshadedx,dcp_sisubdivision,dcp_sischoolseat,dcp_projectbrief,dcp_additionalpublicinformation,dcp_projectname,dcp_publicstatus,dcp_projectcompleted,dcp_hiddenprojectmetrictarget,dcp_ulurp_nonulurp,dcp_validatedcommunitydistricts,dcp_bsanumber,dcp_wrpnumber,dcp_lpcnumber,dcp_name,dcp_nydospermitnumber,dcp_lastmilestonedate,_dcp_applicant_customer_value,_dcp_applicantadministrator_customer_value",
 
     $count: true,
 

--- a/server/src/assignment/assignment.service.ts
+++ b/server/src/assignment/assignment.service.ts
@@ -250,7 +250,7 @@ function generateAssignmentsQueryObject(contact) {
 
   return {
     $select:
-      "dcp_name,statecode,dcp_applicanttype,dcp_borough,dcp_ceqrnumber,dcp_ceqrtype,dcp_certifiedreferred,dcp_femafloodzonea,dcp_femafloodzoneshadedx,dcp_sisubdivision,dcp_sischoolseat,dcp_projectbrief,dcp_additionalpublicinformation,dcp_projectname,dcp_publicstatus,dcp_projectcompleted,dcp_hiddenprojectmetrictarget,dcp_ulurp_nonulurp,dcp_validatedcommunitydistricts,dcp_bsanumber,dcp_wrpnumber,dcp_lpcnumber,dcp_name,dcp_nydospermitnumber,dcp_lastmilestonedate,_dcp_applicant_customer_value,_dcp_applicantadministrator_customer_value",
+      "dcp_name,statecode,dcp_applicanttype,dcp_borough,dcp_ceqrnumber,dcp_ceqrtype,dcp_certifiedreferred,dcp_easeis,dcp_femafloodzonea,dcp_femafloodzoneshadedx,dcp_sisubdivision,dcp_sischoolseat,dcp_projectbrief,dcp_additionalpublicinformation,dcp_projectname,dcp_publicstatus,dcp_projectcompleted,dcp_hiddenprojectmetrictarget,dcp_ulurp_nonulurp,dcp_validatedcommunitydistricts,dcp_bsanumber,dcp_wrpnumber,dcp_lpcnumber,dcp_name,dcp_nydospermitnumber,dcp_lastmilestonedate,_dcp_applicant_customer_value,_dcp_applicantadministrator_customer_value",
 
     $count: true,
 

--- a/server/src/project/project.entity.ts
+++ b/server/src/project/project.entity.ts
@@ -6,6 +6,7 @@ export const KEYS = [
   "dcp_borough",
   "dcp_ceqrnumber",
   "dcp_ceqrtype",
+  "dcp_easeis",
   "dcp_certifiedreferred",
   "dcp_femafloodzonea",
   "dcp_femafloodzoneshadedx",

--- a/server/src/project/project.service.ts
+++ b/server/src/project/project.service.ts
@@ -69,6 +69,11 @@ export const PROJECT_VISIBILITY_LOOKUP = {
   "Internal DCP Only": 717170000,
   LUP: 717170004
 };
+export const EASEIS_LOOKUP = {
+  EAS: 717170000,
+  EIS: 717170001,
+  "Technical Memorandum": 717170002
+};
 
 // Only these fields will be value mapped
 export const FIELD_LABEL_REPLACEMENT_WHITELIST = [
@@ -79,6 +84,7 @@ export const FIELD_LABEL_REPLACEMENT_WHITELIST = [
   "dcp_ulurp_nonulurp",
   "_dcp_keyword_value",
   "dcp_ceqrtype",
+  "dcp_easeis",
   "dcp_applicantrole",
   "_dcp_applicant_customer_value",
   "_dcp_recommendationsubmittedby_value",
@@ -172,6 +178,12 @@ const QUERY_TEMPLATES = {
       coerceToNumber(mapInLookup(queryParamValue, APPLICABILITY_LOOKUP))
     ),
 
+  dcp_easeis: queryParamValue =>
+    equalsAnyOf(
+      "dcp_easeis",
+      coerceToNumber(mapInLookup(queryParamValue, EASEIS_LOOKUP))
+    ),
+
   dcp_certifiedreferred: queryParamValue =>
     all(
       comparisonOperator(
@@ -229,6 +241,7 @@ export const ALLOWED_FILTERS = [
   "action-ulurpnumber",
   "boroughs",
   "dcp_ceqrtype", // is this even used? 'Type I', 'Type II', 'Unlisted', 'Unknown'
+  "dcp_easeis", // 'EAS', 'EIS', 'Technical Memorandum'
   "dcp_ulurp_nonulurp", // 'ULURP', 'Non-ULURP'
   "dcp_femafloodzonea",
   "dcp_femafloodzoneshadedx",
@@ -271,6 +284,7 @@ function generateQueryObject(query, overrides?) {
     "dcp_borough",
     "dcp_ceqrnumber",
     "dcp_ceqrtype",
+    "dcp_easeis",
     "dcp_certifiedreferred",
     "dcp_femafloodzonea",
     "dcp_femafloodzoneshadedx",
@@ -379,6 +393,7 @@ export class ProjectService {
       "dcp_borough",
       "dcp_ceqrnumber",
       "dcp_ceqrtype",
+      "dcp_easeis",
       "dcp_certifiedreferred",
       "dcp_femafloodzonea",
       "dcp_femafloodzoneshadedx",


### PR DESCRIPTION
<!---
   The below template is a general guide, but not a strict prescription!
-->

### Summary
## Acceptance Criteria

- [x] Add ability to filter on `dcp_easeis` attribute on project entity to existing `/projects` endpoint
- [x] When filter is given, only return projects that meet the given criteria
- [x] Filter should accept following possible values. Add constant mapping option numbers to values in `/server/src/_utils/constants.ts`
     - EAS [717170000] = EAS
     - EIS [717170001] = EIS
     - Tech Memo [717170002] = Technical Memorandum

#### Tasks/Bug Numbers
 - Closes #1667 

