### PR TITLE
Change info modal text for CEQR filter and update local storage variable

### DIFF
--- a/client/app/components/info-modal.js
+++ b/client/app/components/info-modal.js
@@ -4,7 +4,7 @@ import ENV from 'labs-zap-search/config/environment';
 
 export default class InfoModalComponent extends Component {
   // We have manually overridden this to hide the modal by default when running tests in tests/index.html
-  open = ENV.showAlerts === true && window.localStorage.hideMessage !== 'true';
+  open = ENV.showCeqr === true && window.localStorage.hideCeqrFilterMessage !== 'true';
 
   dontShowModalAgain = false;
 
@@ -12,7 +12,7 @@ export default class InfoModalComponent extends Component {
   closeModal() {
     this.set('open', false);
     if (this.dontShowModalAgain) {
-      window.localStorage.hideMessage = true;
+      window.localStorage.hideCeqrFilterMessage = true;
     }
   }
 }

--- a/client/app/styles/modules/_m-info-modal.scss
+++ b/client/app/styles/modules/_m-info-modal.scss
@@ -38,6 +38,13 @@
     padding: 4rem;
   }
 
+  .info-model-content {
+    line-height: normal;
+    font-size: 21px;
+    font-weight: 500;
+    letter-spacing: 0.315px;
+  }
+
   &:focus {
     outline: none;
   }

--- a/client/app/templates/components/info-modal.hbs
+++ b/client/app/templates/components/info-modal.hbs
@@ -9,9 +9,9 @@
       style="display:block;"
       data-test-info-modal
     >
-      <h1>Subscribe and Get Notified.</h1>
+      <h1>New CEQR Filter Option</h1>
 
-      <h4>Subscribe to <LinkTo @route="subscribe" {{action closeModal}} style="text-decoration: underline;">Zoning Applicant Portal Email Notifications</LinkTo>. Get updates about Community Districts and citywide projects.</h4>
+      <p class="info-model-content">Search for projects by documents related to City Environmental Quality Review, including by Environmental Assessments Statements (EAS), Environmental Impact Statements (EIS), and Technical Memorandum.</p>
 
       {{input type="checkbox" checked=this.dontShowModalAgain}}
       Don't show this message again


### PR DESCRIPTION
### Summary
* Update text in `info-modal` to be able CEQR Filter functionality instead of ZAP Alerts
* Update the local storage variable name to `hideCeqrFilterMessage` so users who previously dismissed the info modal will see it again.