### PR TITLE
Improve error handling and logging for artifactWithDocuments method in artifact service

### DIFF
--- a/server/src/artifact/artifact.service.ts
+++ b/server/src/artifact/artifact.service.ts
@@ -88,17 +88,21 @@ export class ArtifactService {
           )
         };
       } catch (e) {
-        const errorMessage = `Error loading documents for artifact ${dcp_name}.`;
-        console.log(errorMessage);
+        if (e instanceof HttpException) {
+          throw e;
+        } else {
+          const errorMessage = `Error loading documents for artifact ${dcp_name}.`;
+          console.log("Error Message:", e);
 
-        throw new HttpException(
-          {
-            code: "ARTIFACT_WITH_DOCUMENTS",
-            title: "Artifact Documents Error",
-            detail: errorMessage
-          },
-          HttpStatus.NOT_FOUND
-        );
+          throw new HttpException(
+            {
+              code: "ARTIFACT_WITH_DOCUMENTS",
+              title: "Artifact Documents Error",
+              detail: errorMessage
+            },
+            HttpStatus.NOT_FOUND
+          );
+        }
       }
     }
 


### PR DESCRIPTION
### Summary
This PR improves the error handling and logging for the `artifactWithDocuments` method in `artifact.service.ts`. We noticed that the `e` being caught by the try/catch wasn't actually being logged or used. Instead, that catch block also hard coded `errorMessage` and threw a new `404` `HttpException`

#### Tasks/Bug Numbers
 - Closes #1703 

### Technical Explanation
a. I added a new `if (e instanceof HttpException)` block in the try catch. This is meant to mirror the pattern seen in methods downstream of this one such as `getArtifactSharepointDocuments` and `sharepointService.getSharepointFolderFiles`. This should mean that errors thrown by downstream methods are successfully bubbled up instead of being overwritten by `artifactWithDocuments`
b. The code that now lives in the `else` block of that if now logs out `e` instead of the hard coded `errorMessage`. This should ensure any error caught here that _isn't_ and instance of `HttpException` is simply logged as is for maximum transparency. The hard coded `errorMessage` is set as the `detail` property on the 404 `HttpException` that this catch block throws so it's still being logged. 
