### PR TITLE
Update netlify.toml to enable CEQR filter in production

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
   environment = { HOST="https://zap-api-staging.herokuapp.com", NYCID_CLIENT_ID="lup-portal-staging", NYC_ID_HOST="https://accounts-nonprd.nyc.gov/account", MAINTENANCE_START="06/01/22 15:00", MAINTENANCE_END="06/01/22 16:00", SHOW_ALERTS="ON", FEATURE_FLAG_EXCLUDE_FROM_SEARCH_RESULTS="ON",  FEATURE_FLAG_SHOW_SANDBOX_WARNING="ON", SHOW_CEQR="ON" }
 
 [context.master]
-  environment = { HOST="https://zap-api-production.herokuapp.com", NYCID_CLIENT_ID="lup-portal-production", NYC_ID_HOST="https://www1.nyc.gov/account", MAINTENANCE_START="06/01/22 15:00", MAINTENANCE_END="06/01/22 16:00", SHOW_ALERTS="ON", FEATURE_FLAG_EXCLUDE_FROM_SEARCH_RESULTS="OFF",  FEATURE_FLAG_SHOW_SANDBOX_WARNING="OFF", SHOW_CEQR="OFF" }
+  environment = { HOST="https://zap-api-production.herokuapp.com", NYCID_CLIENT_ID="lup-portal-production", NYC_ID_HOST="https://www1.nyc.gov/account", MAINTENANCE_START="06/01/22 15:00", MAINTENANCE_END="06/01/22 16:00", SHOW_ALERTS="ON", FEATURE_FLAG_EXCLUDE_FROM_SEARCH_RESULTS="OFF",  FEATURE_FLAG_SHOW_SANDBOX_WARNING="OFF", SHOW_CEQR="ON" }
 
 # qa team
 [context.qa]


### PR DESCRIPTION
This PR updates the `SHOW_CEQR` feature flag for master (production) context to turn on this functionality in production.