### PR TITLE
Set feature flag for ZAP Alerts to ON for master context for production release

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
   environment = { HOST="https://zap-api-staging.herokuapp.com", NYCID_CLIENT_ID="lup-portal-staging", NYC_ID_HOST="https://accounts-nonprd.nyc.gov/account", MAINTENANCE_START="06/01/22 15:00", MAINTENANCE_END="06/01/22 16:00", SHOW_ALERTS="ON", FEATURE_FLAG_EXCLUDE_FROM_SEARCH_RESULTS="ON",  FEATURE_FLAG_SHOW_SANDBOX_WARNING="ON", SHOW_CEQR="ON" }
 
 [context.master]
-  environment = { HOST="https://zap-api-production.herokuapp.com", NYCID_CLIENT_ID="lup-portal-production", NYC_ID_HOST="https://www1.nyc.gov/account", MAINTENANCE_START="06/01/22 15:00", MAINTENANCE_END="06/01/22 16:00", SHOW_ALERTS="OFF", FEATURE_FLAG_EXCLUDE_FROM_SEARCH_RESULTS="OFF",  FEATURE_FLAG_SHOW_SANDBOX_WARNING="OFF", SHOW_CEQR="OFF" }
+  environment = { HOST="https://zap-api-production.herokuapp.com", NYCID_CLIENT_ID="lup-portal-production", NYC_ID_HOST="https://www1.nyc.gov/account", MAINTENANCE_START="06/01/22 15:00", MAINTENANCE_END="06/01/22 16:00", SHOW_ALERTS="ON", FEATURE_FLAG_EXCLUDE_FROM_SEARCH_RESULTS="OFF",  FEATURE_FLAG_SHOW_SANDBOX_WARNING="OFF", SHOW_CEQR="OFF" }
 
 # qa team
 [context.qa]


### PR DESCRIPTION
This change updates the front end environment variables set in `netlify.toml`. It sets the `SHOW_ALERTS` variable to `ON` for the `master` build context for a production release.