### PR TITLE
Increasing ZAP Alerts polling limit to 10 minutes from 5

### DIFF
--- a/server/src/subscriber/subscriber.controller.ts
+++ b/server/src/subscriber/subscriber.controller.ts
@@ -8,7 +8,7 @@ import crypto from 'crypto';
 import { isElement } from "underscore";
 
 const PAUSE_BETWEEN_CHECKS = 30000;
-const CHECKS_BEFORE_FAIL = 10;
+const CHECKS_BEFORE_FAIL = 20;
 
 @Controller()
 export class SubscriberController {


### PR DESCRIPTION
### Summary
This change increases the number of attempts made to detect a new subscriber and send their confirmation email from 10 to 20. We still attempt ever 30 seconds, so this change increases the total time out from 5 minutes to 10.