### PR TITLE
Remove all references to ZAP Alerts feature flag

### DIFF
--- a/client/app/router.js
+++ b/client/app/router.js
@@ -28,13 +28,11 @@ Router.map(function() { // eslint-disable-line
   this.route('show-project', { path: '/projects/:id' });
   this.route('show-geography', { path: '/projects' });
   this.route('disclaimer');
-  if (config.showAlerts) {
-    this.route('statuses');
-    this.route('subscribed');
-    this.route('subscription-update', { path: '/subscribers/:id' });
-    this.route('subscription-confirmation', { path: '/subscribers/:id/confirm' });
-    this.route('subscribe');
-  }
+  this.route('statuses');
+  this.route('subscribed');
+  this.route('subscription-update', { path: '/subscribers/:id' });
+  this.route('subscription-confirmation', { path: '/subscribers/:id/confirm' });
+  this.route('subscribe');
   this.route('not-found', { path: '/*path' });
   this.route('oops');
   this.route('my-projects', function() {

--- a/client/app/templates/application.hbs
+++ b/client/app/templates/application.hbs
@@ -34,9 +34,7 @@
   {{#banner.nav}}
     <ul class="menu vertical large-horizontal">
       <li>{{link-to 'Find Projects' 'show-geography'}}</li>
-      {{#if (eq this.ENV.showAlerts true)}}
-        <li>{{link-to 'Email Notifications' 'subscribe'}}</li>
-      {{/if}}
+      <li>{{link-to 'Email Notifications' 'subscribe'}}</li>
       {{#if this.ENV.LUPP_ENABLED}}
         {{sign-in}}
       {{/if}}

--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -16,7 +16,6 @@ module.exports = function (environment) {
     },
     NYC_ID_HOST,
     maintenanceTimes: getMaintenanceTimes(),
-    showAlerts: getFeatureFlagShowAlerts(),
     showCeqr: getFeatureFlagShowCeqr(),
     featureFlagExcludeFromSearchResults: getFeatureFlagExcludeFromSearchResults(),
     featureFlagShowSandboxWarning: getFeatureFlagShowSandboxWarning(),
@@ -185,10 +184,6 @@ function getMaintenanceTimes() {
   } = process.env;
 
   return [MAINTENANCE_START, MAINTENANCE_END];
-}
-
-function getFeatureFlagShowAlerts() {
-  return process.env.SHOW_ALERTS === 'ON';
 }
 
 function getFeatureFlagShowCeqr() {

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,15 +5,15 @@
   ignore = "false"
 
 [context.develop]
-  environment = { HOST="https://zap-api-staging.herokuapp.com", NYCID_CLIENT_ID="lup-portal-staging", NYC_ID_HOST="https://accounts-nonprd.nyc.gov/account", MAINTENANCE_START="06/01/22 15:00", MAINTENANCE_END="06/01/22 16:00", SHOW_ALERTS="ON", FEATURE_FLAG_EXCLUDE_FROM_SEARCH_RESULTS="ON",  FEATURE_FLAG_SHOW_SANDBOX_WARNING="ON", SHOW_CEQR="ON" }
+  environment = { HOST="https://zap-api-staging.herokuapp.com", NYCID_CLIENT_ID="lup-portal-staging", NYC_ID_HOST="https://accounts-nonprd.nyc.gov/account", MAINTENANCE_START="06/01/22 15:00", MAINTENANCE_END="06/01/22 16:00", FEATURE_FLAG_EXCLUDE_FROM_SEARCH_RESULTS="ON",  FEATURE_FLAG_SHOW_SANDBOX_WARNING="ON", SHOW_CEQR="ON" }
 
 [context.master]
-  environment = { HOST="https://zap-api-production.herokuapp.com", NYCID_CLIENT_ID="lup-portal-production", NYC_ID_HOST="https://www1.nyc.gov/account", MAINTENANCE_START="06/01/22 15:00", MAINTENANCE_END="06/01/22 16:00", SHOW_ALERTS="ON", FEATURE_FLAG_EXCLUDE_FROM_SEARCH_RESULTS="OFF",  FEATURE_FLAG_SHOW_SANDBOX_WARNING="OFF", SHOW_CEQR="ON" }
+  environment = { HOST="https://zap-api-production.herokuapp.com", NYCID_CLIENT_ID="lup-portal-production", NYC_ID_HOST="https://www1.nyc.gov/account", MAINTENANCE_START="06/01/22 15:00", MAINTENANCE_END="06/01/22 16:00", FEATURE_FLAG_EXCLUDE_FROM_SEARCH_RESULTS="OFF",  FEATURE_FLAG_SHOW_SANDBOX_WARNING="OFF", SHOW_CEQR="ON" }
 
 # qa team
 [context.qa]
-  environment = { HOST="https://zap-api-staging.herokuapp.com", NYCID_CLIENT_ID="lup-portal-staging", NYC_ID_HOST="https://accounts-nonprd.nyc.gov/account", MAINTENANCE_START="06/01/22 15:00", MAINTENANCE_END="06/01/22 16:00", SHOW_ALERTS="OFF", FEATURE_FLAG_EXCLUDE_FROM_SEARCH_RESULTS="ON", FEATURE_FLAG_SHOW_SANDBOX_WARNING="ON", SHOW_CEQR="ON" }
+  environment = { HOST="https://zap-api-staging.herokuapp.com", NYCID_CLIENT_ID="lup-portal-staging", NYC_ID_HOST="https://accounts-nonprd.nyc.gov/account", MAINTENANCE_START="06/01/22 15:00", MAINTENANCE_END="06/01/22 16:00", FEATURE_FLAG_EXCLUDE_FROM_SEARCH_RESULTS="ON", FEATURE_FLAG_SHOW_SANDBOX_WARNING="ON", SHOW_CEQR="ON" }
 
 # deploy-preview
 [context.deploy-preview]
- environment = { HOST="https://zap-api-staging.herokuapp.com", NYCID_CLIENT_ID="lup-portal-staging", NYC_ID_HOST="https://accounts-nonprd.nyc.gov/account", MAINTENANCE_START="06/01/22 15:00", MAINTENANCE_END="06/01/22 16:00", SHOW_ALERTS="ON", FEATURE_FLAG_EXCLUDE_FROM_SEARCH_RESULTS="ON",  FEATURE_FLAG_SHOW_SANDBOX_WARNING="ON", SHOW_CEQR="ON" }
+ environment = { HOST="https://zap-api-staging.herokuapp.com", NYCID_CLIENT_ID="lup-portal-staging", NYC_ID_HOST="https://accounts-nonprd.nyc.gov/account", MAINTENANCE_START="06/01/22 15:00", MAINTENANCE_END="06/01/22 16:00", FEATURE_FLAG_EXCLUDE_FROM_SEARCH_RESULTS="ON",  FEATURE_FLAG_SHOW_SANDBOX_WARNING="ON", SHOW_CEQR="ON" }


### PR DESCRIPTION
### Summary

This PR removes all usage of the feature flag for ZAP Alerts and set all code that was behind the flag to execute by default.