### PR TITLE
Revert "Added bottom margin to CEQR filter as fix for spacing on Edge"

### DIFF
--- a/client/app/styles/modules/_m-project-filters.scss
+++ b/client/app/styles/modules/_m-project-filters.scss
@@ -87,9 +87,6 @@ $project-filters-font-size: rem-calc(12);
     font-size: $project-filters-font-size;
   }
 
-  .filter-section-ceqr {
-    margin-bottom: 2em;
-  }
 }
 
 .filter-text-input {


### PR DESCRIPTION
Reverting this change because it addresses an issue that only appears in Staging due to the Staging warning banner. We will fix that banner in a separate PR.